### PR TITLE
Don't allow modify on fields that are implemented via an interface

### DIFF
--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
@@ -72,7 +72,7 @@ object Config2Blueprint {
         val dblUsage = inputTypes.contains(typeName) && outputTypes.contains(typeName)
         for {
           _      <- TValid.fail(s"$typeName cannot be both used both as input and output type").when(dblUsage)
-          fields <- toFieldList(typeName, typeInfo)
+          fields <- toFieldList(typeName, typeInfo, config.graphQL.types.toList)
         } yield {
           val definition = Blueprint.ObjectTypeDefinition(
             name = typeName,
@@ -94,23 +94,63 @@ object Config2Blueprint {
       } yield Blueprint.FieldDefinition(name = fieldName, args = args, ofType = ofType, description = field.doc)
     }
 
-    private def toFieldList(typeName: String, typeInfo: Type): TValid[String, List[Blueprint.FieldDefinition]] = {
+    private def validateModify(
+      fieldName: String,
+      field: Field,
+      typeName: String,
+      typeInfo: Type,
+      types: List[(String, Type)],
+    ): TValid[String, String] = {
+      field.modify match {
+        case Some(ModifyField(None, None)) => TValid.succeed("")
+        case None                          => TValid.succeed("")
+        case _                             =>
+          val interfaceWithSameField = types.filter(_._2.interface.isDefined)
+            .filter(interface => typeInfo.implements.toList.flatten.contains(interface._1))
+            .find(interface => interface._2.fields.find { case (iFieldName, _) => iFieldName == fieldName }.isDefined)
+
+          interfaceWithSameField match {
+            case Some(value) => TValid.fail(
+                s"Cannot use modify on field ${fieldName} on type ${typeName} because it implements interface ${value._1} with the same field"
+              )
+            case _           => TValid.succeed("")
+          }
+      }
+    }
+
+    private def validateField(
+      fieldName: String,
+      field: Field,
+      typeName: String,
+      typeInfo: Type,
+      types: List[(String, Type)],
+    ): TValid[String, String] = { for { _ <- validateModify(fieldName, field, typeName, typeInfo, types) } yield "" }
+
+    private def toFieldList(
+      typeName: String,
+      typeInfo: Type,
+      types: List[(String, Type)],
+    ): TValid[String, List[Blueprint.FieldDefinition]] = {
       TValid.foreach(typeInfo.fields.toList) { case (fieldName, field) =>
-        (for {
-          bField <- toFieldDefault(fieldName, field)
-          bField <-
-            if (inputTypes.contains(typeName)) TValid.succeed(List(bField))
-            else for {
-              bField      <- updateUnsafeField(field, bField).trace("@" + UnsafeSteps.directive.name)
-              bField      <- updateFieldHttp(field, bField).trace("@" + Http.directive.name)
-              mayBeBField <- updateModifyField(field, bField).trace("@" + ModifyField.directive.name)
-              bField      <- mayBeBField match {
-                case Some(bField) => updateInlineField(typeName, typeInfo, fieldName, field, bField).some
-                    .trace("@" + InlineType.directive.name)
-                case None         => TValid.none
-              }
-            } yield bField.toList
-        } yield bField).trace(fieldName)
+        {
+
+          for {
+            bField <- toFieldDefault(fieldName, field)
+            bField <-
+              if (inputTypes.contains(typeName)) TValid.succeed(List(bField))
+              else for {
+                _           <- validateField(fieldName, field, typeName, typeInfo, types)
+                bField      <- updateUnsafeField(field, bField).trace("@" + UnsafeSteps.directive.name)
+                bField      <- updateFieldHttp(field, bField).trace("@" + Http.directive.name)
+                mayBeBField <- updateModifyField(field, bField).trace("@" + ModifyField.directive.name)
+                bField      <- mayBeBField match {
+                  case Some(bField) => updateInlineField(typeName, typeInfo, fieldName, field, bField).some
+                      .trace("@" + InlineType.directive.name)
+                  case None         => TValid.none
+                }
+              } yield bField.toList
+          } yield bField
+        }.trace(fieldName)
       }.map(_.flatten).trace(typeName)
     }
 

--- a/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
+++ b/runtime/src/main/scala/tailcall/runtime/transcoder/Config2Blueprint.scala
@@ -133,7 +133,6 @@ object Config2Blueprint {
     ): TValid[String, List[Blueprint.FieldDefinition]] = {
       TValid.foreach(typeInfo.fields.toList) { case (fieldName, field) =>
         {
-
           for {
             bField <- toFieldDefault(fieldName, field)
             bField <-

--- a/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-interface-field.graphql
+++ b/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-interface-field.graphql
@@ -1,0 +1,39 @@
+#> server-sdl
+schema {
+  query: Query
+}
+
+interface IA {
+  a: String
+}
+
+type B implements IA {
+  a: String @modify(name: "x")
+  b: String
+}
+
+type Query {
+  bar: B
+}
+
+#> client-sdl
+schema {
+  query: Query
+}
+
+interface IA {
+  a: String
+}
+
+type B implements IA {
+  b: String
+  x: String
+}
+
+type Query {
+  bar: B
+}
+
+#> client-error
+# Cannot use modify on field a on type B because it implements interface IA with the same field
+# B,a

--- a/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-interface-field.graphql
+++ b/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-interface-field.graphql
@@ -36,4 +36,4 @@ type Query {
 
 #> client-error
 # Cannot use modify on field a on type B because it implements interface IA with the same field
-# B,a
+# B,a,@modify

--- a/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-interface-field.graphql
+++ b/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-interface-field.graphql
@@ -35,5 +35,4 @@ type Query {
 }
 
 #> client-error
-# Cannot use modify on field a on type B because it implements interface IA with the same field
-# B,a,@modify
+# - [B, a, @modify] Cannot use modify on field a because it is implemented from interface IA

--- a/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-non-interface-field.graphql
+++ b/runtime/src/test/resources/tailcall/runtime/graphql/test-modify-non-interface-field.graphql
@@ -1,0 +1,35 @@
+#> server-sdl
+schema {
+  query: Query
+}
+
+interface IA {
+  a: String
+}
+
+type B implements IA {
+  a: String
+  b: String @modify(name: "x")
+}
+
+type Query {
+  bar: B
+}
+
+#> client-sdl
+schema {
+  query: Query
+}
+
+interface IA {
+  a: String
+}
+
+type B implements IA {
+  a: String
+  x: String
+}
+
+type Query {
+  bar: B
+}

--- a/runtime/src/test/scala/tailcall/runtime/ConfigPropertySpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/ConfigPropertySpec.scala
@@ -41,7 +41,9 @@ object ConfigPropertySpec extends TailcallSpec with GraphQLTestSpec {
   }
 
   def buildExpectedError(inputString: String): TValid[String, String] = {
-    val parts = inputString.replace("# ", "").split("\n")
-    TValid.fail(parts(0)).trace(unsafeWrapArray(parts(1).split(",")): _*)
+    val parts    = inputString.split("] ")
+    val message  = parts(1)
+    val location = parts(0).replace("# - [", "").split(",").map(_.trim)
+    TValid.fail(message).trace(unsafeWrapArray(location): _*)
   }
 }

--- a/runtime/src/test/scala/tailcall/runtime/internal/GraphQLTestSpec.scala
+++ b/runtime/src/test/scala/tailcall/runtime/internal/GraphQLTestSpec.scala
@@ -22,6 +22,7 @@ trait GraphQLTestSpec {
     } yield contentList.map { case (file, content) =>
       val components = content.split("#>").map(_.trim)
       GraphQLSpec(
+        file.name,
         extractComponent(file, components.toList, "server-sdl"),
         extractComponent(file, components.toList, "client-sdl"),
         extractComponent(file, components.toList, "client-error"),
@@ -30,5 +31,5 @@ trait GraphQLTestSpec {
 }
 
 object GraphQLTestSpec {
-  final case class GraphQLSpec(serverSDL: String, clientSDL: String, clientError: String)
+  final case class GraphQLSpec(name: String, serverSDL: String, clientSDL: String, clientError: String)
 }


### PR DESCRIPTION
Fixes https://github.com/tailcallhq/tailcall/issues/216

@tusharmath - I've added a section for the error message in the graphql spec file. If the error message section is present, then the test checks for error while generating the client SDL. If not, it checks for success against the given client SDL