### PR TITLE
fix: unreserved chars in path segment

### DIFF
--- a/runtime/src/main/scala/tailcall/runtime/model/Path.scala
+++ b/runtime/src/main/scala/tailcall/runtime/model/Path.scala
@@ -62,7 +62,7 @@ object Path {
   }
 
   object syntax {
-    val segment = (Syntax.alphaNumeric | Syntax.charIn('-', '_')).repeat
+    val segment = (Syntax.alphaNumeric | Syntax.charIn('-', '_', '.', '~')).repeat
       .transform[String](_.asString, Chunk.fromIterable(_))
 
     val param = MustacheExpression.syntax.transform[Segment.Param](Segment.Param(_), _.mustache)

--- a/runtime/src/test/scala/tailcall/runtime/PathSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/PathSpec.scala
@@ -56,5 +56,12 @@ object PathSpec extends TailcallSpec {
           } yield assertTrue(actual == expected)
         }
       },
+      test("unreserved characters in path segment") {
+        val inputs = List("/v1.1", "/v2~2", "/some-name", "/some_name")
+
+        checkAll(Gen.fromIterable(inputs)) { case str =>
+          assertTrue(Path.unsafe.fromString(str).encode.getOrElse("") == str)
+        }
+      },
     )
 }

--- a/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/transcoder/ConfigSDLIdentitySpec.scala
@@ -267,34 +267,6 @@ object ConfigSDLIdentitySpec extends TailcallSpec {
         // Config will need to have support for keeping a copy of all the directives.
         // Currently we lose them when we parse a doc into a Config.
       } @@ ignore,
-      test("path with unreserved characters") {
-        val graphQL = """
-                        |schema {
-                        |  query: Query
-                        |}
-                        |
-                        |type Query {
-                        |  bar: [User] @http(path: "/v1~1/users")
-                        |  foo: [User] @http(path: "/v1.1/users")
-                        |}
-                        |
-                        |type User {
-                        |  id: Int
-                        |  name: String
-                        |}
-                        |
-                        |""".stripMargin.trim
-
-        val config = Config.default.withTypes(
-          "Query" -> Type(
-            "foo" -> Field.ofType("User").asList.withHttp(Operation.Http(Path.unsafe.fromString("/v1.1/users"))),
-            "bar" -> Field.ofType("User").asList.withHttp(Operation.Http(Path.unsafe.fromString("/v1~1/users"))),
-          ),
-          "User"  -> Type("id" -> Field.ofType("Int"), "name" -> Field.ofType("String")),
-        )
-
-        assertIdentity(config, graphQL)
-      },
     )
 
   private def assertIdentity(config: Config, sdl: String): ZIO[Any, String, TestResult] = {


### PR DESCRIPTION
Allow additional characters in path, to be able to specify paths like
https://restcountries.com/v3.1/all

(https://datatracker.ietf.org/doc/html/rfc3986#section-2.3)