### PR TITLE
fix: upstream setting keys should be optional

### DIFF
--- a/examples/.tailcallrc.graphql
+++ b/examples/.tailcallrc.graphql
@@ -1,17 +1,13 @@
 directive @server(
-  allowedHeaders: [String]
-  baseURL: String
   enableApolloTracing: Boolean
   enableCacheControlHeader: Boolean
   enableGraphiql: String
-  enableHttpCache: Boolean
   enableIntrospection: Boolean
   enableQueryValidation: Boolean
   enableResponseValidation: Boolean
   globalResponseTimeout: Int
   port: Int
   vars: [KeyValue]
-  batch: Batch
   upstream: Upstream
 ) on SCHEMA
 directive @http(
@@ -42,16 +38,20 @@ input Proxy {
 }
 
 input Upstream {
-  pool_idle_timeout: Int
-  pool_max_idle_per_host: Int
+  allowedHeaders: [String]
+  connect_timeout: Int
   keep_alive_interval: Int
   keep_alive_timeout: Int
   keep_alive_while_idle: Boolean
+  pool_idle_timeout: Int
+  pool_max_idle_per_host: Int
   proxy: Proxy
-  connect_timeout: Int
-  timeout: Int
   tcp_keep_alive: Int
+  timeout: Int
   user_agent: String
+  base_url: String
+  enable_http_cache: Boolean
+  batch: Batch
 }
 
 input KeyValue {

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -343,7 +343,7 @@ fn update_http(field: &config::Field, mut b_field: FieldDefinition, config: &Con
     Some(http) => match http
       .base_url
       .as_ref()
-      .map_or_else(|| config.server.base_url.as_ref(), Some)
+      .map_or_else(|| config.server.upstream.base_url.as_ref(), Some)
     {
       Some(base_url) => {
         let mut base_url = base_url.clone();

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -68,16 +68,26 @@ pub struct Proxy {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Setters, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct Upstream {
+  #[serde(skip_serializing_if = "is_default")]
   pub pool_idle_timeout: Option<u64>,
+  #[serde(skip_serializing_if = "is_default")]
   pub pool_max_idle_per_host: Option<usize>,
+  #[serde(skip_serializing_if = "is_default")]
   pub keep_alive_interval: Option<u64>,
+  #[serde(skip_serializing_if = "is_default")]
   pub keep_alive_timeout: Option<u64>,
+  #[serde(skip_serializing_if = "is_default")]
   pub keep_alive_while_idle: Option<bool>,
+  #[serde(skip_serializing_if = "is_default")]
   pub proxy: Option<Proxy>,
+  #[serde(skip_serializing_if = "is_default")]
   pub connect_timeout: Option<u64>,
+  #[serde(skip_serializing_if = "is_default")]
   pub timeout: Option<u64>,
+  #[serde(skip_serializing_if = "is_default")]
   pub tcp_keep_alive: Option<u64>,
+  #[serde(skip_serializing_if = "is_default")]
   pub user_agent: Option<String>,
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -67,80 +67,17 @@ pub struct Proxy {
   pub url: String,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Setters)]
-#[serde(rename_all = "camelCase", default)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Setters, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Upstream {
-  #[serde(default = "pool_idle_timeout_default")]
-  pub pool_idle_timeout: u64,
-  #[serde(default = "pool_max_idle_per_host_default")]
-  pub pool_max_idle_per_host: usize,
-  #[serde(default = "keep_alive_interval_default")]
-  pub keep_alive_interval: u64,
-  #[serde(default = "keep_alive_timeout_default")]
-  pub keep_alive_timeout: u64,
-  #[serde(default = "keep_alive_while_idle_default")]
-  pub keep_alive_while_idle: bool,
-  #[serde(default)]
+  pub pool_idle_timeout: Option<u64>,
+  pub pool_max_idle_per_host: Option<usize>,
+  pub keep_alive_interval: Option<u64>,
+  pub keep_alive_timeout: Option<u64>,
+  pub keep_alive_while_idle: Option<bool>,
   pub proxy: Option<Proxy>,
-  #[serde(default = "connect_timeout_default")]
-  pub connect_timeout: u64,
-  #[serde(default = "timeout_default")]
-  pub timeout: u64,
-  #[serde(default = "tcp_keep_alive_default")]
-  pub tcp_keep_alive: u64,
-  #[serde(default = "user_agent_default")]
-  pub user_agent: String,
-}
-
-impl Default for Upstream {
-  fn default() -> Self {
-    Upstream {
-      pool_idle_timeout: pool_idle_timeout_default(),
-      pool_max_idle_per_host: pool_max_idle_per_host_default(),
-      keep_alive_interval: keep_alive_interval_default(),
-      keep_alive_timeout: keep_alive_timeout_default(),
-      keep_alive_while_idle: keep_alive_while_idle_default(),
-      proxy: None,
-      connect_timeout: connect_timeout_default(),
-      timeout: timeout_default(),
-      tcp_keep_alive: tcp_keep_alive_default(),
-      user_agent: user_agent_default(),
-    }
-  }
-}
-
-fn pool_idle_timeout_default() -> u64 {
-  60
-}
-
-fn pool_max_idle_per_host_default() -> usize {
-  200
-}
-
-fn keep_alive_interval_default() -> u64 {
-  60
-}
-
-fn keep_alive_timeout_default() -> u64 {
-  60
-}
-
-fn keep_alive_while_idle_default() -> bool {
-  false
-}
-
-fn connect_timeout_default() -> u64 {
-  60
-}
-
-fn timeout_default() -> u64 {
-  60
-}
-
-fn tcp_keep_alive_default() -> u64 {
-  5
-}
-
-fn user_agent_default() -> String {
-  "Tailcall/1.0".to_string()
+  pub connect_timeout: Option<u64>,
+  pub timeout: Option<u64>,
+  pub tcp_keep_alive: Option<u64>,
+  pub user_agent: Option<String>,
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -91,3 +91,33 @@ pub struct Upstream {
   #[serde(skip_serializing_if = "is_default")]
   pub user_agent: Option<String>,
 }
+
+impl Upstream {
+  pub fn get_pool_idle_timeout(&self) -> u64 {
+    self.pool_idle_timeout.unwrap_or(60)
+  }
+  pub fn get_pool_max_idle_per_host(&self) -> usize {
+    self.pool_max_idle_per_host.unwrap_or(60)
+  }
+  pub fn get_keep_alive_interval(&self) -> u64 {
+    self.keep_alive_interval.unwrap_or(60)
+  }
+  pub fn get_keep_alive_timeout(&self) -> u64 {
+    self.keep_alive_timeout.unwrap_or(60)
+  }
+  pub fn get_keep_alive_while_idle(&self) -> bool {
+    self.keep_alive_while_idle.unwrap_or(false)
+  }
+  pub fn get_connect_timeout(&self) -> u64 {
+    self.connect_timeout.unwrap_or(60)
+  }
+  pub fn get_timeout(&self) -> u64 {
+    self.timeout.unwrap_or(60)
+  }
+  pub fn get_tcp_keep_alive(&self) -> u64 {
+    self.tcp_keep_alive.unwrap_or(5)
+  }
+  pub fn get_user_agent(&self) -> String {
+    self.user_agent.clone().unwrap_or("Tailcall/1.0".to_string())
+  }
+}

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -8,13 +8,9 @@ use crate::config::{is_default, KeyValues};
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Server {
-  pub allowed_headers: Option<HashSet<String>>,
-  #[serde(rename = "baseURL")]
-  pub base_url: Option<String>,
   pub enable_apollo_tracing: Option<bool>,
   pub enable_cache_control_header: Option<bool>,
   pub enable_graphiql: Option<String>,
-  pub enable_http_cache: Option<bool>,
   pub enable_introspection: Option<bool>,
   pub enable_query_validation: Option<bool>,
   pub enable_response_validation: Option<bool>,
@@ -24,10 +20,9 @@ pub struct Server {
   pub upstream: Upstream,
   #[serde(default, skip_serializing_if = "is_default")]
   pub vars: KeyValues,
-  pub batch: Option<Batch>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Setters)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, Setters)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Batch {
   pub max_size: usize,
@@ -41,9 +36,6 @@ impl Default for Batch {
 }
 
 impl Server {
-  pub fn enable_http_cache(&self) -> bool {
-    self.enable_http_cache.unwrap_or(false)
-  }
   pub fn enable_http_validation(&self) -> bool {
     self.enable_response_validation.unwrap_or(false)
   }
@@ -55,10 +47,6 @@ impl Server {
   }
   pub fn enable_query_validation(&self) -> bool {
     self.enable_query_validation.unwrap_or(true)
-  }
-  pub fn allowed_headers(&self) -> HashSet<String> {
-    // TODO: cloning isn't required we can return a ref here
-    self.allowed_headers.clone().unwrap_or_default()
   }
 }
 
@@ -90,6 +78,15 @@ pub struct Upstream {
   pub tcp_keep_alive: Option<u64>,
   #[serde(skip_serializing_if = "is_default")]
   pub user_agent: Option<String>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub allowed_headers: Option<HashSet<String>>,
+  #[serde(rename = "baseURL")]
+  #[serde(skip_serializing_if = "is_default")]
+  pub base_url: Option<String>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub enable_http_cache: Option<bool>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub batch: Option<Batch>,
 }
 
 impl Upstream {
@@ -119,5 +116,11 @@ impl Upstream {
   }
   pub fn get_user_agent(&self) -> String {
     self.user_agent.clone().unwrap_or("Tailcall/1.0".to_string())
+  }
+  pub fn get_enable_http_cache(&self) -> bool {
+    self.enable_http_cache.unwrap_or(false)
+  }
+  pub fn get_allowed_headers(&self) -> HashSet<String> {
+    self.allowed_headers.clone().unwrap_or_default()
   }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -36,15 +36,15 @@ impl DefaultHttpClient {
     let upstream = &server.upstream;
 
     let mut builder = Client::builder()
-      .tcp_keepalive(Some(Duration::from_secs(upstream.tcp_keep_alive)))
-      .timeout(Duration::from_secs(upstream.timeout))
-      .connect_timeout(Duration::from_secs(upstream.connect_timeout))
-      .http2_keep_alive_interval(Some(Duration::from_secs(upstream.keep_alive_interval)))
-      .http2_keep_alive_timeout(Duration::from_secs(upstream.keep_alive_timeout))
-      .http2_keep_alive_while_idle(upstream.keep_alive_while_idle)
-      .pool_idle_timeout(Some(Duration::from_secs(upstream.pool_idle_timeout)))
-      .pool_max_idle_per_host(upstream.pool_max_idle_per_host)
-      .user_agent(upstream.user_agent.clone());
+      .tcp_keepalive(Some(Duration::from_secs(upstream.tcp_keep_alive.unwrap_or(5))))
+      .timeout(Duration::from_secs(upstream.timeout.unwrap_or(60)))
+      .connect_timeout(Duration::from_secs(upstream.connect_timeout.unwrap_or(60)))
+      .http2_keep_alive_interval(Some(Duration::from_secs(upstream.keep_alive_interval.unwrap_or(60))))
+      .http2_keep_alive_timeout(Duration::from_secs(upstream.keep_alive_timeout.unwrap_or(60)))
+      .http2_keep_alive_while_idle(upstream.keep_alive_while_idle.unwrap_or(false))
+      .pool_idle_timeout(Some(Duration::from_secs(upstream.pool_idle_timeout.unwrap_or(60))))
+      .pool_max_idle_per_host(upstream.pool_max_idle_per_host.unwrap_or(200))
+      .user_agent(upstream.user_agent.clone().unwrap_or("Tailcall/1.0".to_string()));
 
     if let Some(ref proxy) = upstream.proxy {
       builder = builder.proxy(reqwest::Proxy::http(proxy.url.clone()).expect("Failed to set proxy in http client"));

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 
 use super::Response;
-use crate::config::Server;
+use crate::config::{Server};
 
 #[async_trait::async_trait]
 pub trait HttpClient {
@@ -36,15 +36,15 @@ impl DefaultHttpClient {
     let upstream = &server.upstream;
 
     let mut builder = Client::builder()
-      .tcp_keepalive(Some(Duration::from_secs(upstream.tcp_keep_alive.unwrap_or(5))))
-      .timeout(Duration::from_secs(upstream.timeout.unwrap_or(60)))
-      .connect_timeout(Duration::from_secs(upstream.connect_timeout.unwrap_or(60)))
-      .http2_keep_alive_interval(Some(Duration::from_secs(upstream.keep_alive_interval.unwrap_or(60))))
-      .http2_keep_alive_timeout(Duration::from_secs(upstream.keep_alive_timeout.unwrap_or(60)))
-      .http2_keep_alive_while_idle(upstream.keep_alive_while_idle.unwrap_or(false))
-      .pool_idle_timeout(Some(Duration::from_secs(upstream.pool_idle_timeout.unwrap_or(60))))
-      .pool_max_idle_per_host(upstream.pool_max_idle_per_host.unwrap_or(200))
-      .user_agent(upstream.user_agent.clone().unwrap_or("Tailcall/1.0".to_string()));
+      .tcp_keepalive(Some(Duration::from_secs(upstream.get_tcp_keep_alive())))
+      .timeout(Duration::from_secs(upstream.get_timeout()))
+      .connect_timeout(Duration::from_secs(upstream.get_connect_timeout()))
+      .http2_keep_alive_interval(Some(Duration::from_secs(upstream.get_keep_alive_interval())))
+      .http2_keep_alive_timeout(Duration::from_secs(upstream.get_keep_alive_timeout()))
+      .http2_keep_alive_while_idle(upstream.get_keep_alive_while_idle())
+      .pool_idle_timeout(Some(Duration::from_secs(upstream.get_pool_idle_timeout())))
+      .pool_max_idle_per_host(upstream.get_pool_max_idle_per_host())
+      .user_agent(upstream.get_user_agent());
 
     if let Some(ref proxy) = upstream.proxy {
       builder = builder.proxy(reqwest::Proxy::http(proxy.url.clone()).expect("Failed to set proxy in http client"));

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -52,7 +52,7 @@ impl DefaultHttpClient {
 
     let mut client = ClientBuilder::new(builder.build().expect("Failed to build client"));
 
-    if server.enable_http_cache() {
+    if server.upstream.get_enable_http_cache() {
       client = client.with(Cache(HttpCache {
         mode: CacheMode::Default,
         manager: MokaManager::default(),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 
 use super::Response;
-use crate::config::{Server};
+use crate::config::Server;
 
 #[async_trait::async_trait]
 pub trait HttpClient {

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -22,7 +22,7 @@ fn graphiql() -> Result<Response<Body>> {
 
 async fn graphql_request(req: Request<Body>, server_ctx: &ServerContext) -> Result<Response<Body>> {
   let server = server_ctx.server.clone();
-  let allowed = server.allowed_headers.unwrap_or_default();
+  let allowed = server.upstream.allowed_headers.unwrap_or_default();
   let headers = create_allowed_headers(req.headers(), &allowed);
   let bytes = hyper::body::to_bytes(req.into_body()).await?;
   let request: async_graphql_hyper::GraphQLRequest = serde_json::from_slice(&bytes)?;

--- a/src/http/server_context.rs
+++ b/src/http/server_context.rs
@@ -21,7 +21,7 @@ fn assign_data_loaders(blueprint: &mut Blueprint, server: Server, http_client: D
       for field in &mut def.fields {
         if let Some(Expression::Unsafe(Operation::Endpoint(req_template, group_by, _))) = &mut field.resolver {
           let data_loader = HttpDataLoader::new(http_client.clone(), group_by.clone())
-            .to_data_loader(server.batch.clone().unwrap_or_default());
+            .to_data_loader(server.upstream.batch.clone().unwrap_or_default());
           field.resolver = Some(Expression::Unsafe(Operation::Endpoint(
             req_template.clone(),
             group_by.clone(),

--- a/src/lambda/expression.rs
+++ b/src/lambda/expression.rs
@@ -104,8 +104,15 @@ impl Expression {
               let req = req_template.to_request(ctx)?;
               let is_get = req.method() == reqwest::Method::GET;
               // Attempt to short circuit GET request
-              if is_get && ctx.req_ctx.server.batch.is_some() {
-                let headers = ctx.req_ctx.server.batch.clone().map(|s| s.headers).unwrap_or_default();
+              if is_get && ctx.req_ctx.server.upstream.batch.is_some() {
+                let headers = ctx
+                  .req_ctx
+                  .server
+                  .upstream
+                  .batch
+                  .clone()
+                  .map(|s| s.headers)
+                  .unwrap_or_default();
                 let endpoint_key = crate::http::DataLoaderRequest::new(req, headers);
                 let resp = dl
                   .as_ref()

--- a/tests/graphql/errors/test-batch-operator-post.graphql
+++ b/tests/graphql/errors/test-batch-operator-post.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://localhost:3000") {
+schema @server(upstream: {baseURL: "http://localhost:3000"}) {
   query: Query
 }
 

--- a/tests/graphql/errors/test-const-with-inline.graphql
+++ b/tests/graphql/errors/test-const-with-inline.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/errors/test-const.graphql
+++ b/tests/graphql/errors/test-const.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "https://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/errors/test-http-with-inline.graphql
+++ b/tests/graphql/errors/test-http-with-inline.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/errors/test-multiple-resolvable-directives-on-field.graphql
+++ b/tests/graphql/errors/test-multiple-resolvable-directives-on-field.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "https://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/merge/test-merge-server-sdl.graphql
+++ b/tests/graphql/merge/test-merge-server-sdl.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 
@@ -13,7 +13,7 @@ type User {
 }
 
 #> merged-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/passed/test-batching-group-by.graphql
+++ b/tests/graphql/passed/test-batching-group-by.graphql
@@ -2,11 +2,13 @@
 schema
   @server(
     port: 8000
-    baseURL: "http://jsonplaceholder.typicode.com"
-    enableHttpCache: true
     enableGraphiql: "/graphiql"
-    enableQueryValidation: false
-    batch: {delay: 1, maxSize: 1000}
+    upstream: {
+      baseURL: "http://jsonplaceholder.typicode.com"
+      enableQueryValidation: false
+      enableHttpCache: true
+      batch: {delay: 1, maxSize: 1000}
+    }
   ) {
   query: Query
 }

--- a/tests/graphql/passed/test-batching.graphql
+++ b/tests/graphql/passed/test-batching.graphql
@@ -2,11 +2,13 @@
 schema
   @server(
     port: 8000
-    baseURL: "http://jsonplaceholder.typicode.com"
-    enableHttpCache: true
     enableGraphiql: "/graphiql"
     enableQueryValidation: false
-    batch: {maxSize: 1000, delay: 0, headers: []}
+    upstream: {
+      enableHttpCache: true
+      batch: {maxSize: 1000, delay: 0, headers: []}
+      baseURL: "http://jsonplaceholder.typicode.com"
+    }
   ) {
   query: Query
 }

--- a/tests/graphql/passed/test-const-nullable.graphql
+++ b/tests/graphql/passed/test-const-nullable.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "https://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/passed/test-const.graphql
+++ b/tests/graphql/passed/test-const.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "https://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/passed/test-https.graphql
+++ b/tests/graphql/passed/test-https.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "https://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "https://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/passed/test-mutation-put.graphql
+++ b/tests/graphql/passed/test-mutation-put.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplaceholder.typicode.com"}) {
   query: Query
   mutation: Mutation
 }

--- a/tests/graphql/passed/test-mutation.graphql
+++ b/tests/graphql/passed/test-mutation.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplaceholder.typicode.com"}) {
   query: Query
   mutation: Mutation
 }

--- a/tests/graphql/passed/test-nesting-level3.graphql
+++ b/tests/graphql/passed/test-nesting-level3.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/passed/test-simple-query.graphql
+++ b/tests/graphql/passed/test-simple-query.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/passed/test-with-nesting.graphql
+++ b/tests/graphql/passed/test-with-nesting.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplaceholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-batching-group-by.graphql
+++ b/tests/graphql/test-batching-group-by.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://abc.com", batch: {delay: 1, headers: [], maxSize: 1000}) {
+schema @server(upstream: {baseURL: "http://abc.com", batch: {delay: 1, headers: [], maxSize: 1000}}) {
   query: Query
 }
 

--- a/tests/graphql/test-custom-scalar.graphql
+++ b/tests/graphql/test-custom-scalar.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-description-many.graphql
+++ b/tests/graphql/test-description-many.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-enum.graphql
+++ b/tests/graphql/test-enum.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-http-baseurl.graphql
+++ b/tests/graphql/test-http-baseurl.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://abc.com") {
+schema @server(upstream: {baseURL: "http://abc.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-http-headers.graphql
+++ b/tests/graphql/test-http-headers.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://localhost:4000") {
+schema @server(upstream: {baseURL: "http://localhost:4000"}) {
   query: Query
 }
 

--- a/tests/graphql/test-http-tmpl.graphql
+++ b/tests/graphql/test-http-tmpl.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-http.graphql
+++ b/tests/graphql/test-http.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-inline-list.graphql
+++ b/tests/graphql/test-inline-list.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-inline.graphql
+++ b/tests/graphql/test-inline.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-interface.graphql
+++ b/tests/graphql/test-interface.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-modify.graphql
+++ b/tests/graphql/test-modify.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-multi-interface.graphql
+++ b/tests/graphql/test-multi-interface.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-query-documentation.graphql
+++ b/tests/graphql/test-query-documentation.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-query.graphql
+++ b/tests/graphql/test-query.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-server-vars.graphql
+++ b/tests/graphql/test-server-vars.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com", vars: [{key: "foo", value: "bar"}]) {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}, vars: [{key: "foo", value: "bar"}]) {
   query: Query
 }
 

--- a/tests/graphql/test-union.graphql
+++ b/tests/graphql/test-union.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-unsafe.graphql
+++ b/tests/graphql/test-unsafe.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://jsonplacheholder.typicode.com") {
+schema @server(upstream: {baseURL: "http://jsonplacheholder.typicode.com"}) {
   query: Query
 }
 

--- a/tests/graphql/test-upstream.graphql
+++ b/tests/graphql/test-upstream.graphql
@@ -1,0 +1,17 @@
+#> server-sdl
+schema @server(upstream: {proxy: {url: "http://localhost:8080"}}) {
+  query: Query
+}
+
+type Query {
+  hello: String @http(baseURL: "http://localhost:8000", path: "/hello")
+}
+
+#> client-sdl
+type Query {
+  hello: String
+}
+
+schema {
+  query: Query
+}

--- a/tests/graphql/todo/test-batched-query.graphql
+++ b/tests/graphql/todo/test-batched-query.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(baseURL: "http://127.0.0.1:3000") {
+schema @server(upstream: {baseURL: "http://127.0.0.1:3000"}) {
   query: Query
 }
 

--- a/tests/graphql_spec.rs
+++ b/tests/graphql_spec.rs
@@ -18,7 +18,7 @@ use tailcall::config::Config;
 use tailcall::directive::DirectiveCodec;
 use tailcall::http::{RequestContext, ServerContext};
 use tailcall::print_schema;
-use tailcall::valid::Cause;
+use tailcall::valid::{Cause, ValidExtensions};
 
 mod graphql_mock;
 
@@ -201,7 +201,9 @@ async fn test_execution() -> std::io::Result<()> {
     let mut config = Config::from_sdl(&spec.server_sdl[0]).unwrap();
     config.server.enable_query_validation = Some(false);
 
-    let blueprint = Blueprint::try_from(&config).unwrap();
+    let blueprint = Blueprint::try_from(&config)
+      .trace(spec.path.to_str().unwrap_or_default())
+      .unwrap();
     let server_ctx = ServerContext::new(blueprint, config.server.clone());
     let schema = server_ctx.schema.clone();
 


### PR DESCRIPTION
**Summary:**  
upstream setting keys should be optional in order to have the capability to merge right else if right don't have upstream values it would pick default always


**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
