### PR TITLE
refactor: use btreeset where duplicates are not allowed

### DIFF
--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use async_graphql::dynamic::{Schema, SchemaBuilder};
 use async_graphql::extensions::ApolloTracing;
@@ -69,7 +69,7 @@ pub struct ObjectTypeDefinition {
   pub name: String,
   pub fields: Vec<FieldDefinition>,
   pub description: Option<String>,
-  pub implements: Vec<String>,
+  pub implements: BTreeSet<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use async_graphql::parser::types::ConstDirective;
 #[allow(unused_imports)]
@@ -150,7 +150,7 @@ fn to_enum_type_definition(
   name: &str,
   type_: &config::Type,
   _config: &Config,
-  variants: Vec<String>,
+  variants: BTreeSet<String>,
 ) -> Valid<Definition> {
   let enum_type_definition = Definition::EnumTypeDefinition(EnumTypeDefinition {
     name: name.to_string(),

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use anyhow::Result;
 use async_graphql::parser::types::ServiceDocument;
@@ -111,9 +111,9 @@ pub struct Type {
   #[serde(default)]
   pub interface: bool,
   #[serde(default)]
-  pub implements: Vec<String>,
+  pub implements: BTreeSet<String>,
   #[serde(rename = "enum", default)]
-  pub variants: Option<Vec<String>>,
+  pub variants: Option<BTreeSet<String>>,
   #[serde(default)]
   pub scalar: bool,
 }


### PR DESCRIPTION
**Summary:**  
Vec<_> makes merging of config's error prone due to possibility of duplicates


**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
