### PR TITLE
CI: ignore build when no changes for executable

### DIFF
--- a/.github/scripts/check_if_build.sh
+++ b/.github/scripts/check_if_build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# fetch main branch for comparison
+git fetch origin main:main
+
+cat <(git log -n 5)
+
+base_commit=$(git rev-parse HEAD^)
+
+echo "Current branch: $(git branch --show-current)"
+echo "Current commit: $(git rev-parse HEAD)"
+echo "Base commit: $base_commit"
+echo "----------------------------------------"
+# Compare the changes from the common ancestor to the current commit
+changed_files=$(git diff --name-only $base_commit HEAD)
+echo -e "Changed files: \n $changed_files"
+echo "----------------------------------------"
+check_files=("Cargo.toml" "Cargo.lock" "fly.toml" "Dockerfile")
+
+for file in "${check_files[@]}"; do
+    if [[ $changed_files == *"$file"* ]]; then
+        echo "Set check_if_build=true >> \$GITHUB_OUTPUT"
+        echo "check_if_build=true" >>$GITHUB_OUTPUT
+        exit 0
+    fi
+done
+
+if [[ $changed_files == *"src/"* ]]; then
+    echo "Set check_if_build=true >> \$GITHUB_OUTPUT"
+    echo "check_if_build=true" >>$GITHUB_OUTPUT
+else
+    echo "Set check_if_build=false >> \$GITHUB_OUTPUT"
+    echo "check_if_build=false" >>$GITHUB_OUTPUT
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     types: [opened, reopened, synchronize]
 jobs:
   check_if_build:
+    name: Check if Build
     runs-on: ubuntu-latest
 
     steps:
@@ -212,7 +213,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          # use-cross: ${{ matrix.cross }} // invalid action input
           override: true
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,20 @@ on:
     branches: [main]
     types: [opened, reopened, synchronize]
 jobs:
+  check_if_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1000
+      - id: check
+        run: |
+          chmod +x .github/scripts/check_if_build.sh
+          .github/scripts/check_if_build.sh
+    outputs:
+      check_if_build: ${{ steps.check.outputs.check_if_build }}
+
   test:
     name: Run Tests
     if: (github.event_name == 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
@@ -30,6 +44,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run Cargo Test
         uses: actions-rs/cargo@v1
@@ -85,8 +100,8 @@ jobs:
   deploy:
     name: Deploy App
     runs-on: ubuntu-latest
-    needs: [test, format]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test, format, check_if_build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.check_if_build.outputs.check_if_build == 'true')
     concurrency:
       group: deploy-job
       cancel-in-progress: true
@@ -118,16 +133,16 @@ jobs:
       - name: Set Output for Later Jobs
         id: set_output
         run: |
-          echo "::set-output name=create_release_name::${{ steps.create_release.outputs.name }}"
-          echo "::set-output name=create_release_id::${{ steps.create_release.outputs.id }}"
+          echo "create_release_name=${{ steps.create_release.outputs.name }}" >> $GITHUB_OUTPUT
+          echo "create_release_id=${{ steps.create_release.outputs.id }}" >> $GITHUB_OUTPUT
     outputs:
       create_release_name: ${{ steps.set_output.outputs.create_release_name }}
       create_release_id: ${{ steps.set_output.outputs.create_release_id }}
 
   release:
     name: Release
-    needs: [test, format, draft_release]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test, format, draft_release, check_if_build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.check_if_build.outputs.check_if_build == 'true')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -197,7 +212,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          use-cross: ${{ matrix.cross }}
+          # use-cross: ${{ matrix.cross }} // invalid action input
           override: true
 
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
+version = "0.4.67+curl-8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
+checksum = "3cc35d066510b197a0f72de863736641539957628c8a42e70e27c66849e77c34"
 dependencies = [
  "cc",
  "libc",
@@ -2919,7 +2919,6 @@ dependencies = [
  "clap",
  "colored",
  "criterion",
- "curl-sys",
  "derive_setters",
  "env_logger",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ criterion = "0.5.1"
 httpmock = "0.6"
 mockito = "1.2.0"
 pretty_assertions = "1.4.0"
-curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
+stripmargin = "0.1.1"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._
1. add script file to check if the changes in ./src and "cargo.toml" "cargo.lock" "fly.toml" "DockerFile". So if changes are in tests(.rs. i.e. integration test), the build workflow can still run for the test.
2. using job condition `if` to skip `deploy` and `release` jobs.
3. add restore-keys so that even if there is a tiny change in the cache, the cache can still be used for that non-change pkg.
4. replace ::set-output name with echo "name=value" >> $GITHUB_OUTPUT. 
ref: [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
5. update the revision of sys-curl for Sonoma or later version of macos.
ref: https://github.com/tailcallhq/tailcall/pull/453


**Issue Reference(s):**  
Fixes #443 . 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
