### PR TITLE
feat: add const directive

### DIFF
--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use async_graphql::parser::types::ConstDirective;
 #[allow(unused_imports)]
 use async_graphql::InputType;
+use async_graphql_value::ConstValue;
 use hyper::header::{HeaderName, HeaderValue};
 use hyper::HeaderMap;
 use regex::Regex;
@@ -16,6 +17,7 @@ use crate::config::{Arg, Config, Field, InlineType};
 use crate::directive::DirectiveCodec;
 use crate::endpoint::Endpoint;
 use crate::json::JsonSchema;
+use crate::lambda::Expression::Literal;
 use crate::lambda::Lambda;
 use crate::request_template::RequestTemplate;
 use crate::valid::{OptionExtension, Valid as ValidDefault, ValidExtensions, ValidationError, VectorExtension};
@@ -187,6 +189,11 @@ fn to_field(
   name: &str,
   field: &Field,
 ) -> Valid<Option<blueprint::FieldDefinition>> {
+  let directives = field.resolvable_directives();
+  if directives.len() > 1 {
+    return Valid::fail(format!("Multiple resolvers detected [{}]", directives.join(", ")));
+  }
+
   let field_type = &field.type_of;
   let args = to_args(field)?;
 
@@ -201,6 +208,7 @@ fn to_field(
 
   let field_definition = update_http(field, field_definition, config).trace("@http")?;
   let field_definition = update_unsafe(field.clone(), field_definition);
+  let field_definition = update_const_field(field, field_definition, config).trace("@const")?;
   let field_definition = update_inline_field(type_of, field, field_definition, config).trace("@inline")?;
   let maybe_field_definition = update_modify(field, field_definition, type_of, config).trace("@modify")?;
   Ok(maybe_field_definition)
@@ -283,8 +291,7 @@ fn update_unsafe(field: config::Field, mut b_field: FieldDefinition) -> FieldDef
   b_field
 }
 
-fn update_http(field: &config::Field, b_field: FieldDefinition, config: &Config) -> Valid<FieldDefinition> {
-  let mut b_field = b_field;
+fn update_http(field: &config::Field, mut b_field: FieldDefinition, config: &Config) -> Valid<FieldDefinition> {
   match field.http.as_ref() {
     Some(http) => match http
       .base_url
@@ -358,8 +365,23 @@ fn update_modify(
     None => Valid::Ok(Some(b_field)),
   }
 }
-fn needs_resolving(field: &config::Field) -> bool {
-  field.unsafe_operation.is_some() || field.http.is_some()
+fn update_const_field(field: &config::Field, mut b_field: FieldDefinition, config: &Config) -> Valid<FieldDefinition> {
+  match field.const_field.as_ref() {
+    Some(const_field) => {
+      let data = const_field.data.to_owned();
+      match ConstValue::from_json(data.to_owned()) {
+        Ok(gql_value) => match to_json_schema_for_field(field, config).validate(&gql_value) {
+          Ok(_) => {
+            b_field.resolver = Some(Literal(data));
+            Valid::Ok(b_field)
+          }
+          Err(err) => err.into(),
+        },
+        Err(e) => Valid::fail(format!("invalid JSON: {}", e)),
+      }
+    }
+    None => Valid::Ok(b_field),
+  }
 }
 fn is_scalar(type_name: &str) -> bool {
   ["String", "Int", "Float", "Boolean", "ID", "JSON"].contains(&type_name)
@@ -424,11 +446,15 @@ fn process_field_within_type(
   invalid_path_handler: &dyn Fn(&str, &[String]) -> Valid<Type>,
 ) -> Valid<Type> {
   if let Some(next_field) = type_info.fields.get(field_name) {
-    if needs_resolving(next_field) {
+    if next_field.has_resolver() {
       return Valid::<Type>::validate_or(
         Valid::fail(format!(
           "Inline can't be done because of {} resolver at [{}.{}]",
-          next_field.http.as_ref().map(|_| "http").unwrap_or_else(|| "unsafe"),
+          {
+            let next_dir_http = next_field.http.as_ref().map(|_| "http");
+            let next_dir_const = next_field.const_field.as_ref().map(|_| "const");
+            next_dir_http.or(next_dir_const).unwrap_or("unsafe")
+          },
           field.type_of,
           field_name
         )),

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -169,11 +169,25 @@ pub struct Field {
   #[serde(rename = "unsafe")]
   pub unsafe_operation: Option<Unsafe>,
   pub batch: Option<Batch>,
+  pub const_field: Option<ConstField>,
 }
 
 impl Field {
   pub fn has_resolver(&self) -> bool {
-    self.http.is_some() || self.unsafe_operation.is_some()
+    self.http.is_some() || self.unsafe_operation.is_some() || self.const_field.is_some()
+  }
+  pub fn resolvable_directives(&self) -> Vec<&str> {
+    let mut directives = Vec::with_capacity(3);
+    if self.http.is_some() {
+      directives.push("@http")
+    }
+    if self.unsafe_operation.is_some() {
+      directives.push("@unsafe")
+    }
+    if self.const_field.is_some() {
+      directives.push("@const")
+    }
+    directives
   }
   pub fn has_batched_resolver(&self) -> bool {
     if let Some(http) = self.http.as_ref() {
@@ -252,6 +266,11 @@ impl Http {
     self.match_key = Some(key.to_string());
     self
   }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ConstField {
+  pub data: Value,
 }
 
 impl Config {

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -196,6 +196,7 @@ fn to_common_field(
   let http = to_http(directives);
   let unsafe_operation = to_unsafe_operation(directives);
   let batch = to_batch(directives);
+  let const_field = to_const_field(directives);
   config::Field {
     type_of,
     list,
@@ -208,6 +209,7 @@ fn to_common_field(
     http,
     unsafe_operation,
     batch,
+    const_field,
   }
 }
 fn to_unsafe_operation(directives: &[Positioned<ConstDirective>]) -> Option<config::Unsafe> {
@@ -292,6 +294,15 @@ fn to_batch(directives: &[Positioned<ConstDirective>]) -> Option<Batch> {
   directives.iter().find_map(|directive| {
     if directive.node.name.node == "batch" {
       Batch::from_directive(&directive.node).ok()
+    } else {
+      None
+    }
+  })
+}
+fn to_const_field(directives: &[Positioned<ConstDirective>]) -> Option<config::ConstField> {
+  directives.iter().find_map(|directive| {
+    if directive.node.name.node == "const" {
+      config::ConstField::from_directive(&directive.node).ok()
     } else {
       None
     }

--- a/src/valid/cause.rs
+++ b/src/valid/cause.rs
@@ -35,6 +35,16 @@ impl<E> Cause<E> {
   }
 }
 
+impl Cause<&str> {
+  pub fn to_owned(&self) -> Cause<String> {
+    Cause {
+      message: self.message.to_owned(),
+      description: self.description.map(|d| d.to_owned()),
+      trace: self.trace.iter().map(|t| t.to_owned()).collect(),
+    }
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use std::collections::VecDeque;

--- a/src/valid/valid.rs
+++ b/src/valid/valid.rs
@@ -104,6 +104,13 @@ impl<A> OptionExtension<A> for Option<A> {
   }
 }
 
+impl<A> From<ValidationError<&str>> for Valid<A, String> {
+  fn from(value: ValidationError<&str>) -> Self {
+    let message = value.as_vec().iter().map(|c| c.to_owned()).collect();
+    Valid::fail_cause(message)
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use crate::valid::{

--- a/tests/graphql/errors/test-const-with-inline.graphql
+++ b/tests/graphql/errors/test-const-with-inline.graphql
@@ -1,0 +1,25 @@
+#> server-sdl
+schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  post: Post @http(path: "/posts/1") @inline(path: ["user", "name"])
+}
+
+type Post {
+  id: Int
+  title: String
+  body: String
+  userId: Int
+  user: User @const(data: {id: 1, name: "user1"})
+}
+
+type User {
+  id: Int
+  name: String
+}
+
+#> client-sdl
+type Failure
+@error(message: "Inline can't be done because of const resolver at [Post.user]", trace: ["Query", "post", "@inline"])

--- a/tests/graphql/errors/test-const.graphql
+++ b/tests/graphql/errors/test-const.graphql
@@ -1,0 +1,17 @@
+#> server-sdl
+schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type User {
+  name: String
+  age: Int!
+}
+
+type Query {
+  user: User @const(data: {name: "John"})
+}
+
+#> client-sdl
+type Failure
+@error(message: "expected field to be non-nullable", trace: ["Query", "user", "@const"])

--- a/tests/graphql/errors/test-multiple-resolvable-directives-on-field.graphql
+++ b/tests/graphql/errors/test-multiple-resolvable-directives-on-field.graphql
@@ -1,0 +1,21 @@
+#> server-sdl
+schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type User {
+  name: String
+  id: Int
+}
+
+type Query {
+  user1: User @const(data: {name: "John"}) @http(path: "/users/1")
+  user2: User @const(data: {name: "John"}) @unsafe(script: "return {id: 1, name: 'foo'}")
+  user3: User @http(path: "/users/1") @unsafe(script: "return {id: 1, name: 'foo'}")
+}
+
+#> client-sdl
+type Failure
+@error(message: "Multiple resolvers detected [@http, @const]", trace: ["Query", "user1"])
+@error(message: "Multiple resolvers detected [@unsafe, @const]", trace: ["Query", "user2"])
+@error(message: "Multiple resolvers detected [@http, @unsafe]", trace: ["Query", "user3"])

--- a/tests/graphql/passed/test-const-nullable.graphql
+++ b/tests/graphql/passed/test-const-nullable.graphql
@@ -1,0 +1,21 @@
+#> server-sdl
+schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type User {
+  name: String
+  age: Int
+}
+
+type Query {
+  user: User @const(data: {name: "John"})
+}
+
+#> client-query
+query @expect(json: {data:{user:{name: "John", age: null}}}) {
+  user {
+    age
+    name
+  }
+}

--- a/tests/graphql/passed/test-const-with-inline-with-modify-field.graphql
+++ b/tests/graphql/passed/test-const-with-inline-with-modify-field.graphql
@@ -1,0 +1,37 @@
+#> server-sdl
+schema {
+  query: Query
+}
+
+type User {
+  name: String
+}
+type Query {
+  person1: User
+    @const(data: {name: "person1"})
+    @modify(name: "user1")
+    @inline(path:["name"])
+  person2: User
+    @modify(name: "user2")
+    @inline(path:["name"])
+    @const(data: {name: "person2"})
+  person3: User
+    @inline(path:["name"])
+    @const(data: {name: "person3"})
+    @modify(name: "user3")
+}
+
+#> client-query
+query @expect(json: {data:{user1:"person1"}}) {
+  user1
+}
+
+#> client-query
+query @expect(json: {data:{user2:"person2"}}) {
+  user2
+}
+
+#> client-query
+query @expect(json: {data:{user3:"person3"}}) {
+  user3
+}

--- a/tests/graphql/passed/test-const.graphql
+++ b/tests/graphql/passed/test-const.graphql
@@ -1,0 +1,21 @@
+#> server-sdl
+schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type User {
+  name: String
+  age: Int
+}
+
+type Query {
+  user: User @const(data: {name: "John", age: 12})
+}
+
+#> client-query
+query @expect(json: {data:{user:{name: "John", age: 12}}}) {
+  user {
+    age
+    name
+  }
+}


### PR DESCRIPTION
**Summary:**  
It adds `@const` directive to set const value for test and other purposes. `const` also makes sure that provided `data` conforms with the type `T`.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.

/claim #373