### PR TITLE
Add dedicated benchmarking infrastructure

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,7 @@ name: benchmark
 
 on:
   pull_request:
-    types: [opened, labeled]
+    types: [opened, edited, labeled]
     branches:
       - main
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
   benchmark:
     name: Rust project
     if: contains(github.event.pull_request.labels.*.name, 'benchmark')
-    runs-on: ubuntu-latest
+    runs-on: benchmarking-runner
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   benchmark:
-    name: Rust project
+    name: Macro Benchmarks
     if: contains(github.event.pull_request.labels.*.name, 'benchmark')
     runs-on: benchmarking-runner
     permissions:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,8 @@ name: benchmark
 on:
   pull_request:
     types: [opened, labeled]
+    branches:
+      - main
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,16 +2,14 @@ name: benchmark
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened, labeled]
-    branches: 
-      - main
-  
+    types: [opened, labeled]
+
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to run benchmark on'
+        description: "Branch to run benchmark on"
         required: true
-        default: 'ci_benchmark'
+        default: "main"
 
 jobs:
   benchmark:
@@ -45,7 +43,7 @@ jobs:
         with:
           command: build
           args: --release
-      
+
       - name: Run tailcall
         run: |
           ./target/release/tailcall start ci-benchmark/benchmark.graphql&
@@ -54,7 +52,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y nginx
-          
+
       - name: Clean Up
         run: |
           sudo rm -rf /etc/nginx/sites-enabled/default
@@ -71,7 +69,7 @@ jobs:
       - name: Start Nginx
         run: |
           sudo systemctl start nginx
-          
+
       - name: Install wrk
         run: |
           sudo apt-get install -y wrk
@@ -85,7 +83,7 @@ jobs:
         working-directory: ci-benchmark
         run: |
           wrk -d 30 -t 1 -c 100 -s wrk.lua http://localhost:8000/graphql > wrk-output.txt
-      
+
       - id: convert_wrk_output_markdown
         name: Convert output to markdown
         working-directory: ci-benchmark
@@ -107,10 +105,9 @@ jobs:
           echo "body<<$delimiter" >> $GITHUB_OUTPUT
           echo "$body" >> $GITHUB_OUTPUT
           echo "$delimiter" >> $GITHUB_OUTPUT
-                    
+
       - name: Create commit comment
         uses: peter-evans/commit-comment@v3
         with:
           sha: ${{github.event.pull_request.head.sha}}
           body: ${{steps.get_comment_body.outputs.body}}
-  

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,7 @@ name: benchmark
 
 on:
   pull_request:
-    types: [opened, edited, labeled]
+    types: [opened, synchronize, labeled]
     branches:
       - main
 


### PR DESCRIPTION
This allows us to run benchmarks on a consistent hosted infrastructure. Before this change, github would run the benchmarks on shared infrastructure, and hence the performance tests would return vastly different results.