### PR TITLE
Remove unnecessary Option wrapping in Config.rs

### DIFF
--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -53,11 +53,11 @@ fn to_schema(config: &Config) -> Valid<SchemaDefinition> {
     .schema
     .query
     .as_ref()
-    .validate_some("Query type is not defined".to_string())?;
+    .ok_or_else(|| ValidationError::new("Query type is not defined".to_string()))?;
 
   Ok(SchemaDefinition {
-    query: query.clone(),
-    mutation: config.graphql.schema.mutation.clone(),
+    query: query.to_owned(),
+    mutation: Some(config.graphql.schema.mutation.clone().unwrap_or_else(|| "".to_string())),
     directives: vec![to_directive(config.server.to_directive("server".to_string()))?],
   })
 }

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -19,7 +19,7 @@ use crate::http::Method;
 use crate::json::JsonSchema;
 use crate::lambda::Lambda;
 use crate::request_template::RequestTemplate;
-use crate::valid::{OptionExtension, Valid as ValidDefault, ValidExtensions, ValidationError, VectorExtension};
+use crate::valid::{Valid as ValidDefault, ValidExtensions, ValidationError, VectorExtension};
 use crate::{blueprint, config};
 
 type Valid<A> = ValidDefault<A, String>;

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -112,10 +112,13 @@ impl Config {
 pub struct Type {
   pub fields: BTreeMap<String, Field>,
   pub doc: Option<String>,
+  #[serde(default)]
   pub interface: Option<bool>,
+  #[serde(default)]
   pub implements: Option<Vec<String>>,
   #[serde(rename = "enum")]
   pub variants: Option<Vec<String>>,
+  #[serde(default)]
   pub scalar: Option<bool>,
 }
 impl Type {
@@ -152,8 +155,11 @@ pub struct RootSchema {
 #[setters(strip_option)]
 pub struct Field {
   pub type_of: String,
+  #[serde(default)]
   pub list: Option<bool>,
+  #[serde(default)]
   pub required: Option<bool>,
+  #[serde(default)]
   pub list_type_required: Option<bool>,
   pub args: Option<BTreeMap<String, Arg>>,
   pub doc: Option<String>,
@@ -190,6 +196,7 @@ pub struct Unsafe {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ModifyField {
   pub name: Option<String>,
+  #[serde(default)]
   pub omit: Option<bool>,
 }
 
@@ -222,6 +229,7 @@ pub struct Http {
   pub input: Option<JsonSchema>,
   pub output: Option<JsonSchema>,
   pub body: Option<String>,
+  #[serde(rename = "enum")]
   pub match_path: Option<Vec<String>>,
   pub match_key: Option<String>,
   #[serde(rename = "baseURL")]


### PR DESCRIPTION
**Summary:**  
The fields in `config.rs` were of type `Option<bool>` and `Option<Vec<_>>`
this PR adds `serde::default` for each field.

The build is pasing.

**Issue Reference(s):**  
Fixes #371

/claim #371
