### PR TITLE
Implement Apollo federation subgraph spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = { version = "0.10", features = ["std"] }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11", features = ["json","rustls-tls"], default-features = false }
 hyper = { version = "0.14", features = ["full"], default-features = false }
-async-graphql = { version = "6.0", features = [
+async-graphql = { version = "6.0.5", features = [
    "dynamic-schema",
    "dataloader",
    "apollo_tracing"

--- a/examples/federation/posts.graphql
+++ b/examples/federation/posts.graphql
@@ -16,6 +16,14 @@ type Query {
 
 type Post @entityResolver(path: "/posts/{{value.id}}") {
   id: Int! @key
-  title: String!
+  title: String! @shareable
+  body: String!
+}
+
+type Comment {
+  postId: Int! @key
+  id: Int!
+  name: String!
+  email: String!
   body: String!
 }

--- a/examples/federation/posts.graphql
+++ b/examples/federation/posts.graphql
@@ -1,0 +1,22 @@
+schema
+  @server(
+    port: 8001
+    baseURL: "http://jsonplaceholder.typicode.com"
+    enableHttpCache: true
+    enableGraphiql: "/graphiql"
+    enableQueryValidation: false
+  ) {
+  query: Query
+}
+
+type Query {
+  posts: [Post] @http(path: "/posts")
+  # TODO! use object directive for entityResolver 
+  post(id: Int): Post @http(path: "/posts/{{args.id}}", entityResolver: true, entityType: "Post")
+}
+
+type Post {
+  id: Int! @key
+  title: String!
+  body: String!
+}

--- a/examples/federation/posts.graphql
+++ b/examples/federation/posts.graphql
@@ -11,11 +11,10 @@ schema
 
 type Query {
   posts: [Post] @http(path: "/posts")
-  # TODO! use object directive for entityResolver 
-  post(id: Int): Post @http(path: "/posts/{{args.id}}", entityResolver: true, entityType: "Post")
+  post(id: Int): Post @http(path: "/posts/{{args.id}}")
 }
 
-type Post {
+type Post @entityResolver(path: "/posts/{{value.id}}") {
   id: Int! @key
   title: String!
   body: String!

--- a/examples/federation/user.graphql
+++ b/examples/federation/user.graphql
@@ -20,7 +20,7 @@ type User {
   email: String!
   phone: String
   website: String
-	posts: [Post] @http(path: "/users/{{value.id}}/posts")
+  posts: [Post] @http(path: "/users/{{value.id}}/posts")
 }
 
 type Post @entityResolver(path: "/posts/{{value.id}}") {

--- a/examples/federation/user.graphql
+++ b/examples/federation/user.graphql
@@ -1,0 +1,31 @@
+schema
+  @server(
+    port: 8002
+    baseURL: "http://jsonplaceholder.typicode.com"
+    enableHttpCache: true
+    enableGraphiql: "/graphiql"
+    enableQueryValidation: false
+  ) {
+  query: Query
+}
+
+type Query {
+  # TODO! use object directive for entityResolver 
+  post2(id: Int): Post @http(path: "/posts/{{value.id}}", entityResolver: true, entityType: "Post")
+}
+
+type User {
+  id: Int! @key
+  name: String!
+  username: String!
+  email: String!
+  phone: String
+  website: String
+	posts: [Post] @http(path: "/users/{{value.id}}/posts")
+}
+
+type Post {
+  id: Int! @key
+  userId: Int!
+  user: User @http(path: "/users/{{value.userId}}")
+}

--- a/examples/federation/user.graphql
+++ b/examples/federation/user.graphql
@@ -10,8 +10,7 @@ schema
 }
 
 type Query {
-  # TODO! use object directive for entityResolver 
-  post2(id: Int): Post @http(path: "/posts/{{value.id}}", entityResolver: true, entityType: "Post")
+  post2(id: Int): Post @http(path: "/posts/{{value.id}}")
 }
 
 type User {
@@ -24,7 +23,7 @@ type User {
 	posts: [Post] @http(path: "/users/{{value.id}}/posts")
 }
 
-type Post {
+type Post @entityResolver(path: "/posts/{{value.id}}") {
   id: Int! @key
   userId: Int!
   user: User @http(path: "/users/{{value.userId}}")

--- a/examples/federation/user.graphql
+++ b/examples/federation/user.graphql
@@ -25,6 +25,7 @@ type User {
 
 type Post @entityResolver(path: "/posts/{{value.id}}") {
   id: Int! @key
+  title: String! @shareable
   userId: Int!
   user: User @http(path: "/users/{{value.userId}}")
 }

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -72,6 +72,7 @@ pub struct ObjectTypeDefinition {
   pub fields: Vec<FieldDefinition>,
   pub description: Option<String>,
   pub implements: Vec<String>,
+  pub key: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -120,6 +121,9 @@ pub struct FieldDefinition {
   pub directives: Vec<Directive>,
   pub description: Option<String>,
   pub entity_resolver: Option<bool>,
+  pub entity_type: Option<String>,
+  pub entity_key: Option<String>,
+  pub is_federation_key: bool,
 }
 
 impl FieldDefinition {

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -124,10 +124,10 @@ pub struct FieldDefinition {
   pub resolver: Option<Expression>,
   pub directives: Vec<Directive>,
   pub description: Option<String>,
-  // pub entity_resolver: Option<bool>,
-  // pub entity_type: Option<String>,
-  // pub entity_key: Option<String>,
   pub is_federation_key: bool,
+  pub shareable: bool,
+  pub external: bool,
+  pub requires: Option<String>,
 }
 
 impl FieldDefinition {

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::collections::{BTreeMap, HashMap};
 
 use async_graphql::dynamic::{Schema, SchemaBuilder};
@@ -19,6 +21,7 @@ pub struct Blueprint {
   pub definitions: Vec<Definition>,
   pub schema: SchemaDefinition,
   pub entity_resolvers: BTreeMap<String, Option<Expression>>,
+  pub entity_key_map: BTreeMap<String, (String, String)>,
 }
 
 #[derive(Clone, Debug)]
@@ -72,6 +75,7 @@ pub struct ObjectTypeDefinition {
   pub description: Option<String>,
   pub implements: Vec<String>,
   pub key: Option<String>,
+  pub key_type: Option<String>,
   pub entity_resolver: Option<Expression>,
 }
 
@@ -120,9 +124,9 @@ pub struct FieldDefinition {
   pub resolver: Option<Expression>,
   pub directives: Vec<Directive>,
   pub description: Option<String>,
-  pub entity_resolver: Option<bool>,
-  pub entity_type: Option<String>,
-  pub entity_key: Option<String>,
+  // pub entity_resolver: Option<bool>,
+  // pub entity_type: Option<String>,
+  // pub entity_key: Option<String>,
   pub is_federation_key: bool,
 }
 
@@ -170,8 +174,9 @@ impl Blueprint {
     schema: SchemaDefinition,
     definitions: Vec<Definition>,
     entity_resolvers: BTreeMap<String, Option<Expression>>,
+    entity_key_map: BTreeMap<String, (String, String)>,
   ) -> Self {
-    Self { schema, definitions, entity_resolvers }
+    Self { schema, definitions, entity_resolvers, entity_key_map }
   }
 
   pub fn query(&self) -> String {

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use super::GlobalTimeout;
 use crate::config;
 use crate::lambda::{Expression, Lambda};
+use std::collections::BTreeMap;
 
 /// Blueprint is an intermediary representation that allows us to generate graphQL APIs.
 /// It can only be generated from a valid Config.
@@ -18,6 +19,7 @@ use crate::lambda::{Expression, Lambda};
 pub struct Blueprint {
   pub definitions: Vec<Definition>,
   pub schema: SchemaDefinition,
+  pub entity_resolvers: BTreeMap<String, Option<Expression>>,
 }
 
 #[derive(Clone, Debug)]
@@ -117,6 +119,7 @@ pub struct FieldDefinition {
   pub resolver: Option<Expression>,
   pub directives: Vec<Directive>,
   pub description: Option<String>,
+  pub entity_resolver: Option<bool>,
 }
 
 impl FieldDefinition {
@@ -159,8 +162,8 @@ pub struct UnionTypeDefinition {
   pub types: Vec<String>,
 }
 impl Blueprint {
-  pub fn new(schema: SchemaDefinition, definitions: Vec<Definition>) -> Self {
-    Self { schema, definitions }
+  pub fn new(schema: SchemaDefinition, definitions: Vec<Definition>, entity_resolvers: BTreeMap<String, Option<Expression>>) -> Self {
+    Self { schema, definitions, entity_resolvers }
   }
 
   pub fn query(&self) -> String {

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -166,7 +166,11 @@ pub struct UnionTypeDefinition {
   pub types: Vec<String>,
 }
 impl Blueprint {
-  pub fn new(schema: SchemaDefinition, definitions: Vec<Definition>, entity_resolvers: BTreeMap<String, Option<Expression>>) -> Self {
+  pub fn new(
+    schema: SchemaDefinition,
+    definitions: Vec<Definition>,
+    entity_resolvers: BTreeMap<String, Option<Expression>>,
+  ) -> Self {
     Self { schema, definitions, entity_resolvers }
   }
 

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -73,6 +73,7 @@ pub struct ObjectTypeDefinition {
   pub description: Option<String>,
   pub implements: Vec<String>,
   pub key: Option<String>,
+  pub entity_resolver: Option<Expression>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use async_graphql::dynamic::{Schema, SchemaBuilder};
 use async_graphql::extensions::ApolloTracing;
@@ -9,7 +9,6 @@ use serde_json::Value;
 use super::GlobalTimeout;
 use crate::config;
 use crate::lambda::{Expression, Lambda};
-use std::collections::BTreeMap;
 
 /// Blueprint is an intermediary representation that allows us to generate graphQL APIs.
 /// It can only be generated from a valid Config.

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -189,7 +189,7 @@ fn to_object_type_definition(name: &str, type_of: &config::Type, config: &Config
   let fields = to_fields(type_of, config)?;
   let key_field = fields.iter().find(|field| field.is_federation_key);
   let key = key_field.map(|field| field.name.clone());
-  let key_type = key_field.map(|field| field.of_type.name().clone().to_string());
+  let key_type = key_field.map(|field| field.of_type.name().to_string());
   let object_definition = ObjectTypeDefinition {
     name: name.to_string(),
     description: type_of.doc.clone(),

--- a/src/blueprint/into_schema.rs
+++ b/src/blueprint/into_schema.rs
@@ -162,8 +162,9 @@ fn create(blueprint: &Blueprint) -> SchemaBuilder {
 
           for item in representations.iter() {
             let item = item.object()?;
+            // TODO use key name and value instead of hardcoding id
             let id = item.try_get("id")?.u64()?;
-            let mut value_map = IndexMap::new();
+            let mut value_map = IndexMap::new();   
             value_map.insert(Name::new("id"), Value::from(id));
             let val = Value::Object(value_map);
             let entity_resolver_context = EntityResolverContext { entity_resolver_value: Some(&val)};
@@ -179,7 +180,6 @@ fn create(blueprint: &Blueprint) -> SchemaBuilder {
               Some(Some(expr)) => {
                 let ctx = EvaluationContext::new(req_ctx, &entity_resolver_context);
                 let const_value = expr.eval(&ctx).await?;
-                // println!("{:?}", const_value);
                 values.push(FieldValue::from(const_value).with_type(typename_clone));
               }
             }

--- a/src/blueprint/into_schema.rs
+++ b/src/blueprint/into_schema.rs
@@ -8,12 +8,9 @@ use async_graphql::{Name, Value};
 use async_graphql_value::ConstValue;
 use indexmap::IndexMap;
 
+use crate::blueprint::{Blueprint, Definition, Type};
 use crate::http::RequestContext;
-use crate::lambda::EvaluationContext;
-use crate::{
-  blueprint::{Blueprint, Definition, Type},
-  lambda::ResolverContextLike,
-};
+use crate::lambda::{EvaluationContext, ResolverContextLike};
 
 struct EntityResolverContext<'a> {
   pub entity_resolver_value: Option<&'a Value>,

--- a/src/blueprint/into_schema.rs
+++ b/src/blueprint/into_schema.rs
@@ -83,6 +83,15 @@ fn to_type(def: &Definition) -> dynamic::Type {
           dyn_schema_field =
             dyn_schema_field.argument(dynamic::InputValue::new(arg.name.clone(), to_type_ref(&arg.of_type)));
         }
+        if field.shareable {
+          dyn_schema_field = dyn_schema_field.shareable();
+        }
+        if field.external {
+          dyn_schema_field = dyn_schema_field.external();
+        }
+        if field.requires.is_some() {
+          dyn_schema_field = dyn_schema_field.requires(field.requires.unwrap());
+        }
         object = object.field(dyn_schema_field);
       }
       for interface in def.implements.iter() {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -112,6 +112,7 @@ pub struct Type {
   pub interface: bool,
   #[serde(default)]
   pub implements: Vec<String>,
+  pub entity_resolver: Option<EntityResolver>,
   #[serde(rename = "enum", default)]
   pub variants: Option<Vec<String>>,
   #[serde(default)]
@@ -260,6 +261,8 @@ pub struct Http {
   #[serde(rename = "entityType")]
   pub entity_type: Option<String>,
 }
+
+pub type EntityResolver = Http;
 
 impl Http {
   pub fn batch_key(mut self, key: &str) -> Self {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -166,6 +166,9 @@ pub struct Field {
   pub group_by: Option<GroupBy>,
   pub const_field: Option<ConstField>,
   pub is_federation_key: bool,
+  pub shareable: bool,
+  pub external: bool,
+  pub requires: Option<Requires>,
 }
 
 impl Field {
@@ -296,4 +299,9 @@ impl Config {
   pub fn n_plus_one(&self) -> Vec<Vec<(String, String)>> {
     super::n_plus_one::n_plus_one(self)
   }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct Requires {
+  pub fields: String,
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -164,6 +164,7 @@ pub struct Field {
   #[serde(rename = "groupBy")]
   pub group_by: Option<GroupBy>,
   pub const_field: Option<ConstField>,
+  pub is_federation_key: bool,
 }
 
 impl Field {
@@ -255,6 +256,9 @@ pub struct Http {
   pub headers: KeyValues,
   #[serde(rename = "entityResolver")]
   pub entity_resolver: Option<bool>,
+  pub entity_id: Option<String>,
+  #[serde(rename = "entityType")]
+  pub entity_type: Option<String>,
 }
 
 impl Http {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -253,6 +253,8 @@ pub struct Http {
   #[serde(default)]
   #[serde(skip_serializing_if = "is_default")]
   pub headers: KeyValues,
+  #[serde(rename = "entityResolver")]
+  pub entity_resolver: Option<bool>,
 }
 
 impl Http {

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -211,7 +211,7 @@ fn to_common_field(
     unsafe_operation,
     group_by,
     const_field,
-    is_federation_key
+    is_federation_key,
   })
 }
 fn to_unsafe_operation(directives: &[Positioned<ConstDirective>]) -> Option<config::Unsafe> {
@@ -286,7 +286,7 @@ fn to_http(directives: &[Positioned<ConstDirective>]) -> Valid<Option<config::Ht
 fn is_federation_key(directives: &[Positioned<ConstDirective>]) -> bool {
   for directive in directives {
     if directive.node.name.node == "key" {
-      return true
+      return true;
     }
   }
   return false;

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -11,7 +11,7 @@ use async_graphql::Name;
 
 use crate::config;
 use crate::config::group_by::GroupBy;
-use crate::config::{Config, GraphQL, Http, RootSchema, Server, Union, EntityResolver};
+use crate::config::{Config, EntityResolver, GraphQL, Http, RootSchema, Server, Union};
 use crate::directive::DirectiveCodec;
 use crate::valid::{Valid as ValidDefault, ValidExtensions, ValidationError};
 
@@ -79,14 +79,14 @@ fn to_types(type_definitions: &Vec<&Positioned<TypeDefinition>>) -> Valid<BTreeM
         &type_definition.node.description,
         false,
         &object_type.implements,
-        &type_definition.node.directives
+        &type_definition.node.directives,
       )?),
       TypeKind::Interface(interface_type) => Some(to_object_type(
         &interface_type.fields,
         &type_definition.node.description,
         true,
         &interface_type.implements,
-        &type_definition.node.directives
+        &type_definition.node.directives,
       )?),
       TypeKind::Enum(enum_type) => Some(to_enum(enum_type)),
       TypeKind::InputObject(input_object_type) => Some(to_input_object(input_object_type)?),
@@ -123,7 +123,6 @@ fn to_object_type(
   interface: bool,
   implements: &[Positioned<Name>],
   directives: &[Positioned<ConstDirective>],
-
 ) -> Valid<config::Type> {
   let fields = to_fields(fields)?;
   let doc = description.as_ref().map(|pos| pos.node.clone());
@@ -294,7 +293,7 @@ fn is_federation_key(directives: &[Positioned<ConstDirective>]) -> bool {
       return true;
     }
   }
-  return false;
+  false
 }
 fn to_union(union_type: UnionType, doc: &Option<String>) -> Union {
   let types = union_type
@@ -330,7 +329,6 @@ fn to_entity_resolver(directives: &[Positioned<ConstDirective>]) -> Valid<Option
   }
   Valid::Ok(None)
 }
-
 
 trait HasName {
   fn name(&self) -> &Positioned<Name>;

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -197,6 +197,7 @@ fn to_common_field(
   let unsafe_operation = to_unsafe_operation(directives);
   let group_by = to_batch(directives);
   let const_field = to_const_field(directives);
+  let is_federation_key = is_federation_key(directives);
   Valid::Ok(config::Field {
     type_of,
     list,
@@ -210,6 +211,7 @@ fn to_common_field(
     unsafe_operation,
     group_by,
     const_field,
+    is_federation_key
   })
 }
 fn to_unsafe_operation(directives: &[Positioned<ConstDirective>]) -> Option<config::Unsafe> {
@@ -280,6 +282,14 @@ fn to_http(directives: &[Positioned<ConstDirective>]) -> Valid<Option<config::Ht
     }
   }
   Valid::Ok(None)
+}
+fn is_federation_key(directives: &[Positioned<ConstDirective>]) -> bool {
+  for directive in directives {
+    if directive.node.name.node == "key" {
+      return true
+    }
+  }
+  return false;
 }
 fn to_union(union_type: UnionType, doc: &Option<String>) -> Union {
   let types = union_type


### PR DESCRIPTION
**Summary:**  
This PR adds support for tailcall to be a subgraph in Apollo federation, as the first step towards supporting a graphql datasource as mentioned [here](https://github.com/tailcallhq/tailcall/issues/461)
Discussed [here](https://github.com/tailcallhq/tailcall/discussions/460)

The full list of apollo federation directives that async-graphql implements is [here](https://async-graphql.github.io/async-graphql/en/apollo_federation.html#entities-and-key)

Support for the following directives have been added.
- `@entityResolver`
- `@key`
- `@shareable`
- `@external`
- `@requires`


