### PR TITLE
Feature: add `@extends` feature on types

### DIFF
--- a/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
@@ -34,7 +34,7 @@ final case class Blueprint(definitions: List[Blueprint.Definition]) {
 
   def endpoints: List[Endpoint] =
     for {
-      fields     <- definitions.collect { case Blueprint.ObjectTypeDefinition(_, fields, _) => fields }
+      fields     <- definitions.collect { case Blueprint.ObjectTypeDefinition(_, fields, _, _) => fields }
       definition <- fields
       resolver   <- definition.resolver.toList.map(_.compile)
       endpoint   <- resolver.collect { case Expression.Unsafe(Expression.Unsafe.EndpointCall(endpoint)) => endpoint }
@@ -52,10 +52,12 @@ final case class Blueprint(definitions: List[Blueprint.Definition]) {
       case Blueprint.SchemaDefinition(_, _, _, _)          => "a"
       case Blueprint.ScalarTypeDefinition(name, _, _)      => "b" + name
       case Blueprint.InputObjectTypeDefinition(name, _, _) => "c" + name
-      case Blueprint.ObjectTypeDefinition(name, _, _)      => "d" + name
+      case Blueprint.ObjectTypeDefinition(name, _, _, _)   => "d" + name
+      case Blueprint.InterfaceTypeDefinition(name, _, _)   => "e" + name
     }.map {
-      case self @ Blueprint.ObjectTypeDefinition(_, fields, _)      => self.copy(fields = fields.sortBy(_.name))
+      case self @ Blueprint.ObjectTypeDefinition(_, fields, _, _)   => self.copy(fields = fields.sortBy(_.name))
       case self @ Blueprint.InputObjectTypeDefinition(_, fields, _) => self.copy(fields = fields.sortBy(_.name))
+      case self @ Blueprint.InterfaceTypeDefinition(_, fields, _)   => self.copy(fields = fields.sortBy(_.name))
       case self                                                     => self
     })
 
@@ -110,8 +112,18 @@ object Blueprint {
       }
   }
 
-  final case class ObjectTypeDefinition(name: String, fields: List[FieldDefinition], description: Option[String] = None)
-      extends Definition
+  final case class ObjectTypeDefinition(
+    name: String,
+    fields: List[FieldDefinition],
+    description: Option[String] = None,
+    implements: Option[List[NamedType]] = None,
+  ) extends Definition
+
+  final case class InterfaceTypeDefinition(
+    name: String,
+    fields: List[FieldDefinition],
+    description: Option[String] = None,
+  ) extends Definition
 
   final case class InputObjectTypeDefinition(
     name: String,

--- a/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Blueprint.scala
@@ -116,7 +116,7 @@ object Blueprint {
     name: String,
     fields: List[FieldDefinition],
     description: Option[String] = None,
-    implements: Option[List[NamedType]] = None,
+    implements: List[NamedType] = Nil,
   ) extends Definition
 
   final case class InterfaceTypeDefinition(

--- a/runtime/src/main/scala/tailcall/runtime/model/Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Config.scala
@@ -320,7 +320,7 @@ object Config {
 
   final case class Type(
     doc: Option[String] = None,
-    @jsonField("extends") extendsFrom: Option[ExtendsType] = None,
+    @jsonField("extends") extendsFrom: ExtendsType = ExtendsType(types = Nil),
     fields: Map[String, Field] = Map.empty,
   ) {
     self =>
@@ -341,7 +341,7 @@ object Config {
     def withFields(input: (String, Field)*): Type =
       input.foldLeft(self) { case (self, (name, field)) => self.withField(name, field) }
 
-    def withExtends(typeName: String): Type = self.copy(extendsFrom = Option(ExtendsType(`type` = typeName)))
+    def withExtends(types: List[String]): Type = self.copy(extendsFrom = ExtendsType(types = types))
   }
 
   final case class GraphQL(schema: RootSchema = RootSchema(), types: Map[String, Type] = Map.empty) {
@@ -511,8 +511,8 @@ object Config {
   }
 
   object Type {
-    def apply(fields: (String, Field)*): Type = Type(None, None, fields.toMap)
-    def empty: Type                           = Type(None, None, Map.empty[String, Field])
+    def apply(fields: (String, Field)*): Type = Type(None, ExtendsType(types = Nil), fields.toMap)
+    def empty: Type                           = Type(None, ExtendsType(types = Nil), Map.empty[String, Field])
   }
 
   object Field {

--- a/runtime/src/main/scala/tailcall/runtime/model/Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Config.scala
@@ -320,7 +320,7 @@ object Config {
 
   final case class Type(
     doc: Option[String] = None,
-    `extends`: Option[ExtendsType] = None,
+    @jsonField("extends") extendsFrom: Option[ExtendsType] = None,
     fields: Map[String, Field] = Map.empty,
   ) {
     self =>
@@ -341,7 +341,7 @@ object Config {
     def withFields(input: (String, Field)*): Type =
       input.foldLeft(self) { case (self, (name, field)) => self.withField(name, field) }
 
-    def withExtends(typeName: String): Type = self.copy(`extends` = Option(ExtendsType(`type` = typeName)))
+    def withExtends(typeName: String): Type = self.copy(extendsFrom = Option(ExtendsType(`type` = typeName)))
   }
 
   final case class GraphQL(schema: RootSchema = RootSchema(), types: Map[String, Type] = Map.empty) {

--- a/runtime/src/main/scala/tailcall/runtime/model/Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Config.scala
@@ -318,7 +318,11 @@ object Config {
       RootSchema(query = other.query.orElse(query), mutation = other.mutation.orElse(mutation))
   }
 
-  final case class Type(doc: Option[String] = None, fields: Map[String, Field] = Map.empty) {
+  final case class Type(
+    doc: Option[String] = None,
+    `extends`: Option[ExtendsType] = None,
+    fields: Map[String, Field] = Map.empty,
+  ) {
     self =>
 
     def apply(input: (String, Field)*): Type = withFields(input: _*)
@@ -336,6 +340,8 @@ object Config {
 
     def withFields(input: (String, Field)*): Type =
       input.foldLeft(self) { case (self, (name, field)) => self.withField(name, field) }
+
+    def withExtends(typeName: String): Type = self.copy(`extends` = Option(ExtendsType(`type` = typeName)))
   }
 
   final case class GraphQL(schema: RootSchema = RootSchema(), types: Map[String, Type] = Map.empty) {
@@ -452,6 +458,7 @@ object Config {
         case None        => Some(update)
       })
     }
+
   }
 
   final case class Arg(
@@ -504,8 +511,8 @@ object Config {
   }
 
   object Type {
-    def apply(fields: (String, Field)*): Type = Type(None, fields.toMap)
-    def empty: Type                           = Type(None, Map.empty[String, Field])
+    def apply(fields: (String, Field)*): Type = Type(None, None, fields.toMap)
+    def empty: Type                           = Type(None, None, Map.empty[String, Field])
   }
 
   object Field {

--- a/runtime/src/main/scala/tailcall/runtime/model/ExtendsType.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/ExtendsType.scala
@@ -1,0 +1,16 @@
+package tailcall.runtime.model
+
+import tailcall.runtime.DirectiveCodec
+import zio.json.JsonCodec
+import zio.schema.annotation.caseName
+import zio.schema.codec.JsonCodec.jsonCodec
+import zio.schema.{DeriveSchema, Schema}
+
+@caseName("extends")
+final case class ExtendsType(`type`: String)
+
+object ExtendsType {
+  implicit val schema: Schema[ExtendsType] = DeriveSchema.gen[ExtendsType]
+  implicit val json: JsonCodec[ExtendsType] = jsonCodec(schema)
+  implicit val directive: DirectiveCodec[ExtendsType] = DirectiveCodec.gen[ExtendsType]
+}

--- a/runtime/src/main/scala/tailcall/runtime/model/ExtendsType.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/ExtendsType.scala
@@ -10,7 +10,7 @@ import zio.schema.{DeriveSchema, Schema}
 final case class ExtendsType(`type`: String)
 
 object ExtendsType {
-  implicit val schema: Schema[ExtendsType] = DeriveSchema.gen[ExtendsType]
-  implicit val json: JsonCodec[ExtendsType] = jsonCodec(schema)
+  implicit val schema: Schema[ExtendsType]            = DeriveSchema.gen[ExtendsType]
+  implicit val json: JsonCodec[ExtendsType]           = jsonCodec(schema)
   implicit val directive: DirectiveCodec[ExtendsType] = DirectiveCodec.gen[ExtendsType]
 }

--- a/runtime/src/main/scala/tailcall/runtime/model/ExtendsType.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/ExtendsType.scala
@@ -7,7 +7,7 @@ import zio.schema.codec.JsonCodec.jsonCodec
 import zio.schema.{DeriveSchema, Schema}
 
 @caseName("extends")
-final case class ExtendsType(`type`: String)
+final case class ExtendsType(types: List[String])
 
 object ExtendsType {
   implicit val schema: Schema[ExtendsType]            = DeriveSchema.gen[ExtendsType]

--- a/runtime/src/main/scala/tailcall/runtime/service/GraphQLGenerator.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/GraphQLGenerator.scala
@@ -7,7 +7,6 @@ import caliban.schema.{Operation, RootSchemaBuilder}
 import caliban.tools.RemoteSchema
 import caliban.wrappers.Wrapper
 import tailcall.runtime.model.Blueprint
-import tailcall.runtime.model.Blueprint.InterfaceTypeDefinition
 import tailcall.runtime.transcoder.Transcoder
 import zio.{ZIO, ZLayer}
 
@@ -19,16 +18,6 @@ object GraphQLGenerator {
   final case class Live(sGen: StepGenerator) extends GraphQLGenerator {
     override def toGraphQL(blueprint: Blueprint): GraphQL[HttpContext] = {
       val schema = Transcoder.toDocument(blueprint).toOption.flatMap(RemoteSchema.parseRemoteSchema)
-      val possibleAdditionalTypeNames = blueprint.definitions.map(d =>
-        d match {
-          case InterfaceTypeDefinition(name, _, _) => name.substring(1, name.length)
-          case _                                   => ""
-        }
-      ).filter(_.nonEmpty)
-      val additionalTypes             = schema match {
-        case Some(s) => s.types.filter(t => possibleAdditionalTypeNames.contains(t.name.getOrElse("")))
-        case None    => Nil
-      }
       new GraphQL[HttpContext] {
         override protected val schemaBuilder: RootSchemaBuilder[HttpContext] = {
           val stepResult = sGen.resolve(blueprint)
@@ -47,7 +36,7 @@ object GraphQLGenerator {
         override protected val wrappers: List[Wrapper[Any]]                  = Nil
         override protected val additionalDirectives: List[__Directive]       = Nil
         override protected val features: Set[Feature]                        = Set.empty
-      }.withAdditionalTypes(additionalTypes)
+      }
     }
   }
 

--- a/runtime/src/main/scala/tailcall/runtime/service/GraphQLGenerator.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/GraphQLGenerator.scala
@@ -7,6 +7,7 @@ import caliban.schema.{Operation, RootSchemaBuilder}
 import caliban.tools.RemoteSchema
 import caliban.wrappers.Wrapper
 import tailcall.runtime.model.Blueprint
+import tailcall.runtime.model.Blueprint.InterfaceTypeDefinition
 import tailcall.runtime.transcoder.Transcoder
 import zio.{ZIO, ZLayer}
 
@@ -18,6 +19,15 @@ object GraphQLGenerator {
   final case class Live(sGen: StepGenerator) extends GraphQLGenerator {
     override def toGraphQL(blueprint: Blueprint): GraphQL[HttpContext] = {
       val schema = Transcoder.toDocument(blueprint).toOption.flatMap(RemoteSchema.parseRemoteSchema)
+
+      // Interfaces created by extending from types have an `I` prefix
+      val objTypesForInterfaces = blueprint.definitions
+        .collect { case InterfaceTypeDefinition(name, _, _) if name.startsWith("I") => name.substring(1, name.length) }
+      // Types that are extended by @extends directives
+      val additionalTypes       = schema match {
+        case Some(s) => s.types.filter(t => t.name.exists(objTypesForInterfaces.contains))
+        case None    => Nil
+      }
       new GraphQL[HttpContext] {
         override protected val schemaBuilder: RootSchemaBuilder[HttpContext] = {
           val stepResult = sGen.resolve(blueprint)
@@ -31,7 +41,7 @@ object GraphQLGenerator {
             __type  <- schema.flatMap(_.mutationType)
             resolve <- stepResult.mutation
           } yield Operation(__type, resolve)
-          RootSchemaBuilder(query = queryOperation, mutationOperation, None)
+          RootSchemaBuilder(query = queryOperation, mutationOperation, None, additionalTypes)
         }
         override protected val wrappers: List[Wrapper[Any]]                  = Nil
         override protected val additionalDirectives: List[__Directive]       = Nil

--- a/runtime/src/main/scala/tailcall/runtime/service/StepGenerator.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/StepGenerator.scala
@@ -37,7 +37,7 @@ object StepGenerator {
 
     // A map of all the object types and a way to construct an instance of them.
     private val objectStepRef: Map[String, Context => Step[HttpContext]] = blueprint.definitions
-      .collect { case obj @ Blueprint.ObjectTypeDefinition(_, _, _) => (obj.name, ctx => fromObjectDef(obj, ctx)) }
+      .collect { case obj @ Blueprint.ObjectTypeDefinition(_, _, _, _) => (obj.name, ctx => fromObjectDef(obj, ctx)) }
       .toMap
 
     def resolve: StepResult[HttpContext] = {

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Blueprint2Document.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Blueprint2Document.scala
@@ -71,9 +71,6 @@ trait Blueprint2Document {
       case Blueprint.ListType(ofType, nonNull) => CalibanType.ListType(toCalibanType(ofType), nonNull)
     }
 
-  final private def toCalibanImplements(implements: Option[List[Blueprint.NamedType]]): List[CalibanType.NamedType] =
-    implements match {
-      case Some(list) => list.map(t => CalibanType.NamedType(t.name, t.nonNull))
-      case None       => List[CalibanType.NamedType]()
-    }
+  final private def toCalibanImplements(implements: List[Blueprint.NamedType]): List[CalibanType.NamedType] =
+    if (implements.nonEmpty) implements.map(t => CalibanType.NamedType(t.name, t.nonNull)) else Nil
 }

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Blueprint2Document.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Blueprint2Document.scala
@@ -24,12 +24,15 @@ trait Blueprint2Document {
           case Blueprint.SchemaDefinition(query, mutation, subscription, directives) => CalibanDefinition
               .TypeSystemDefinition
               .SchemaDefinition(directives.map(toCalibanDirective(_)), query, mutation, subscription)
-          case Blueprint.ObjectTypeDefinition(name, fields, description)      => CalibanDefinition.TypeSystemDefinition
-              .TypeDefinition.ObjectTypeDefinition(description, name, Nil, Nil, fields.map(toCalibanField))
+          case Blueprint.ObjectTypeDefinition(name, fields, description, implements) => CalibanDefinition
+              .TypeSystemDefinition.TypeDefinition
+              .ObjectTypeDefinition(description, name, toCalibanImplements(implements), Nil, fields.map(toCalibanField))
           case Blueprint.InputObjectTypeDefinition(name, fields, description) => CalibanDefinition.TypeSystemDefinition
               .TypeDefinition.InputObjectTypeDefinition(description, name, Nil, fields.map(toCalibanInputValue))
           case Blueprint.ScalarTypeDefinition(name, directives, description)  => CalibanDefinition.TypeSystemDefinition
               .TypeDefinition.ScalarTypeDefinition(description, name, directives.map(toCalibanDirective(_)))
+          case Blueprint.InterfaceTypeDefinition(name, fields, description)   => CalibanDefinition.TypeSystemDefinition
+              .TypeDefinition.InterfaceTypeDefinition(description, name, Nil, fields.map(toCalibanField))
         },
         SourceMapper.empty,
       )
@@ -66,5 +69,11 @@ trait Blueprint2Document {
     tpe match {
       case Blueprint.NamedType(name, nonNull)  => CalibanType.NamedType(name, nonNull)
       case Blueprint.ListType(ofType, nonNull) => CalibanType.ListType(toCalibanType(ofType), nonNull)
+    }
+
+  final private def toCalibanImplements(implements: Option[List[Blueprint.NamedType]]): List[CalibanType.NamedType] =
+    implements match {
+      case Some(list) => list.map(t => CalibanType.NamedType(t.name, t.nonNull))
+      case None       => List[CalibanType.NamedType]()
     }
 }

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
@@ -2,7 +2,6 @@ package tailcall.runtime.transcoder
 
 import tailcall.runtime.http.{Method, Scheme}
 import tailcall.runtime.internal.TValid
-// import tailcall.runtime.internal.TValid.Succeed
 import tailcall.runtime.lambda.Syntax._
 import tailcall.runtime.lambda._
 import tailcall.runtime.model.Config._

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
@@ -2,6 +2,7 @@ package tailcall.runtime.transcoder
 
 import tailcall.runtime.http.{Method, Scheme}
 import tailcall.runtime.internal.TValid
+import tailcall.runtime.internal.TValid.Succeed
 import tailcall.runtime.lambda.Syntax._
 import tailcall.runtime.lambda._
 import tailcall.runtime.model.Config._
@@ -11,7 +12,6 @@ import tailcall.runtime.model.UnsafeSteps.Operation.Http
 import tailcall.runtime.model._
 import zio.Chunk
 import zio.schema.DynamicValue
-import tailcall.runtime.internal.TValid.Succeed
 
 trait Config2Blueprint {
   def toBlueprint(config: Config): TValid[String, Blueprint] = Config2Blueprint.Live(config).toBlueprint

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
@@ -72,7 +72,7 @@ object Config2Blueprint {
       typeInfo: Type,
       types: List[(String, Type)],
     ): TValid[String, List[Blueprint.FieldDefinition]] = {
-      typeInfo.`extends` match {
+      typeInfo.extendsFrom match {
         case Some(ext) =>
           val parent = getTypeByName(ext.`type`, types)
           parent match {
@@ -90,7 +90,7 @@ object Config2Blueprint {
     }
 
     private def getParentTypeName(typeInfo: Type): String = {
-      typeInfo.`extends` match {
+      typeInfo.extendsFrom match {
         case Some(value) => value.`type`
         case _           => ""
       }
@@ -113,8 +113,7 @@ object Config2Blueprint {
             name = typeName,
             fields = fields,
             description = typeInfo.doc,
-            implements =
-              if (parentTypeName.nonEmpty) Some(List(Blueprint.NamedType(s"I${parentTypeName}", true))) else None,
+            implements = if (parentTypeName.nonEmpty) List(Blueprint.NamedType(s"I${parentTypeName}", true)) else Nil,
           )
           if (inputTypes.contains(typeName)) toInputObjectTypeDefinition(objDefinition) else objDefinition
         }

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
@@ -2,8 +2,10 @@ package tailcall.runtime.transcoder
 
 import tailcall.runtime.http.{Method, Scheme}
 import tailcall.runtime.internal.TValid
+import tailcall.runtime.internal.TValid.{Errors, Succeed}
 import tailcall.runtime.lambda.Syntax._
 import tailcall.runtime.lambda._
+import tailcall.runtime.model.Blueprint.ObjectTypeDefinition
 import tailcall.runtime.model.Config._
 import tailcall.runtime.model.Mustache.MustacheExpression
 import tailcall.runtime.model.UnsafeSteps.Operation
@@ -11,9 +13,6 @@ import tailcall.runtime.model.UnsafeSteps.Operation.Http
 import tailcall.runtime.model._
 import zio.Chunk
 import zio.schema.DynamicValue
-import tailcall.runtime.model.Blueprint.ObjectTypeDefinition
-import tailcall.runtime.internal.TValid.Succeed
-import tailcall.runtime.internal.TValid.Errors
 
 trait Config2Blueprint {
   def toBlueprint(config: Config): TValid[String, Blueprint] = Config2Blueprint.Live(config).toBlueprint

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
@@ -118,7 +118,9 @@ trait Config2Document {
       fields = fields,
       description = typeInfo.doc,
       implements = Nil,
-      directives = if (typeInfo.extendsFrom.types.nonEmpty) typeInfo.extendsFrom.toDirective.toList else Nil,
+      directives =
+        if (typeInfo.extendsFrom.exists(_.nonEmpty)) ExtendsType(typeInfo.extendsFrom.toList.flatten).toDirective.toList
+        else Nil,
     )
   }
 

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
@@ -118,7 +118,7 @@ trait Config2Document {
       fields = fields,
       description = typeInfo.doc,
       implements = Nil,
-      directives = Nil,
+      directives = if (typeInfo.`extends`.nonEmpty) typeInfo.`extends`.toList.flatMap(_.toDirective.toList) else Nil,
     )
   }
 

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
@@ -118,7 +118,7 @@ trait Config2Document {
       fields = fields,
       description = typeInfo.doc,
       implements = Nil,
-      directives = if (typeInfo.extendsFrom.nonEmpty) typeInfo.extendsFrom.toList.flatMap(_.toDirective.toList) else Nil,
+      directives = if (typeInfo.extendsFrom.types.nonEmpty) typeInfo.extendsFrom.toDirective.toList else Nil,
     )
   }
 

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Document.scala
@@ -118,7 +118,7 @@ trait Config2Document {
       fields = fields,
       description = typeInfo.doc,
       implements = Nil,
-      directives = if (typeInfo.`extends`.nonEmpty) typeInfo.`extends`.toList.flatMap(_.toDirective.toList) else Nil,
+      directives = if (typeInfo.extendsFrom.nonEmpty) typeInfo.extendsFrom.toList.flatMap(_.toDirective.toList) else Nil,
     )
   }
 

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
@@ -116,7 +116,7 @@ trait Document2Config {
       toFieldMap(definition).map(
         definition.name -> Config.Type(
           doc = definition.description,
-          `extends` = definition.directives.flatMap(_.fromDirective[ExtendsType].toList).headOption,
+          extendsFrom = definition.directives.flatMap(_.fromDirective[ExtendsType].toList).headOption,
           _,
         )
       ).trace(definition.name)

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
@@ -111,12 +111,20 @@ trait Document2Config {
   }
 
   final private def toTypes(document: Document): TValid[Nothing, Map[String, Config.Type]] = {
+    // val ext = definition.directives.flatMap(_.fromDirective[ModifyField].toList).headOption
     val outputTypes = TValid.foreach(document.objectTypeDefinitions) { definition =>
-      toFieldMap(definition).map(definition.name -> Config.Type(doc = definition.description, _)).trace(definition.name)
+      toFieldMap(definition).map(
+        definition.name -> Config.Type(
+          doc = definition.description,
+          `extends` = definition.directives.flatMap(_.fromDirective[ExtendsType].toList).headOption,
+          _,
+        )
+      ).trace(definition.name)
     }.map(_.toMap)
 
     val inputTypes = TValid.foreach(document.inputObjectTypeDefinitions) { definition =>
-      toFieldMap(definition).map(definition.name -> Config.Type(doc = definition.description, _)).trace(definition.name)
+      toFieldMap(definition).map(definition.name -> Config.Type(doc = definition.description, None, _))
+        .trace(definition.name)
     }.map(_.toMap)
 
     (outputTypes zipPar inputTypes)(_ ++ _)

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
@@ -115,14 +115,16 @@ trait Document2Config {
       toFieldMap(definition).map(
         definition.name -> Config.Type(
           doc = definition.description,
-          extendsFrom = definition.directives.flatMap(_.fromDirective[ExtendsType].toList).headOption,
+          extendsFrom = definition.directives.flatMap(_.fromDirective[ExtendsType].toList).headOption
+            .getOrElse(ExtendsType(types = Nil)),
           _,
         )
       ).trace(definition.name)
     }.map(_.toMap)
 
     val inputTypes = TValid.foreach(document.inputObjectTypeDefinitions) { definition =>
-      toFieldMap(definition).map(definition.name -> Config.Type(doc = definition.description, None, _))
+      toFieldMap(definition)
+        .map(definition.name -> Config.Type(doc = definition.description, ExtendsType(types = Nil), _))
         .trace(definition.name)
     }.map(_.toMap)
 

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
@@ -115,16 +115,14 @@ trait Document2Config {
       toFieldMap(definition).map(
         definition.name -> Config.Type(
           doc = definition.description,
-          extendsFrom = definition.directives.flatMap(_.fromDirective[ExtendsType].toList).headOption
-            .getOrElse(ExtendsType(types = Nil)),
           _,
+          Option(definition.directives.flatMap(_.fromDirective[ExtendsType].toList).flatMap(_.types)),
         )
       ).trace(definition.name)
     }.map(_.toMap)
 
     val inputTypes = TValid.foreach(document.inputObjectTypeDefinitions) { definition =>
-      toFieldMap(definition)
-        .map(definition.name -> Config.Type(doc = definition.description, ExtendsType(types = Nil), _))
+      toFieldMap(definition).map(definition.name -> Config.Type(doc = definition.description, _, None))
         .trace(definition.name)
     }.map(_.toMap)
 

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Document2Config.scala
@@ -111,7 +111,6 @@ trait Document2Config {
   }
 
   final private def toTypes(document: Document): TValid[Nothing, Map[String, Config.Type]] = {
-    // val ext = definition.directives.flatMap(_.fromDirective[ModifyField].toList).headOption
     val outputTypes = TValid.foreach(document.objectTypeDefinitions) { definition =>
       toFieldMap(definition).map(
         definition.name -> Config.Type(

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Document2SDL.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Document2SDL.scala
@@ -1,7 +1,6 @@
 package tailcall.runtime.transcoder
 
 import caliban.GraphQL
-import caliban.InputValue.ListValue
 import caliban.execution.Feature
 import caliban.introspection.adt.__Directive
 import caliban.parsing.adt.Definition.TypeSystemDefinition
@@ -10,33 +9,19 @@ import caliban.parsing.adt.{Definition, Document}
 import caliban.schema.{Operation, RootSchemaBuilder, Step}
 import caliban.tools.RemoteSchema
 import caliban.wrappers.Wrapper
+import tailcall.runtime.DirectiveCodec.DecoderSyntax
 import tailcall.runtime.internal.TValid
+import tailcall.runtime.model.ExtendsType
 
 trait Document2SDL {
   final def toSDL(document: Document): TValid[Nothing, String] =
     TValid.succeed {
-      val normalized        = normalize(document)
-      val schema            = RemoteSchema.parseRemoteSchema(normalized)
-      val extDirectiveTypes = document.objectTypeDefinitions.map(definition => {
-        val extendsDirective = definition.directives.find(directive => directive.name == "extends")
-        extendsDirective match {
-          case Some(value) =>
-            val typesOption = value.arguments.get("types")
-            typesOption match {
-              case Some(inputValue) => inputValue match {
-                  case ListValue(values) => values.map(_.toString)
-                  case _                 => Nil
-                }
-              case _                => Nil
-            }
-          case None        => Nil
-        }
-      }).flatten
+      val normalized = normalize(document)
+      val schema     = RemoteSchema.parseRemoteSchema(normalized)
 
-      val additionalTypes = schema match {
-        case Some(s) => s.types.filter(t => extDirectiveTypes.contains(s"\"${t.name.getOrElse("")}\""))
-        case None    => Nil
-      }
+      // Types that are extended by @extends directives
+      val extDirectiveTypes = document.objectTypeDefinitions
+        .flatMap(_.directives.flatMap(_.fromDirective[ExtendsType].toList.flatMap(_.types))).toSet
 
       new GraphQL[Any] {
         override protected val schemaBuilder: RootSchemaBuilder[Any]   = {
@@ -44,13 +29,17 @@ trait Document2SDL {
             schema.map(_.queryType).map(__type => Operation(__type, Step.NullStep)),
             schema.flatMap(_.mutationType).map(__type => Operation(__type, Step.NullStep)),
             None,
-            schemaDirectives = normalized.schemaDefinition.map(_.directives).getOrElse(Nil),
+            schema match {
+              case Some(s) => s.types.filter(_.name.exists(extDirectiveTypes.contains))
+              case None    => Nil
+            },
+            normalized.schemaDefinition.map(_.directives).getOrElse(Nil),
           )
         }
         override protected val wrappers: List[Wrapper[Any]]            = Nil
         override protected val additionalDirectives: List[__Directive] = Nil
         override protected val features: Set[Feature]                  = Set.empty
-      }.withAdditionalTypes(additionalTypes).render
+      }.render
     }
 
   /**

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
@@ -76,12 +76,12 @@ object Config2BlueprintSpec extends TailcallSpec {
       test("extends with duplicate field") {
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
           "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(typeName = "Identified"),
+          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(types = List("Identified")),
           "UserQuery"  -> Config.Type(
             "name"  -> Config.Field.str,
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts"))),
-          ).withExtends(typeName = "User"),
+          ).withExtends(types = List("User")),
           "Post"       -> Config.Type("title" -> Config.Field.str),
           "Query"      -> Config
             .Type("users" -> Config.Field.ofType("User").asList.withHttp(Http(path = Path.unsafe.fromString("/users")))),
@@ -93,11 +93,11 @@ object Config2BlueprintSpec extends TailcallSpec {
       test("extends with missing parent type") {
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
           // "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"      -> Config.Type("name" -> Config.Field.str).withExtends(typeName = "Identified"),
+          "User"      -> Config.Type("name" -> Config.Field.str).withExtends(types = List("Identified")),
           "UserQuery" -> Config.Type(
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
-          ).withExtends(typeName = "User"),
+          ).withExtends(types = List("User")),
           "Post"      -> Config.Type("title" -> Config.Field.str),
           "Query"     -> Config
             .Type("users" -> Config.Field.ofType("User").asList.withHttp(Http(path = Path.unsafe.fromString("/users")))),
@@ -109,6 +109,21 @@ object Config2BlueprintSpec extends TailcallSpec {
         )
         assertZIO(Transcoder.toBlueprint(config).toZIO.flip)(equalTo(expected))
 
+      },
+      test("extends") {
+        val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
+          "Identified" -> Config.Type("id" -> Config.Field.int),
+          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(types = List[String]("Identified")),
+          "UserQuery"  -> Config.Type(
+            "posts" -> Config.Field.ofType("Post").asList
+              .withHttp(Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
+          ).withExtends(types = List[String]("User")),
+          "Post"       -> Config.Type("title" -> Config.Field.str),
+          "Query"      -> Config
+            .Type("users" -> Config.Field.ofType("User").asList.withHttp(Http(path = Path.unsafe.fromString("/users")))),
+        )
+
+        assertTrue(Transcoder.toBlueprint(config).isValid)
       },
     )
 }

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
@@ -92,7 +92,6 @@ object Config2BlueprintSpec extends TailcallSpec {
       },
       test("extends with missing parent type") {
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
-          // "Identified" -> Config.Type("id" -> Config.Field.int),
           "User"      -> Config.Type("name" -> Config.Field.str).extendsWith("Identified"),
           "UserQuery" -> Config.Type(
             "posts" -> Config.Field.ofType("Post").asList

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
@@ -76,28 +76,28 @@ object Config2BlueprintSpec extends TailcallSpec {
       test("extends with duplicate field") {
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
           "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(types = List("Identified")),
+          "User"       -> Config.Type("name" -> Config.Field.str).extendsWith("Identified"),
           "UserQuery"  -> Config.Type(
             "name"  -> Config.Field.str,
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts"))),
-          ).withExtends(types = List("User")),
+          ).extendsWith("User"),
           "Post"       -> Config.Type("title" -> Config.Field.str),
           "Query"      -> Config
             .Type("users" -> Config.Field.ofType("User").asList.withHttp(Http(path = Path.unsafe.fromString("/users")))),
         )
 
-        val expected = Chunk(TValid.Cause("""Duplicate field found for UserQuery""", List[String]()))
+        val expected = Chunk(TValid.Cause("""Duplicate field found for UserQuery""", Nil))
         assertZIO(Transcoder.toBlueprint(config).toZIO.flip)(equalTo(expected))
       },
       test("extends with missing parent type") {
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
           // "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"      -> Config.Type("name" -> Config.Field.str).withExtends(types = List("Identified")),
+          "User"      -> Config.Type("name" -> Config.Field.str).extendsWith("Identified"),
           "UserQuery" -> Config.Type(
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
-          ).withExtends(types = List("User")),
+          ).extendsWith("User"),
           "Post"      -> Config.Type("title" -> Config.Field.str),
           "Query"     -> Config
             .Type("users" -> Config.Field.ofType("User").asList.withHttp(Http(path = Path.unsafe.fromString("/users")))),
@@ -113,11 +113,11 @@ object Config2BlueprintSpec extends TailcallSpec {
       test("extends") {
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
           "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(types = List[String]("Identified")),
+          "User"       -> Config.Type("name" -> Config.Field.str).extendsWith("Identified"),
           "UserQuery"  -> Config.Type(
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
-          ).withExtends(types = List[String]("User")),
+          ).extendsWith("User"),
           "Post"       -> Config.Type("title" -> Config.Field.str),
           "Query"      -> Config
             .Type("users" -> Config.Field.ofType("User").asList.withHttp(Http(path = Path.unsafe.fromString("/users")))),

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/Config2BlueprintSpec.scala
@@ -73,61 +73,6 @@ object Config2BlueprintSpec extends TailcallSpec {
         val expected = List(TSchema.obj("b" -> TSchema.str.opt, "c" -> TSchema.str.opt).opt)
         assertZIO(schemas)(equalTo(expected))
       },
-      test("extends support") {
-        val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
-          "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(typeName = "Identified"),
-          "UserQuery"  -> Config.Type(
-            "posts" -> Config.Field.ofType("Post").asList
-              .withHttp(Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
-          ).withExtends(typeName = "User"),
-          "Post"       -> Config.Type("title" -> Config.Field.str),
-          "Query"      -> Config
-            .Type("users" -> Config.Field.ofType("User").asList.withHttp(Http(path = Path.unsafe.fromString("/users")))),
-        )
-
-        val blueprintOption = Transcoder.toBlueprint(config)
-        assertTrue(blueprintOption.isValid)
-
-        val blueprint = blueprintOption.toList.head
-
-        def findInterfaceByName(definitionName: String) = {
-          blueprint.definitions.find {
-            case Blueprint.InterfaceTypeDefinition(name, _, _) => name == definitionName
-            case _                                             => false
-          }
-        }
-
-        def findObjectTypeByName(definitionName: String) = {
-          blueprint.definitions.find {
-            case Blueprint.ObjectTypeDefinition(name, _, _, _) => name == definitionName
-            case _                                             => false
-          }
-        }
-
-        def getImplementsForType(definitionName: String) = {
-          val definition = findObjectTypeByName(definitionName)
-          definition match {
-            case Some(d) => d match {
-                case Blueprint.ObjectTypeDefinition(_, _, _, implements) => implements match {
-                    case Some(l) => l.head.name
-                    case _       => ""
-                  }
-                case _                                                   => ""
-              }
-            case _       => "None"
-          }
-        }
-
-        assertTrue(findInterfaceByName("IIdentified").isDefined)
-        assertTrue(findInterfaceByName("IUser").isDefined)
-        assertTrue(findObjectTypeByName("User").isDefined)
-        assertTrue(findObjectTypeByName("UserQuery").isDefined)
-        assertTrue(findObjectTypeByName("Post").isDefined)
-        assertTrue(getImplementsForType("User").equals("IIdentified"))
-        assertTrue(getImplementsForType("UserQuery").equals("IUser"))
-
-      },
       test("extends with duplicate field") {
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
           "Identified" -> Config.Type("id" -> Config.Field.int),

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/Config2SDLSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/Config2SDLSpec.scala
@@ -369,8 +369,16 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
+                           |type A {
+                           |  b: B
+                           |}
+                           |
                            |type B {
                            |  c: String
+                           |}
+                           |
+                           |type Foo {
+                           |  a: A
                            |}
                            |
                            |type Query {
@@ -387,6 +395,10 @@ object Config2SDLSpec extends TailcallSpec {
           )
           val expected = """schema {
                            |  query: Query
+                           |}
+                           |
+                           |type Foo {
+                           |  a: String
                            |}
                            |
                            |type Query {
@@ -407,8 +419,16 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
+                           |type A {
+                           |  b: [B]
+                           |}
+                           |
                            |type B {
                            |  c: String
+                           |}
+                           |
+                           |type Foo {
+                           |  a: [A]
                            |}
                            |
                            |type Query {
@@ -429,8 +449,16 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
+                           |type A {
+                           |  b: [B]
+                           |}
+                           |
                            |type B {
                            |  c: String
+                           |}
+                           |
+                           |type Foo {
+                           |  a: [A]
                            |}
                            |
                            |type Query {
@@ -450,6 +478,10 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
+                           |type Foo {
+                           |  a: [String!]
+                           |}
+                           |
                            |type Query {
                            |  foo: String
                            |}
@@ -467,6 +499,10 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
+                           |type Foo {
+                           |  a: String!
+                           |}
+                           |
                            |type Query {
                            |  foo: String
                            |}
@@ -482,6 +518,10 @@ object Config2SDLSpec extends TailcallSpec {
 
           val expected = """schema {
                            |  query: Query
+                           |}
+                           |
+                           |type Foo {
+                           |  a: String!
                            |}
                            |
                            |type Query {

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/Config2SDLSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/Config2SDLSpec.scala
@@ -369,16 +369,8 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
-                           |type A {
-                           |  b: B
-                           |}
-                           |
                            |type B {
                            |  c: String
-                           |}
-                           |
-                           |type Foo {
-                           |  a: A
                            |}
                            |
                            |type Query {
@@ -395,10 +387,6 @@ object Config2SDLSpec extends TailcallSpec {
           )
           val expected = """schema {
                            |  query: Query
-                           |}
-                           |
-                           |type Foo {
-                           |  a: String
                            |}
                            |
                            |type Query {
@@ -419,16 +407,8 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
-                           |type A {
-                           |  b: [B]
-                           |}
-                           |
                            |type B {
                            |  c: String
-                           |}
-                           |
-                           |type Foo {
-                           |  a: [A]
                            |}
                            |
                            |type Query {
@@ -449,16 +429,8 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
-                           |type A {
-                           |  b: [B]
-                           |}
-                           |
                            |type B {
                            |  c: String
-                           |}
-                           |
-                           |type Foo {
-                           |  a: [A]
                            |}
                            |
                            |type Query {
@@ -478,10 +450,6 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
-                           |type Foo {
-                           |  a: [String!]
-                           |}
-                           |
                            |type Query {
                            |  foo: String
                            |}
@@ -499,10 +467,6 @@ object Config2SDLSpec extends TailcallSpec {
                            |  query: Query
                            |}
                            |
-                           |type Foo {
-                           |  a: String!
-                           |}
-                           |
                            |type Query {
                            |  foo: String
                            |}
@@ -518,10 +482,6 @@ object Config2SDLSpec extends TailcallSpec {
 
           val expected = """schema {
                            |  query: Query
-                           |}
-                           |
-                           |type Foo {
-                           |  a: String!
                            |}
                            |
                            |type Query {

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/Config2SDLSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/Config2SDLSpec.scala
@@ -1,11 +1,14 @@
 package tailcall.runtime.transcoder
 
-import tailcall.runtime.model.Config
 import tailcall.runtime.model.Config.{Arg, Field, Type}
+import tailcall.runtime.model.UnsafeSteps.Operation
+import tailcall.runtime.model.{Config, Path}
 import tailcall.runtime.service._
 import tailcall.test.TailcallSpec
 import zio.ZIO
 import zio.test.{TestResult, assertTrue}
+
+import java.net.URI
 
 /**
  * Tests for the generation of GraphQL schema from a config.
@@ -492,6 +495,77 @@ object Config2SDLSpec extends TailcallSpec {
           assertSDL(config, expected)
         },
       ),
+      test("blueprint graphql for extends") {
+        val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
+          "Query"       -> Config.Type(
+            "users" -> Config.Field.ofType("UserQuery").asList
+              .withHttp(Operation.Http(Path.unsafe.fromString("/users")))
+          ),
+          "Identified"  -> Config.Type("id" -> Config.Field.int),
+          "Addressable" -> Config.Type("address" -> Config.Field.str),
+          "User"        -> Config.Type("name" -> Config.Field.str).extendsWith("Identified", "Addressable"),
+          "UserQuery"   -> Config.Type(
+            "posts" -> Config.Field.ofType("Post").asList
+              .withHttp(Operation.Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
+          ).extendsWith("User"),
+          "Post"        -> Config.Type("userId" -> Config.Field.int, "id" -> Config.Field.int),
+        )
+
+        val expected = """
+                         |schema {
+                         |  query: Query
+                         |}
+                         |
+                         |interface IAddressable {
+                         |  address: String
+                         |}
+                         |
+                         |interface IIdentified {
+                         |  id: Int
+                         |}
+                         |
+                         |interface IUser {
+                         |  name: String
+                         |  id: Int
+                         |  address: String
+                         |}
+                         |
+                         |type Addressable {
+                         |  address: String
+                         |}
+                         |
+                         |type Identified {
+                         |  id: Int
+                         |}
+                         |
+                         |type Post {
+                         |  userId: Int
+                         |  id: Int
+                         |}
+                         |
+                         |type Query {
+                         |  users: [UserQuery]
+                         |}
+                         |
+                         |type User implements IIdentified & IAddressable {
+                         |  name: String
+                         |  id: Int
+                         |  address: String
+                         |}
+                         |
+                         |type UserQuery implements IUser {
+                         |  posts: [Post]
+                         |  name: String
+                         |  id: Int
+                         |  address: String
+                         |}
+                         |""".stripMargin.trim
+
+        for {
+          blueprint <- Transcoder.toBlueprint(config).toTask
+          graphQL   <- blueprint.toGraphQL
+        } yield assertTrue(graphQL.render == expected)
+      },
     ).provide(GraphQLGenerator.default)
 
   private def assertSDL(config: Config, expected: String): ZIO[GraphQLGenerator, Throwable, TestResult] =

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
@@ -302,11 +302,11 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
               .withHttp(Operation.Http(Path.unsafe.fromString("/users")))
           ),
           "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(types = List("Identified")),
+          "User"       -> Config.Type("name" -> Config.Field.str).extendsWith("Identified"),
           "UserQuery"  -> Config.Type(
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Operation.Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
-          ).withExtends(types = List("User")),
+          ).extendsWith("User"),
           "Post"       -> Config.Type("userId" -> Config.Field.int, "id" -> Config.Field.int),
         )
 
@@ -352,12 +352,12 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
           ),
           "Identified"  -> Config.Type("id" -> Config.Field.int),
           "Addressable" -> Config.Type("address" -> Config.Field.str),
-          "User"      -> Config.Type("name" -> Config.Field.str).withExtends(types = List("Identified", "Addressable")),
-          "UserQuery" -> Config.Type(
+          "User"        -> Config.Type("name" -> Config.Field.str).extendsWith("Identified", "Addressable"),
+          "UserQuery"   -> Config.Type(
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Operation.Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
-          ).withExtends(types = List("User")),
-          "Post"      -> Config.Type("userId" -> Config.Field.int, "id" -> Config.Field.int),
+          ).extendsWith("User"),
+          "Post"        -> Config.Type("userId" -> Config.Field.int, "id" -> Config.Field.int),
         )
 
         assertIdentity(config, graphQL)

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
@@ -273,12 +273,17 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
                         |  query: Query
                         |}
                         |
-                        |type Query {
-                        |  users: [UserQuery] @http(path: "/users")
-                        |}
-                        |
                         |type Identified {
                         |  id: Int
+                        |}
+                        |
+                        |type Post {
+                        |  id: Int
+                        |  userId: Int
+                        |}
+                        |
+                        |type Query {
+                        |  users: [UserQuery] @http(path: "/users")
                         |}
                         |
                         |type User @extends(type: "Identified") {
@@ -289,10 +294,6 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
                         |  posts: [Post] @http(path: "/users/{{value.id}}/posts")
                         |}
                         |
-                        |type Post {
-                        |  id: Int
-                        |  userId: Int
-                        |}
                         |""".stripMargin.trim
 
         val config = Config.default.withBaseURL(URI.create("http://foo.com").toURL).withTypes(
@@ -310,7 +311,7 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
         )
 
         assertIdentity(config, graphQL)
-      } @@ failing,
+      },
     )
 
   private def assertIdentity(config: Config, sdl: String): ZIO[Any, String, TestResult] = {

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
@@ -286,11 +286,11 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
                         |  users: [UserQuery] @http(path: "/users")
                         |}
                         |
-                        |type User @extends(type: "Identified") {
+                        |type User @extends(types: ["Identified"]) {
                         |  name: String
                         |}
                         |
-                        |type UserQuery @extends(type: "User") {
+                        |type UserQuery @extends(types: ["User"]) {
                         |  posts: [Post] @http(path: "/users/{{value.id}}/posts")
                         |}
                         |
@@ -302,11 +302,11 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
               .withHttp(Operation.Http(Path.unsafe.fromString("/users")))
           ),
           "Identified" -> Config.Type("id" -> Config.Field.int),
-          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(typeName = "Identified"),
+          "User"       -> Config.Type("name" -> Config.Field.str).withExtends(types = List("Identified")),
           "UserQuery"  -> Config.Type(
             "posts" -> Config.Field.ofType("Post").asList
               .withHttp(Operation.Http(path = Path.unsafe.fromString("/users/{{value.id}}/posts")))
-          ).withExtends(typeName = "User"),
+          ).withExtends(types = List("User")),
           "Post"       -> Config.Type("userId" -> Config.Field.int, "id" -> Config.Field.int),
         )
 


### PR DESCRIPTION
Add support for the `extends` feature as described here
https://github.com/tailcallhq/tailcall/issues/169

@tusharmath - still working on the tests, debugging an issue where, if a type is not referenced (directly or indirectly) through a query, it does not show up in the graphql. For example, for this file
https://github.com/tailcallhq/type-tango/blob/feature/extends/src/jsonplaceholder/jsonplaceholderWithExtends.graphql
the `Identified` type is not present in the final schema, since it is not referenced by any other field or query, (although the interfaces and implements are created correctly.)
I was able to reproduce this in `main` too, if you remove all references to `Post` (except the type itself) in `jsonplaceholder.graphql`, the `Post` type is not present in the output schema.
