### PR TITLE
better response cache headers

### DIFF
--- a/runtime/src/main/scala/tailcall/runtime/service/DataLoader.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/DataLoader.scala
@@ -2,7 +2,7 @@ package tailcall.runtime.service
 
 import tailcall.runtime.http.{HttpClient, Request}
 import zio._
-import zio.http.{Request => ZRequest}
+import zio.http.{Response, Request => ZRequest}
 
 final case class DataLoader[R, E, A, B](
   ref: Ref[DataLoader.State[E, A, B]],
@@ -66,7 +66,7 @@ final case class DataLoader[R, E, A, B](
 }
 
 object DataLoader {
-  type HttpDataLoader = DataLoader[Any, Throwable, Request, Chunk[Byte]]
+  type HttpDataLoader = DataLoader[Any, Throwable, Request, Response]
   // TODO: make this configurable
   private val allowedHeaders: Set[String] = Set("authorization", "cookie")
 
@@ -76,22 +76,23 @@ object DataLoader {
 
   def http(req: Option[ZRequest] = None): ZLayer[HttpClient, Nothing, HttpDataLoader] =
     ZLayer {
-      ZIO.service[HttpClient].flatMap { client =>
-        DataLoader.one[Request] { request =>
-          val finalHeaders = request.headers ++ getForwardedHeaders(req)
-          for {
-            response <- client.request(request.copy(headers = finalHeaders))
-            _ <- ValidationError.StatusCodeError(response.status.code, request.url).when(response.status.code >= 400)
-            chunk <- response.body.asChunk
-          } yield chunk
-        }
+      ZIO.serviceWithZIO[HttpClient] {
+        client =>
+          DataLoader.one[Request] { request =>
+            val finalHeaders = request.headers ++ getForwardedHeaders(req)
+            for {
+              response <- client.request(request.copy(headers = finalHeaders))
+              _ <- ValidationError.StatusCodeError(response.status.code, request.url).when(response.status.code >= 400)
+
+            } yield response
+          }
       }
     }
 
-  def httpCollect(requests: Chunk[Request]): ZIO[HttpContext, Throwable, Chunk[ZIO[Any, Throwable, Chunk[Byte]]]] =
+  def httpCollect(requests: Chunk[Request]): ZIO[HttpContext, Throwable, Chunk[ZIO[Any, Throwable, Response]]] =
     ZIO.serviceWithZIO[HttpContext](_.dataLoader.collect(requests: _*))
 
-  def httpLoad(request: Request): ZIO[HttpContext, Throwable, Chunk[Byte]] =
+  def httpLoad(request: Request): ZIO[HttpContext, Throwable, Response] =
     ZIO.serviceWithZIO[HttpContext](_.dataLoader.load(request))
 
   def many[A]: PartiallyAppliedDataLoaderMany[A] = new PartiallyAppliedDataLoaderMany(())

--- a/runtime/src/main/scala/tailcall/runtime/service/EndpointGenerator.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/EndpointGenerator.scala
@@ -41,7 +41,7 @@ object EndpointGenerator {
             headers,
             request.body.map(body => Chunk.fromIterable(body.raw.toString().getBytes(Charset.defaultCharset())))
               .getOrElse(Chunk.empty),
-          )).flatMap(res => res.body.asChunk ).map(resp =>
+          )).flatMap(res => res.body.asChunk).map(resp =>
             endpointWithHost.withMethod(request.method)
               .withInput(request.body.flatMap(body => Transcoder.toTSchema(body.raw.toString()).toOption))
               .withOutput(Transcoder.toTSchema(new String(resp.toArray, StandardCharsets.UTF_8)).toOption)

--- a/runtime/src/main/scala/tailcall/runtime/service/EndpointGenerator.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/EndpointGenerator.scala
@@ -41,7 +41,7 @@ object EndpointGenerator {
             headers,
             request.body.map(body => Chunk.fromIterable(body.raw.toString().getBytes(Charset.defaultCharset())))
               .getOrElse(Chunk.empty),
-          )).map(resp =>
+          )).flatMap(res => res.body.asChunk ).map(resp =>
             endpointWithHost.withMethod(request.method)
               .withInput(request.body.flatMap(body => Transcoder.toTSchema(body.raw.toString()).toOption))
               .withOutput(Transcoder.toTSchema(new String(resp.toArray, StandardCharsets.UTF_8)).toOption)

--- a/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
@@ -155,13 +155,12 @@ object EvaluationRuntime {
                   val request = endpoint.evaluate(input.asInstanceOf[DynamicValue])
                   ZIO.logSpan(s"${request.method} ${request.url}") {
                     for {
-                      res     <- DataLoader.httpLoad(request)
-                      httpctx <- ZIO.service[HttpContext]
-                      _       <- httpctx.updateState(_ => HttpContext.State(HttpCache.ttlHeaders(res.headers)))
-                      chunk   <- res.body.asChunk
-                      json    <- ZIO.fromEither(new String(chunk.toArray, StandardCharsets.UTF_8).fromJson[Json])
+                      res   <- DataLoader.httpLoad(request)
+                      _     <- HttpContext.update(_ => HttpContext.State(HttpCache.ttlHeaders(res.headers)))
+                      chunk <- res.body.asChunk
+                      json  <- ZIO.fromEither(new String(chunk.toArray, StandardCharsets.UTF_8).fromJson[Json])
                         .mapError(ValidationError.DecodingError("String", "JsonAST", _))
-                      any     <- Transcoder.toDynamicValue(json).toZIO.mapError(_.mkString(", "))
+                      any   <- Transcoder.toDynamicValue(json).toZIO.mapError(_.mkString(", "))
                         .mapError(new RuntimeException(_))
                     } yield any
                   }

--- a/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
@@ -155,7 +155,8 @@ object EvaluationRuntime {
                   val request = endpoint.evaluate(input.asInstanceOf[DynamicValue])
                   ZIO.logSpan(s"${request.method} ${request.url}") {
                     for {
-                      chunk <- DataLoader.httpLoad(request)
+                      res <- DataLoader.httpLoad(request)
+                      chunk <- res.body.asChunk
                       json  <- ZIO.fromEither(new String(chunk.toArray, StandardCharsets.UTF_8).fromJson[Json])
                         .mapError(ValidationError.DecodingError("String", "JsonAST", _))
                       any   <- Transcoder.toDynamicValue(json).toZIO.mapError(_.mkString(", "))

--- a/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
@@ -156,7 +156,7 @@ object EvaluationRuntime {
                   ZIO.logSpan(s"${request.method} ${request.url}") {
                     for {
                       res   <- DataLoader.httpLoad(request)
-                      _     <- HttpContext.update(_ => HttpContext.State(HttpCache.ttlHeaders(res.headers)))
+                      _     <- HttpContext.update(_.addHeaders(res.headers))
                       chunk <- res.body.asChunk
                       json  <- ZIO.fromEither(new String(chunk.toArray, StandardCharsets.UTF_8).fromJson[Json])
                         .mapError(ValidationError.DecodingError("String", "JsonAST", _))

--- a/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/EvaluationRuntime.scala
@@ -155,8 +155,8 @@ object EvaluationRuntime {
                   val request = endpoint.evaluate(input.asInstanceOf[DynamicValue])
                   ZIO.logSpan(s"${request.method} ${request.url}") {
                     for {
-                      res   <- DataLoader.httpLoad(request)
-                      _     <- HttpContext.update(_.addHeaders(res.headers))
+                      res <- DataLoader.httpLoad(request)
+                      _ <- HttpContext.update(_.withCacheMaxAge(HttpCache.ttlHeaders(res.headers).getOrElse(0 seconds)))
                       chunk <- res.body.asChunk
                       json  <- ZIO.fromEither(new String(chunk.toArray, StandardCharsets.UTF_8).fromJson[Json])
                         .mapError(ValidationError.DecodingError("String", "JsonAST", _))

--- a/runtime/src/main/scala/tailcall/runtime/service/HttpCache.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/HttpCache.scala
@@ -3,6 +3,7 @@ import tailcall.runtime.http.Request
 import zio._
 import zio.cache.{Cache, CacheStats, Lookup}
 import zio.http.Response
+import zio.http.model.Headers
 
 import java.text.SimpleDateFormat
 import java.time.Instant
@@ -13,11 +14,14 @@ private[tailcall] trait HttpCache  {
 }
 private[tailcall] object HttpCache {
   val dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z")
-  final def ttl(res: Response, currentMillis: => Instant = Instant.now()): Option[Duration] = {
-    val headers      = res.headers.toList.map(x => String.valueOf(x.key).toLowerCase -> String.valueOf(x.value)).toMap
-    val cacheControl = headers.get("cache-control").map(_.split(",").map(_.trim).toSet).getOrElse(Set.empty)
+  final def ttl(res: Response, currentMillis: => Instant = Instant.now()): Option[Duration] =
+    ttlHeaders(res.headers, currentMillis)
+
+  final def ttlHeaders(headers: Headers, currentMillis: => Instant = Instant.now()): Option[Duration] = {
+    val headerList   = headers.toList.map(x => String.valueOf(x.key).toLowerCase -> String.valueOf(x.value)).toMap
+    val cacheControl = headerList.get("cache-control").map(_.split(",").map(_.trim).toSet).getOrElse(Set.empty)
     val maxAge       = cacheControl.find(_.startsWith("max-age=")).map(_.split("=").last).flatMap(_.toLongOption)
-    val expires      = maxAge.map(_ => None).getOrElse(headers.get("expires"))
+    val expires      = maxAge.map(_ => None).getOrElse(headerList.get("expires"))
     if (cacheControl.contains("private")) None
     else if (expires.isEmpty) maxAge.map(Duration.fromSeconds)
     else expires match {
@@ -29,6 +33,27 @@ private[tailcall] object HttpCache {
         }
       case None        => None
     }
+  }
+
+  import scala.util.Try
+
+  def calculateMinimumHeader(headers: List[(String, String)]): Option[String] = {
+    val cacheControlDirectives = headers.filter { case (key, _) => key.equalsIgnoreCase("Cache-Control") }
+      .flatMap { case (_, value) => value.split(",") }
+
+    val cacheControlMaxAgeValues = cacheControlDirectives.flatMap(header => Try(header.split("=")(1).toInt).toOption)
+      .filter(value => value > 0)
+
+    val expiresValues = headers.filter { case (key, _) => key.equalsIgnoreCase("Expires") }.flatMap { case (_, value) =>
+      Try(java.time.ZonedDateTime.parse(value)).toOption
+    }
+
+    val isPrivate        = cacheControlDirectives.exists(_.toLowerCase.contains("private"))
+    val minMaxAgeHeader  = cacheControlMaxAgeValues.minOption.map(value => s"Cache-Control: max-age=$value")
+    val minExpiresHeader = expiresValues.minOption.map(value => s"Expires: $value")
+
+    val finalCacheControlHeader = if (isPrivate) Some("Cache-Control: private") else minMaxAgeHeader
+    finalCacheControlHeader.orElse(minExpiresHeader)
   }
 
   def live(cacheSize: Int): ZLayer[Any, Nothing, Live] =

--- a/runtime/src/main/scala/tailcall/runtime/service/HttpCache.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/HttpCache.scala
@@ -17,7 +17,7 @@ private[tailcall] object HttpCache {
   final def ttl(res: Response, currentMillis: => Instant = Instant.now()): Option[Duration] =
     ttlHeaders(res.headers, currentMillis)
 
-  final def ttlHeaders(headers: Headers, currentMillis: => Instant = Instant.now()): Option[Duration] = {
+  final def ttlHeaders(headers: Headers, currentMillis: Instant = Instant.now()): Option[Duration] = {
     val headerList   = headers.toList.map(x => String.valueOf(x.key).toLowerCase -> String.valueOf(x.value)).toMap
     val cacheControl = headerList.get("cache-control").map(_.split(",").map(_.trim).toSet).getOrElse(Set.empty)
     val maxAge       = cacheControl.find(_.startsWith("max-age=")).map(_.split("=").last).flatMap(_.toLongOption)

--- a/runtime/src/main/scala/tailcall/runtime/service/HttpContext.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/HttpContext.scala
@@ -8,24 +8,36 @@ import zio.http.{Response, Request => ZRequest}
 trait HttpContext {
   def dataLoader: DataLoader[Any, Throwable, Request, Response]
   def requestHeaders: Headers
-  final def responseHeaders: UIO[Headers] = updateResponseHeaders(identity)
 
-  def updateResponseHeaders(headers: Headers =>  Headers): UIO[Headers]
+  // final def responseHeaders: UIO[Headers] = updateResponseHeaders(identity)
+
+  final def getState: UIO[Option[Duration]] = updateState(identity).map(_.value)
+
+  def updateState(
+    state: HttpContext.State[Option[Duration]] => HttpContext.State[Option[Duration]]
+  ): UIO[HttpContext.State[Option[Duration]]]
 }
 
 object HttpContext {
-  def default: ZLayer[Any, Throwable, HttpContext]                          = HttpClient.default >>> live(None)
+  def default: ZLayer[Any, Throwable, HttpContext] = HttpClient.default >>> live(None)
+
+  def getState: ZIO[HttpContext, Nothing, Option[Duration]] = ZIO.serviceWithZIO(_.getState)
+
   def live(req: Option[ZRequest]): ZLayer[HttpClient, Nothing, HttpContext] =
     DataLoader.http(req) >>> ZLayer {
       for {
-        ref <- Ref.make(Headers.empty)
+        ref        <- Ref.make(State[Option[Duration]](None))
         dataLoader <- ZIO.service[DataLoader[Any, Throwable, Request, Response]]
       } yield Live(dataLoader, req.map(_.headers).getOrElse(Headers.empty), ref)
     }
 
-  final case class Live(dataLoader: DataLoader[Any, Throwable, Request, Response], requestHeaders: Headers, ref: Ref[Headers])
-      extends HttpContext {
-    override def updateResponseHeaders(f: Headers => Headers): UIO[Headers] = ref.updateAndGet(f)
-
+  final case class State[+A](value: A)
+  final case class Live(
+    dataLoader: DataLoader[Any, Throwable, Request, Response],
+    requestHeaders: Headers,
+    ref: Ref[State[Option[Duration]]],
+  ) extends HttpContext {
+    override def updateState(state: State[Option[Duration]] => State[Option[Duration]]): UIO[State[Option[Duration]]] =
+      ref.updateAndGet(state)
   }
 }

--- a/runtime/src/main/scala/tailcall/runtime/service/HttpContext.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/HttpContext.scala
@@ -3,7 +3,7 @@ package tailcall.runtime.service
 import tailcall.runtime.http.{HttpClient, Request}
 import zio._
 import zio.http.model.Headers
-import zio.http.{Response, Request => ZRequest}
+import zio.http.{Request => ZRequest, Response}
 
 trait HttpContext {
   def dataLoader: DataLoader[Any, Throwable, Request, Response]

--- a/runtime/src/main/scala/tailcall/runtime/service/HttpContext.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/HttpContext.scala
@@ -4,20 +4,19 @@ import tailcall.runtime.http.{HttpClient, Request}
 import tailcall.runtime.service.HttpContext.State
 import zio._
 import zio.http.model.Headers
-import zio.http.{Request => ZRequest, Response}
+import zio.http.{Response, Request => ZRequest}
 
 trait HttpContext {
   def dataLoader: DataLoader[Any, Throwable, Request, Response]
   def requestHeaders: Headers
-  final def getState: UIO[State] = updateState(identity)
-
-  def updateState(state: State => State): UIO[State]
+  final def getState: UIO[State] = update(identity)
+  def update(state: State => State): UIO[State]
 }
 
 object HttpContext {
-  def default: ZLayer[Any, Throwable, HttpContext] = HttpClient.default >>> live(None)
-
-  def getState: ZIO[HttpContext, Nothing, State] = ZIO.serviceWithZIO(_.getState)
+  def default: ZLayer[Any, Throwable, HttpContext]                = HttpClient.default >>> live(None)
+  def update(f: State => State): ZIO[HttpContext, Nothing, State] = ZIO.serviceWithZIO(_.update(f))
+  def getState: ZIO[HttpContext, Nothing, State]                  = ZIO.serviceWithZIO(_.getState)
 
   def live(req: Option[ZRequest]): ZLayer[HttpClient, Nothing, HttpContext] =
     DataLoader.http(req) >>> ZLayer {
@@ -27,12 +26,13 @@ object HttpContext {
       } yield Live(dataLoader, req.map(_.headers).getOrElse(Headers.empty), ref)
     }
 
-  final case class State(value: Option[Duration])
+  final case class State(cacheMaxAge: Option[Duration])
+
   final case class Live(
     dataLoader: DataLoader[Any, Throwable, Request, Response],
     requestHeaders: Headers,
     ref: Ref[State],
   ) extends HttpContext {
-    override def updateState(state: State => State): UIO[State] = ref.updateAndGet(state)
+    override def update(state: State => State): UIO[State] = ref.updateAndGet(state)
   }
 }

--- a/runtime/src/main/scala/tailcall/runtime/service/StepGenerator.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/StepGenerator.scala
@@ -43,7 +43,10 @@ object StepGenerator {
     def resolve: StepResult[HttpContext] = {
       def withHeaders(f: Context => Step[HttpContext]): ZQuery[HttpContext, Nothing, Step[HttpContext]] =
         ZQuery.fromZIO(ZIO.service[HttpContext].map(h =>
-          f(rootContext.copy(headers = h.requestHeaders.map(h => String.valueOf(h.key) -> String.valueOf(h.value)).toMap))
+          f(
+            rootContext
+              .copy(headers = h.requestHeaders.map(h => String.valueOf(h.key) -> String.valueOf(h.value)).toMap)
+          )
         ))
       val queryStep                                                                                     = for {
         query <- blueprint.schema.flatMap(_.query)

--- a/runtime/src/main/scala/tailcall/runtime/service/StepGenerator.scala
+++ b/runtime/src/main/scala/tailcall/runtime/service/StepGenerator.scala
@@ -43,7 +43,7 @@ object StepGenerator {
     def resolve: StepResult[HttpContext] = {
       def withHeaders(f: Context => Step[HttpContext]): ZQuery[HttpContext, Nothing, Step[HttpContext]] =
         ZQuery.fromZIO(ZIO.service[HttpContext].map(h =>
-          f(rootContext.copy(headers = h.headers.map(h => String.valueOf(h.key) -> String.valueOf(h.value)).toMap))
+          f(rootContext.copy(headers = h.requestHeaders.map(h => String.valueOf(h.key) -> String.valueOf(h.value)).toMap))
         ))
       val queryStep                                                                                     = for {
         query <- blueprint.schema.flatMap(_.query)

--- a/runtime/src/test/scala/tailcall/runtime/HttpCacheSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/HttpCacheSpec.scala
@@ -50,37 +50,6 @@ object HttpCacheSpec extends TailcallSpec {
         val expected   = Some(Duration.fromSeconds(1000))
         assert(p)(equalTo(expected))
       },
-      suite("calculate Minimum Headers")(
-        test("private") {
-          val headers  = List(
-            ("Cache-Control", "public, max-age=3600"),
-            ("Cache-Control", "private, max-age=1800"),
-            ("Expires", "Fri, 17 Jun 2023 12:00:00 GMT"),
-            ("Expires", "Fri, 17 Jun 2023 13:30:00 GMT"),
-          )
-          val expected = Some("Cache-Control: private")
-          val actual   = HttpCache.calculateMinimumHeader(headers)
-          assertTrue(actual == expected)
-        },
-        test("default values") {
-          val headers = List(("Cache-Control", "max-age=0"), ("Expires", "-1"))
-          assertTrue(HttpCache.calculateMinimumHeader(headers).isEmpty)
-        },
-        test("Minimum possible input") {
-          val headers = List(("Cache-Control", "max-age=0"), ("Expires", "Thu, 01 Jan 1970 00:00:00 GMT"))
-          assertTrue(HttpCache.calculateMinimumHeader(headers).isEmpty)
-        },
-        test("Multiple Cache-Control headers with different max-age values:") {
-          val headers = List(
-            ("Cache-Control", "max-age=3600"),
-            ("Cache-Control", "max-age=1800"),
-            ("Expires", "Fri, 17 Jun 2023 12:00:00 GMT"),
-            ("Expires", "Fri, 17 Jun 2023 13:30:00 GMT"),
-          )
-          assertTrue(HttpCache.calculateMinimumHeader(headers).contains("Cache-Control: max-age=1800"))
-
-        },
-      ),
     )
   }
 

--- a/server/src/main/scala/tailcall/server/GenericServer.scala
+++ b/server/src/main/scala/tailcall/server/GenericServer.scala
@@ -29,7 +29,7 @@ object GenericServer {
               blueprintData.timeout.millis
             )
           _ <- ZIO.foreachDiscard(res.errors)(error => ZIO.logWarningCause("GraphQLExecutionError", Cause.fail(error)))
-          maxAge <- HttpContext.getState
+          maxAge <- HttpContext.getState.map(_.value)
         } yield Response.json(res.toJson).withCacheControlMaxAge(maxAge.getOrElse(0 second)))
           .provideLayer(HttpContext.live(Option(req)))
 

--- a/server/src/main/scala/tailcall/server/GenericServer.scala
+++ b/server/src/main/scala/tailcall/server/GenericServer.scala
@@ -30,8 +30,7 @@ object GenericServer {
             )
           _ <- ZIO.foreachDiscard(res.errors)(error => ZIO.logWarningCause("GraphQLExecutionError", Cause.fail(error)))
           maxAge <- HttpContext.getState.map(_.cacheMaxAge)
-        } yield Response.json(res.toJson).withCacheControlMaxAge(maxAge.getOrElse(0 second)))
-          .provideLayer(HttpContext.live(Option(req)))
+        } yield Response.json(res.toJson).withCacheControlMaxAge(maxAge)).provideLayer(HttpContext.live(Option(req)))
 
       } yield res
     }

--- a/server/src/main/scala/tailcall/server/GenericServer.scala
+++ b/server/src/main/scala/tailcall/server/GenericServer.scala
@@ -11,24 +11,28 @@ import zio.http.model.{HttpError, Method}
 import zio.json.EncoderOps
 
 object GenericServer {
-  private def toBetterError(error: CalibanError): CalibanError = {
+  private def toBetterError(error: CalibanError): CalibanError                                             = {
     error match {
       case error: CalibanError.ExecutionError  => error.copy(msg = "Orchestration Failure")
       case error: CalibanError.ParsingError    => error
       case error: CalibanError.ValidationError => error
     }
   }
-
   def graphQL: Http[HttpClient with GraphQLGenerator with InterpreterLoader, Throwable, Request, Response] =
     Http.collectZIO[Request] { case req @ Method.POST -> !! / "graphql" / id =>
       for {
         blueprintData <- load(id)
         query         <- GraphQLUtils.decodeQuery(req.body)
-        res           <- blueprintData.interpreter.execute(query).provideLayer(HttpContext.live(Option(req)))
-          .map(res => res.copy(errors = res.errors.map(toBetterError))).timeoutFail(HttpError.RequestTimeout(
-            s"Request timed out after ${blueprintData.timeout}ms"
-          ))(blueprintData.timeout.millis)
-        _ <- ZIO.foreachDiscard(res.errors)(error => ZIO.logWarningCause("GraphQLExecutionError", Cause.fail(error)))
-      } yield Response.json(res.toJson)
+        res           <- (for {
+          res <- blueprintData.interpreter.execute(query).map(res => res.copy(errors = res.errors.map(toBetterError)))
+            .timeoutFail(HttpError.RequestTimeout(s"Request timed out after ${blueprintData.timeout}ms"))(
+              blueprintData.timeout.millis
+            )
+          _ <- ZIO.foreachDiscard(res.errors)(error => ZIO.logWarningCause("GraphQLExecutionError", Cause.fail(error)))
+          maxAge <- HttpContext.getState
+        } yield Response.json(res.toJson).withCacheControlMaxAge(maxAge.getOrElse(0 second)))
+          .provideLayer(HttpContext.live(Option(req)))
+
+      } yield res
     }
 }

--- a/server/src/main/scala/tailcall/server/GenericServer.scala
+++ b/server/src/main/scala/tailcall/server/GenericServer.scala
@@ -29,7 +29,7 @@ object GenericServer {
               blueprintData.timeout.millis
             )
           _ <- ZIO.foreachDiscard(res.errors)(error => ZIO.logWarningCause("GraphQLExecutionError", Cause.fail(error)))
-          maxAge <- HttpContext.getState.map(_.value)
+          maxAge <- HttpContext.getState.map(_.cacheMaxAge)
         } yield Response.json(res.toJson).withCacheControlMaxAge(maxAge.getOrElse(0 second)))
           .provideLayer(HttpContext.live(Option(req)))
 


### PR DESCRIPTION
Intelligently calculate the cache headers from the downstream requests made by each query and forward the minimum to the client