### PR TITLE
fix: cargo test fail in Sonoma or later of macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ dependencies = [
  "clap",
  "colored",
  "criterion",
+ "curl-sys",
  "derive_setters",
  "env_logger",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ nom = "7.1.3"
 exitcode = "1.1.2"
 log = "0.4.20"
 env_logger = "0.10.0"
-curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -57,6 +56,7 @@ httpmock = "0.6"
 mockito = "1.2.0"
 pretty_assertions = "1.4.0"
 stripmargin = "0.1.1"
+curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ nom = "7.1.3"
 exitcode = "1.1.2"
 log = "0.4.20"
 env_logger = "0.10.0"
+curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
 
 [dev-dependencies]
 criterion = "0.5.1"


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._
potential reason:
https://github.com/alexcrichton/curl-rust/issues/524#issuecomment-1702156654

I followed this sulution.
https://github.com/alexcrichton/curl-rust/issues/524#issuecomment-1703325064

ref:
https://github.com/curl/curl/commit/6ab7e19
https://github.com/rust-lang/cargo/issues/12670
https://github.com/alexcrichton/curl-rust/issues/524

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
