### PR TITLE
refactor: replace Option wrappers with serde(default) attribute

### DIFF
--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -15,7 +15,6 @@ use crate::blueprint::*;
 use crate::config::{Arg, Config, Field, InlineType};
 use crate::directive::DirectiveCodec;
 use crate::endpoint::Endpoint;
-use crate::http::Method;
 use crate::json::JsonSchema;
 use crate::lambda::Lambda;
 use crate::request_template::RequestTemplate;
@@ -249,7 +248,6 @@ fn update_http(field: &config::Field, b_field: FieldDefinition, config: &Config)
           base_url.pop();
         }
         base_url.push_str(http.path.clone().as_str());
-        let method = http.method.as_ref().unwrap_or(&Method::GET);
         let query = match http.query.as_ref() {
           Some(q) => q.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
           None => Vec::new(),
@@ -265,7 +263,7 @@ fn update_http(field: &config::Field, b_field: FieldDefinition, config: &Config)
         }
         let req_template = RequestTemplate::try_from(
           Endpoint::new(base_url.to_string())
-            .method(method.clone())
+            .method(http.method.clone())
             .query(query)
             .output(output_schema)
             .input(input_schema)

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -74,7 +74,7 @@ fn to_definitions<'a>(
       } else {
         Valid::fail("No variants found for enum".to_string())
       }
-    } else if type_.scalar.is_some() {
+    } else if type_.scalar {
       to_scalar_type_definition(name).trace(name)
     } else if dbl_usage {
       Valid::fail("type is used in input and output".to_string()).trace(name)
@@ -84,7 +84,7 @@ fn to_definitions<'a>(
         Definition::ObjectTypeDefinition(object_type_definition) => {
           if config.input_types().contains(name) {
             to_input_object_type_definition(object_type_definition).trace(name)
-          } else if type_.interface.unwrap_or(false) {
+          } else if type_.interface {
             to_interface_type_definition(object_type_definition).trace(name)
           } else {
             Valid::Ok(definition)
@@ -143,7 +143,7 @@ fn to_object_type_definition(name: &str, type_of: &config::Type, config: &Config
       name: name.to_string(),
       description: type_of.doc.clone(),
       fields,
-      implements: type_of.implements.as_ref().unwrap_or(&Vec::new()).to_vec(),
+      implements: type_of.implements.clone(),
     })
   })
 }
@@ -193,7 +193,7 @@ fn to_field(
     name: name.to_owned(),
     description: field.doc.clone(),
     args,
-    of_type: to_type(field_type, &field.list, &field.required, &field.list_type_required),
+    of_type: to_type(field_type, field.list, field.required, field.list_type_required),
     directives: Vec::new(),
     resolver: None,
   };
@@ -205,11 +205,10 @@ fn to_field(
   Ok(maybe_field_definition)
 }
 
-fn to_type(name: &str, list: &Option<bool>, required: &Option<bool>, list_type_required: &Option<bool>) -> Type {
-  let non_null = required.unwrap_or(false);
-  if list.unwrap_or(false) {
+fn to_type(name: &str, list: bool, non_null: bool, list_type_required: bool) -> Type {
+  if list {
     Type::ListType {
-      of_type: Box::new(Type::NamedType { name: name.to_string(), non_null: list_type_required.unwrap_or(false) }),
+      of_type: Box::new(Type::NamedType { name: name.to_string(), non_null: list_type_required }),
       non_null,
     }
   } else {
@@ -292,16 +291,14 @@ fn update_modify(
 ) -> Valid<Option<FieldDefinition>> {
   match field.modify.as_ref() {
     Some(modify) => {
-      if modify.omit.as_ref().is_some() {
+      if modify.omit {
         Ok(None)
       } else if let Some(new_name) = &modify.name {
-        if let Some(interface_names) = type_.implements.clone() {
-          for name in interface_names {
-            let interface = config.find_type(&name);
-            if let Some(interface) = interface {
-              if interface.fields.iter().any(|(name, _)| name == new_name) {
-                return Valid::fail("Field is already implemented from interface".to_string());
-              }
+        for name in type_.implements.iter() {
+          let interface = config.find_type(name);
+          if let Some(interface) = interface {
+            if interface.fields.iter().any(|(name, _)| name == new_name) {
+              return Valid::fail("Field is already implemented from interface".to_string());
             }
           }
         }
@@ -335,7 +332,7 @@ fn process_path(
   if let Some((field_name, remaining_path)) = path.split_first() {
     if field_name.parse::<usize>().is_ok() {
       let mut modified_field = field.clone();
-      modified_field.list = Some(false);
+      modified_field.list = false;
       return process_path(
         remaining_path,
         &modified_field,
@@ -367,9 +364,9 @@ fn process_path(
 
   Valid::Ok(to_type(
     &field.type_of,
-    &field.list,
-    &Some(is_required),
-    &field.list_type_required,
+    field.list,
+    is_required,
+    field.list_type_required,
   ))
 }
 
@@ -402,7 +399,7 @@ fn process_field_within_type(
       );
     }
 
-    let next_is_required = is_required && next_field.required.unwrap_or(false);
+    let next_is_required = is_required && next_field.required;
     if is_scalar(&next_field.type_of) {
       return process_path(
         remaining_path,
@@ -424,7 +421,7 @@ fn process_field_within_type(
         invalid_path_handler,
       )?;
 
-      return if next_field.list.unwrap_or(false) {
+      return if next_field.list {
         Valid::Ok(ListType { of_type: Box::new(of_type), non_null: is_required })
       } else {
         Ok(of_type)
@@ -481,7 +478,7 @@ fn to_args(field: &config::Field) -> Valid<Vec<InputFieldDefinition>> {
         Valid::Ok(InputFieldDefinition {
           name: name.clone(),
           description: arg.doc.clone(),
-          of_type: to_type(&arg.type_of, &arg.list, &arg.required, &None),
+          of_type: to_type(&arg.type_of, arg.list, arg.required, false),
           default_value: arg.default_value.clone(),
         })
       })
@@ -490,7 +487,7 @@ fn to_args(field: &config::Field) -> Valid<Vec<InputFieldDefinition>> {
   }
 }
 pub fn to_json_schema_for_field(field: &Field, config: &Config) -> JsonSchema {
-  to_json_schema(&field.type_of, &field.required, &field.list, config)
+  to_json_schema(&field.type_of, field.required, field.list, config)
 }
 pub fn to_json_schema_for_args(args: &Option<BTreeMap<String, Arg>>, config: &Config) -> JsonSchema {
   match args {
@@ -499,7 +496,7 @@ pub fn to_json_schema_for_args(args: &Option<BTreeMap<String, Arg>>, config: &Co
       for (name, arg) in args.iter() {
         schema_fields.insert(
           name.clone(),
-          to_json_schema(&arg.type_of, &arg.required, &arg.list, config),
+          to_json_schema(&arg.type_of, arg.required, arg.list, config),
         );
       }
       JsonSchema::Obj(schema_fields)
@@ -507,9 +504,8 @@ pub fn to_json_schema_for_args(args: &Option<BTreeMap<String, Arg>>, config: &Co
     None => JsonSchema::Obj(HashMap::new()),
   }
 }
-pub fn to_json_schema(type_of: &str, required: &Option<bool>, list: &Option<bool>, config: &Config) -> JsonSchema {
+pub fn to_json_schema(type_of: &str, required: bool, list: bool, config: &Config) -> JsonSchema {
   let type_ = config.find_type(type_of);
-  let list = list.unwrap_or(false);
   let schema = match type_ {
     Some(type_) => {
       let mut schema_fields = HashMap::new();
@@ -529,7 +525,7 @@ pub fn to_json_schema(type_of: &str, required: &Option<bool>, list: &Option<bool
     },
   };
 
-  if required.is_none() {
+  if !required {
     if list {
       JsonSchema::Opt(Box::new(JsonSchema::Arr(Box::new(schema))))
     } else {

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -471,38 +471,28 @@ fn update_inline_field(
   Valid::Ok(base_field)
 }
 fn to_args(field: &config::Field) -> Valid<Vec<InputFieldDefinition>> {
-  match field.args.as_ref() {
-    Some(args) => {
-      // TODO! assert type name
-      args.iter().validate_all(|(name, arg)| {
-        Valid::Ok(InputFieldDefinition {
-          name: name.clone(),
-          description: arg.doc.clone(),
-          of_type: to_type(&arg.type_of, arg.list, arg.required, false),
-          default_value: arg.default_value.clone(),
-        })
-      })
-    }
-    None => Valid::Ok(Vec::new()),
-  }
+  // TODO! assert type name
+  field.args.iter().validate_all(|(name, arg)| {
+    Valid::Ok(InputFieldDefinition {
+      name: name.clone(),
+      description: arg.doc.clone(),
+      of_type: to_type(&arg.type_of, arg.list, arg.required, false),
+      default_value: arg.default_value.clone(),
+    })
+  })
 }
 pub fn to_json_schema_for_field(field: &Field, config: &Config) -> JsonSchema {
   to_json_schema(&field.type_of, field.required, field.list, config)
 }
-pub fn to_json_schema_for_args(args: &Option<BTreeMap<String, Arg>>, config: &Config) -> JsonSchema {
-  match args {
-    Some(args) => {
-      let mut schema_fields = HashMap::new();
-      for (name, arg) in args.iter() {
-        schema_fields.insert(
-          name.clone(),
-          to_json_schema(&arg.type_of, arg.required, arg.list, config),
-        );
-      }
-      JsonSchema::Obj(schema_fields)
-    }
-    None => JsonSchema::Obj(HashMap::new()),
+pub fn to_json_schema_for_args(args: &BTreeMap<String, Arg>, config: &Config) -> JsonSchema {
+  let mut schema_fields = HashMap::new();
+  for (name, arg) in args.iter() {
+    schema_fields.insert(
+      name.clone(),
+      to_json_schema(&arg.type_of, arg.required, arg.list, config),
+    );
   }
+  JsonSchema::Obj(schema_fields)
 }
 pub fn to_json_schema(type_of: &str, required: bool, list: bool, config: &Config) -> JsonSchema {
   let type_ = config.find_type(type_of);

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -248,14 +248,11 @@ fn update_http(field: &config::Field, b_field: FieldDefinition, config: &Config)
           base_url.pop();
         }
         base_url.push_str(http.path.clone().as_str());
-        let query = match http.query.as_ref() {
-          Some(q) => q.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-          None => Vec::new(),
-        };
+        let query = http.query.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         let output_schema = to_json_schema_for_field(field, config);
         let input_schema = to_json_schema_for_args(&field.args, config);
         let mut header_map = HeaderMap::new();
-        for (k, v) in http.headers.clone().unwrap_or_default().iter() {
+        for (k, v) in http.headers.iter() {
           header_map.insert(
             HeaderName::from_bytes(k.as_bytes()).map_err(|e| ValidationError::new(e.to_string()))?,
             HeaderValue::from_str(v.as_str()).map_err(|e| ValidationError::new(e.to_string()))?,

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -11,7 +11,7 @@ use crate::batch::Batch;
 use crate::http::Method;
 use crate::json::JsonSchema;
 
-fn skip_if_default<T: Default + Eq>(val: &T) -> bool {
+fn is_default<T: Default + Eq>(val: &T) -> bool {
   *val == T::default()
 }
 
@@ -176,7 +176,7 @@ impl Field {
   }
   pub fn has_batched_resolver(&self) -> bool {
     if let Some(http) = self.http.as_ref() {
-      http.match_key.is_some() || http.match_path.is_some()
+      http.match_key.is_some() || !http.match_path.is_empty()
     } else {
       false
     }
@@ -196,7 +196,7 @@ pub struct Unsafe {
 pub struct ModifyField {
   pub name: Option<String>,
   #[serde(default)]
-  #[serde(skip_serializing_if = "skip_if_default")]
+  #[serde(skip_serializing_if = "is_default")]
   pub omit: bool,
 }
 
@@ -227,17 +227,23 @@ pub struct Union {
 pub struct Http {
   pub path: String,
   #[serde(default)]
-  #[serde(skip_serializing_if = "skip_if_default")]
+  #[serde(skip_serializing_if = "is_default")]
   pub method: Method,
-  pub query: Option<BTreeMap<String, String>>,
+  #[serde(default)]
+  #[serde(skip_serializing_if = "is_default")]
+  pub query: BTreeMap<String, String>,
   pub input: Option<JsonSchema>,
   pub output: Option<JsonSchema>,
   pub body: Option<String>,
-  pub match_path: Option<Vec<String>>,
+  #[serde(default)]
+  #[serde(skip_serializing_if = "is_default")]
+  pub match_path: Vec<String>,
   pub match_key: Option<String>,
   #[serde(rename = "baseURL")]
   pub base_url: Option<String>,
-  pub headers: Option<BTreeMap<String, String>>,
+  #[serde(default)]
+  #[serde(skip_serializing_if = "is_default")]
+  pub headers: BTreeMap<String, String>,
 }
 
 impl Http {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -53,10 +53,8 @@ impl Config {
     for (_, type_of) in self.graphql.types.iter() {
       if !type_of.interface {
         for (_, field) in type_of.fields.iter() {
-          if let Some(ref args) = field.args {
-            for (_, arg) in args.iter() {
-              types.insert(&arg.type_of);
-            }
+          for (_, arg) in field.args.iter() {
+            types.insert(&arg.type_of);
           }
         }
       }
@@ -157,7 +155,8 @@ pub struct Field {
   pub required: bool,
   #[serde(default)]
   pub list_type_required: bool,
-  pub args: Option<BTreeMap<String, Arg>>,
+  #[serde(default)]
+  pub args: BTreeMap<String, Arg>,
   pub doc: Option<String>,
   pub modify: Option<ModifyField>,
   pub inline: Option<InlineType>,

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -11,6 +11,10 @@ use crate::batch::Batch;
 use crate::http::Method;
 use crate::json::JsonSchema;
 
+fn skip_if_default<T: Default + Eq>(val: &T) -> bool {
+  *val == T::default()
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Setters)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
@@ -192,6 +196,7 @@ pub struct Unsafe {
 pub struct ModifyField {
   pub name: Option<String>,
   #[serde(default)]
+  #[serde(skip_serializing_if = "skip_if_default")]
   pub omit: bool,
 }
 
@@ -221,7 +226,9 @@ pub struct Union {
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Http {
   pub path: String,
-  pub method: Option<Method>,
+  #[serde(default)]
+  #[serde(skip_serializing_if = "skip_if_default")]
+  pub method: Method,
   pub query: Option<BTreeMap<String, String>>,
   pub input: Option<JsonSchema>,
   pub output: Option<JsonSchema>,

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -86,10 +86,7 @@ fn to_types(type_definitions: &Vec<&Positioned<TypeDefinition>>) -> BTreeMap<Str
   types
 }
 fn to_scalar_type() -> config::Type {
-  config::Type {
-    scalar: true,
-    ..Default::default()
-  }
+  config::Type { scalar: true, ..Default::default() }
 }
 fn to_union_types(type_definitions: &Vec<&Positioned<TypeDefinition>>) -> BTreeMap<String, Union> {
   let mut unions = BTreeMap::new();
@@ -123,10 +120,7 @@ fn to_enum(enum_type: EnumType) -> config::Type {
     .iter()
     .map(|value| value.node.value.to_string())
     .collect();
-  config::Type {
-    variants: Some(variants),
-    ..Default::default()
-  }
+  config::Type { variants: Some(variants), ..Default::default() }
 }
 fn to_input_object(input_object_type: InputObjectType) -> config::Type {
   let fields = to_input_object_fields(&input_object_type.fields);

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -152,7 +152,7 @@ fn to_field(field_definition: &FieldDefinition) -> config::Field {
     &field_definition.ty.node,
     &field_definition.ty.node.base,
     field_definition.ty.node.nullable,
-    Some(to_args(field_definition)),
+    to_args(field_definition),
     &field_definition.description,
     &field_definition.directives,
   )
@@ -162,7 +162,7 @@ fn to_input_object_field(field_definition: &InputValueDefinition) -> config::Fie
     &field_definition.ty.node,
     &field_definition.ty.node.base,
     field_definition.ty.node.nullable,
-    None,
+    BTreeMap::new(),
     &field_definition.description,
     &field_definition.directives,
   )
@@ -171,7 +171,7 @@ fn to_common_field(
   type_: &Type,
   base: &BaseType,
   nullable: bool,
-  args: Option<BTreeMap<String, config::Arg>>,
+  args: BTreeMap<String, config::Arg>,
   description: &Option<Positioned<String>>,
   directives: &[Positioned<ConstDirective>],
 ) -> config::Field {

--- a/src/config/into_document.rs
+++ b/src/config/into_document.rs
@@ -24,12 +24,10 @@ fn config_document(config: &Config) -> ServiceDocument {
   };
   definitions.push(TypeSystemDefinition::Schema(pos(schema_definition)));
   for (type_name, type_def) in config.graphql.types.iter() {
-    let kind = if type_def.is_interface() {
+    let kind = if type_def.interface {
       TypeKind::Interface(InterfaceType {
         implements: type_def
           .implements
-          .as_ref()
-          .unwrap_or(&Vec::new())
           .iter()
           .map(|name| pos(Name::new(name.clone())))
           .collect(),
@@ -47,9 +45,9 @@ fn config_document(config: &Config) -> ServiceDocument {
               let us_dir = us.to_directive("unsafe".to_string());
               directives.push(pos(us_dir));
             }
-            let base_type = if field.list.unwrap_or(false) {
+            let base_type = if field.list {
               BaseType::List(Box::new(Type {
-                nullable: !field.required.unwrap_or(false),
+                nullable: !field.required,
                 base: BaseType::Named(Name::new(field.type_of.clone())),
               }))
             } else {
@@ -59,7 +57,7 @@ fn config_document(config: &Config) -> ServiceDocument {
               description: field.doc.clone().map(pos),
               name: pos(Name::new(name.clone())),
               arguments: vec![],
-              ty: pos(Type { nullable: !field.required.unwrap_or(false), base: base_type }),
+              ty: pos(Type { nullable: !field.required, base: base_type }),
 
               directives,
             })
@@ -99,9 +97,9 @@ fn config_document(config: &Config) -> ServiceDocument {
               let modify_dir = modify.to_directive("modify".to_string());
               directives.push(pos(modify_dir));
             }
-            let base_type = if field.list.unwrap_or(false) {
+            let base_type = if field.list {
               async_graphql::parser::types::BaseType::List(Box::new(Type {
-                nullable: !field.required.unwrap_or(false),
+                nullable: !field.required,
                 base: async_graphql::parser::types::BaseType::Named(Name::new(field.type_of.clone())),
               }))
             } else {
@@ -111,7 +109,7 @@ fn config_document(config: &Config) -> ServiceDocument {
             pos(async_graphql::parser::types::InputValueDefinition {
               description: field.doc.clone().map(pos),
               name: pos(Name::new(name.clone())),
-              ty: pos(Type { nullable: !field.required.unwrap_or(false), base: base_type }),
+              ty: pos(Type { nullable: !field.required, base: base_type }),
 
               default_value: None,
               directives,
@@ -125,8 +123,6 @@ fn config_document(config: &Config) -> ServiceDocument {
       TypeKind::Object(ObjectType {
         implements: type_def
           .implements
-          .as_ref()
-          .unwrap_or(&Vec::new())
           .iter()
           .map(|name| pos(Name::new(name.clone())))
           .collect(),
@@ -152,9 +148,9 @@ fn config_document(config: &Config) -> ServiceDocument {
               let modify_dir = modify.to_directive("modify".to_string());
               directives.push(pos(modify_dir));
             }
-            let base_type = if field.list.unwrap_or(false) {
+            let base_type = if field.list {
               async_graphql::parser::types::BaseType::List(Box::new(Type {
-                nullable: !field.required.unwrap_or(false),
+                nullable: !field.required,
                 base: async_graphql::parser::types::BaseType::Named(Name::new(field.type_of.clone())),
               }))
             } else {
@@ -165,9 +161,9 @@ fn config_document(config: &Config) -> ServiceDocument {
             let args = args_map
               .iter()
               .map(|(name, arg)| {
-                let base_type = if arg.list.unwrap_or(false) {
+                let base_type = if arg.list {
                   async_graphql::parser::types::BaseType::List(Box::new(Type {
-                    nullable: !arg.required.unwrap_or(false),
+                    nullable: !arg.required,
                     base: async_graphql::parser::types::BaseType::Named(Name::new(arg.type_of.clone())),
                   }))
                 } else {
@@ -176,7 +172,7 @@ fn config_document(config: &Config) -> ServiceDocument {
                 pos(async_graphql::parser::types::InputValueDefinition {
                   description: arg.doc.clone().map(pos),
                   name: pos(Name::new(name.clone())),
-                  ty: pos(Type { nullable: !arg.required.unwrap_or(false), base: base_type }),
+                  ty: pos(Type { nullable: !arg.required, base: base_type }),
 
                   default_value: arg
                     .default_value
@@ -191,7 +187,7 @@ fn config_document(config: &Config) -> ServiceDocument {
               description: field.doc.clone().map(pos),
               name: pos(Name::new(name.clone())),
               arguments: args,
-              ty: pos(Type { nullable: !field.required.unwrap_or(false), base: base_type }),
+              ty: pos(Type { nullable: !field.required, base: base_type }),
 
               directives,
             })

--- a/src/config/into_document.rs
+++ b/src/config/into_document.rs
@@ -157,7 +157,7 @@ fn config_document(config: &Config) -> ServiceDocument {
               async_graphql::parser::types::BaseType::Named(Name::new(field.type_of.clone()))
             };
 
-            let args_map = field.args.clone().unwrap_or_default();
+            let args_map = field.args.clone();
             let args = args_map
               .iter()
               .map(|(name, arg)| {

--- a/src/config/n_plus_one.rs
+++ b/src/config/n_plus_one.rs
@@ -20,7 +20,7 @@ pub fn n_plus_one(config: &Config) -> Vec<Vec<(String, String)>> {
           } else if field.has_resolver() && !field.has_batched_resolver() && is_list {
             vec![new_path]
           } else {
-            find_fan_out(config, &field.type_of, new_path, field.list.unwrap_or(false) || is_list)
+            find_fan_out(config, &field.type_of, new_path, field.list || is_list)
           }
         })
         .collect(),
@@ -294,10 +294,7 @@ mod tests {
 
   #[test]
   fn test_nplusone_nested_non_list() {
-    let mut f_field = Field::default().type_of("F".to_string()).http(Http::default());
-
-    // imitate Option::Some for list but with false value underneath
-    f_field.list = Some(false);
+    let f_field = Field::default().type_of("F".to_string()).http(Http::default());
 
     let config = Config::default().query("Query").types(vec![
       ("Query", Type::default().fields(vec![("f", f_field)])),

--- a/tests/graphql/test-modify.graphql
+++ b/tests/graphql/test-modify.graphql
@@ -8,7 +8,7 @@ input Foo {
 }
 
 type Query {
-  foo(input: Foo): String @modify(name: "data", omit: false)
+  foo(input: Foo): String @modify(name: "data")
 }
 
 #> client-sdl

--- a/tests/graphql/test-modify.graphql
+++ b/tests/graphql/test-modify.graphql
@@ -8,7 +8,7 @@ input Foo {
 }
 
 type Query {
-  foo(input: Foo): String @modify(name: "data")
+  foo(input: Foo): String @modify(name: "data", omit: false)
 }
 
 #> client-sdl


### PR DESCRIPTION
**Summary:**  

Instead of `Option<bool>` etc use `#[serde(default)]` to mark fields as optional with some default value.

These changes simplifies the code and prevents possible bugs when utilizing Option

**Issue Reference(s):**  
Fixes #371

/claim #371

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
