### PR TITLE
feat:  release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    branches: ['main']
+    tags: [v*]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release:
+    name: Release
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.10]
+        java: [temurin@11]
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout current branch (fast)
+        uses: actions/checkout@v2
+
+      - id: build_stage
+        run: sbt ++${{ matrix.scala }} Universal/stage
+
+      - id: release_tag
+        run: |
+          echo "release_tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+          echo "release_tag=${GITHUB_REF#refs/*/}"
+
+      - id: previous_tag
+        run: |
+          git fetch --prune --unshallow --tags
+          echo tag=`git tag --list "v*" --sort=-version:refname --merged | head -n 2 | tail -n 1` >> $GITHUB_OUTPUT
+          echo tag=`git tag --list "v*" --sort=-version:refname --merged | head -n 2 | tail -n 1`
+          git tag --list "v*" --sort=-version:refname --merged
+
+      - id: validate_tag
+        uses: madhead/semver-utils@latest
+        with:
+          version: ${{steps.release_tag.outputs.release_tag}}
+          compare-to: ${{steps.previous_tag.outputs.tag}}
+          lenient: false
+
+      - if: steps.validate_tag.outputs.comparison-result == '>'
+        uses: TheDoctor0/zip-release@0.7.1
+        with:
+          type: zip
+          filename: release-${{steps.release_tag.outputs.release_tag}}.zip
+
+      - if: steps.validate_tag.outputs.comparison-result == '>'
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: release-${{steps.release_tag.outputs.release_tag}}.zip
+          tag: ${{steps.release_tag.outputs.release_tag}}
+          generateReleaseNotes: ${{true}}


### PR DESCRIPTION
Adds a github action for releases

A release can be created by tagging `main` with a semver tag. On tagging `main` with `vX.Y.Z` for example, the workflow will:

- Checkout current branch.
- Build the executable by running `sbt Universal/stage`.
- Validate that the tag is a valid semver tag, and check that it is greater than the most recent previous tag of the format `v*`.
- Zip the project directory including the executable.
- Create a release and include the zip file in the release.

An example run can be seen here - https://github.com/sujeetsr/hello-world-scala/actions/runs/5122692560 

fixes #137
