### PR TITLE
feat: Load Config via HTTP

### DIFF
--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -27,6 +27,8 @@ pub enum Command {
     file_path: Vec<String>,
     #[arg(long)]
     log_level: Option<log::Level>,
+    #[arg(long)]
+    refresh_interval: Option<u64>,
   },
 
   /// Validate a composition spec

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -28,7 +28,7 @@ pub enum Command {
     #[arg(long)]
     log_level: Option<log::Level>,
     #[arg(long)]
-    refresh_interval: Option<u64>,
+    poll_interval: Option<u64>,
   },
 
   /// Validate a composition spec

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -20,12 +20,12 @@ pub async fn run() -> Result<()> {
   let cli = Cli::parse();
 
   match cli.command {
-    Command::Start { file_path, log_level } => {
+    Command::Start { file_path, log_level, refresh_interval } => {
       env_logger::Builder::new()
         .filter_level(log_level.unwrap_or(Level::Info).to_level_filter())
         .init();
-      let config = Config::from_file_paths(file_path.iter()).await?;
-      start_server(config).await?;
+      let config = Config::from_file_or_url(file_path.iter()).await?;
+      start_server(config.0, config.1, refresh_interval).await?;
       Ok(())
     }
     Command::Check { file_path, n_plus_one_queries, schema } => {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -346,6 +346,19 @@ impl Config {
     super::n_plus_one::n_plus_one(self)
   }
 
+  pub async fn from_file_or_url(file_paths: std::slice::Iter<'_, String>) -> Result<(Config, Option<String>)> {
+    let first_path = file_paths.clone().next().unwrap();
+    if first_path.starts_with("http://") || first_path.starts_with("https://") {
+      let resp = reqwest::get(first_path).await?;
+      let server_sdl = resp.text().await?;
+      let config = Config::from_sdl(&server_sdl)?;
+      Ok((config, Some(first_path.to_string())))
+    } else {
+      let config = Config::from_file_paths(file_paths).await?;
+      Ok((config, None))
+    }
+  }
+
   pub async fn from_file_paths(file_paths: std::slice::Iter<'_, String>) -> Result<Config> {
     let mut config = Config::default();
     let futures: Vec<_> = file_paths

--- a/src/config/config_poll.rs
+++ b/src/config/config_poll.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::atomic::AtomicPtr;
+use std::sync::Arc;
 use std::time::Duration;
 
-use hyper::header::HeaderValue;
-use reqwest::header::IF_NONE_MATCH;
 use reqwest::Client;
 use tokio::time;
 
@@ -15,11 +13,11 @@ use crate::http::ServerContext;
 pub struct ConfigLoader {
   file_path: String,
   refresh_interval: u64,
-  state: Arc<RwLock<ServerContext>>,
+  state: Arc<AtomicPtr<ServerContext>>,
 }
 
 impl ConfigLoader {
-  pub fn new(file_path: String, refresh_interval: u64, state: Arc<RwLock<ServerContext>>) -> Result<Self, CLIError> {
+  pub fn new(file_path: String, refresh_interval: u64, state: Arc<AtomicPtr<ServerContext>>) -> Result<Self, CLIError> {
     Ok(Self { file_path, refresh_interval, state })
   }
 
@@ -30,24 +28,14 @@ impl ConfigLoader {
     let state = Arc::clone(&self.state);
 
     let mut interval = time::interval(Duration::from_secs(refresh_interval));
-    let mut etag: Option<String> = None;
 
     tokio::spawn(async move {
       loop {
         interval.tick().await;
 
-        let mut headers = HashMap::new();
+        let request = client.get(&file_path).build().unwrap();
 
-        if let Some(etag_value) = &etag {
-          headers.insert(IF_NONE_MATCH, HeaderValue::from_str(etag_value).unwrap());
-        }
-
-        let mut resp = client.get(&file_path);
-
-        for (k, v) in headers {
-          resp = resp.header(k, v);
-        }
-        let resp = resp.send().await;
+        let resp = client.execute(request).await;
 
         let resp = match resp {
           Ok(resp) => resp,
@@ -57,18 +45,9 @@ impl ConfigLoader {
           }
         };
 
-        if resp.status() == 304 {
-          log::info!("The resource has not been modified.");
-          continue;
-        }
-
         if !resp.status().is_success() {
           log::info!("Unknown error.");
           continue;
-        }
-
-        if let Some(new_etag) = resp.headers().get("etag") {
-          etag = Some(new_etag.to_str().unwrap().to_string());
         }
 
         let updated_sdl = match resp.text().await {
@@ -78,7 +57,7 @@ impl ConfigLoader {
 
         match Config::from_sdl(&updated_sdl) {
           Ok(updated_config) => {
-            let mut state = state.write().unwrap();
+            let state = unsafe { state.load(std::sync::atomic::Ordering::Relaxed).as_mut().unwrap() };
             match Blueprint::try_from(&updated_config) {
               Ok(blueprint) => {
                 state.schema = blueprint.to_schema();

--- a/src/config/config_poll.rs
+++ b/src/config/config_poll.rs
@@ -1,0 +1,98 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use hyper::header::HeaderValue;
+use reqwest::header::IF_NONE_MATCH;
+use reqwest::Client;
+use tokio::time;
+
+use crate::blueprint::Blueprint;
+use crate::cli::CLIError;
+use crate::config::Config;
+use crate::http::ServerContext;
+
+pub struct ConfigLoader {
+  file_path: String,
+  refresh_interval: u64,
+  state: Arc<RwLock<ServerContext>>,
+}
+
+impl ConfigLoader {
+  pub fn new(file_path: String, refresh_interval: u64, state: Arc<RwLock<ServerContext>>) -> Result<Self, CLIError> {
+    Ok(Self { file_path, refresh_interval, state })
+  }
+
+  pub async fn start_polling(&self) {
+    let client = Client::new();
+    let refresh_interval = self.refresh_interval;
+    let file_path = self.file_path.clone();
+    let state = Arc::clone(&self.state);
+
+    let mut interval = time::interval(Duration::from_secs(refresh_interval));
+    let mut etag: Option<String> = None;
+
+    tokio::spawn(async move {
+      loop {
+        interval.tick().await;
+
+        let mut headers = HashMap::new();
+
+        if let Some(etag_value) = &etag {
+          headers.insert(IF_NONE_MATCH, HeaderValue::from_str(etag_value).unwrap());
+        }
+
+        let mut resp = client.get(&file_path);
+
+        for (k, v) in headers {
+          resp = resp.header(k, v);
+        }
+        let resp = resp.send().await;
+
+        let resp = match resp {
+          Ok(resp) => resp,
+          Err(e) => {
+            log::error!("Failed to refresh configuration: {}", e);
+            continue;
+          }
+        };
+
+        if resp.status() == 304 {
+          log::info!("The resource has not been modified.");
+          continue;
+        }
+
+        if !resp.status().is_success() {
+          log::info!("Unknown error.");
+          continue;
+        }
+
+        if let Some(new_etag) = resp.headers().get("etag") {
+          etag = Some(new_etag.to_str().unwrap().to_string());
+        }
+
+        let updated_sdl = match resp.text().await {
+          Ok(updated_sdl) => updated_sdl,
+          Err(_) => continue,
+        };
+
+        match Config::from_sdl(&updated_sdl) {
+          Ok(updated_config) => {
+            let mut state = state.write().unwrap();
+            match Blueprint::try_from(&updated_config) {
+              Ok(blueprint) => {
+                state.schema = blueprint.to_schema();
+                log::info!("Schema updated sucessfuly");
+              }
+              Err(e) => {
+                log::error!("Failed to create blueprint: {}", e);
+                continue;
+              }
+            }
+          }
+          Err(_) => continue,
+        };
+      }
+    });
+  }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod config;
+pub(crate) mod config_poll;
 mod from_document;
 pub mod group_by;
 mod into_document;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -19,7 +19,7 @@ use hyper::header::CACHE_CONTROL;
 pub use method::Method;
 pub use request_context::RequestContext;
 pub use response::*;
-pub use server::start_server;
+pub use server::{start_server, start_server_with_polling};
 pub use server_context::ServerContext;
 
 pub fn max_age(res: &Response) -> Option<Duration> {

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use async_graphql::http::GraphiQLSource;
@@ -8,10 +8,10 @@ use hyper::{Body, HeaderMap, Request, Response, StatusCode};
 
 use super::request_context::RequestContext;
 use super::ServerContext;
-use crate::async_graphql_hyper;
 use crate::blueprint::Blueprint;
 use crate::cli::CLIError;
 use crate::config::Config;
+use crate::{async_graphql_hyper, config};
 
 fn graphiql() -> Result<Response<Body>> {
   Ok(Response::new(Body::from(
@@ -45,22 +45,30 @@ async fn graphql_request(req: Request<Body>, server_ctx: &ServerContext) -> Resu
 fn not_found() -> Result<Response<Body>> {
   Ok(Response::builder().status(StatusCode::NOT_FOUND).body(Body::empty())?)
 }
-async fn handle_request(req: Request<Body>, state: Arc<ServerContext>) -> Result<Response<Body>> {
-  match *req.method() {
-    hyper::Method::GET
-      if state
-        .blueprint
-        .server
-        .enable_graphiql
-        .as_ref()
-        .map_or(false, |s| s.as_str() == req.uri().path()) =>
-    {
-      graphiql()
+
+async fn handle_request(req: Request<Body>, state: Arc<RwLock<ServerContext>>) -> Result<Response<Body>> {
+  let server_ctx;
+  {
+    let state = state.read().unwrap();
+    server_ctx = state.clone();
+    match *req.method() {
+      hyper::Method::GET
+        if server_ctx
+          .blueprint
+          .server
+          .enable_graphiql
+          .as_ref()
+          .map_or(false, |s| s.as_str() == req.uri().path()) =>
+      {
+        return graphiql()
+      }
+      hyper::Method::POST if req.uri().path() == "/graphql" => (),
+      _ => return not_found(),
     }
-    hyper::Method::POST if req.uri().path() == "/graphql" => graphql_request(req, state.as_ref()).await,
-    _ => not_found(),
   }
+  graphql_request(req, &server_ctx).await
 }
+
 fn create_allowed_headers(headers: &HeaderMap, allowed: &BTreeSet<String>) -> HeaderMap {
   let mut new_headers = HeaderMap::new();
   for (k, v) in headers.iter() {
@@ -71,18 +79,27 @@ fn create_allowed_headers(headers: &HeaderMap, allowed: &BTreeSet<String>) -> He
 
   new_headers
 }
-pub async fn start_server(config: Config) -> Result<()> {
+pub async fn start_server(config: Config, file_path: Option<String>, refresh_interval: Option<u64>) -> Result<()> {
   let blueprint = Blueprint::try_from(&config).map_err(CLIError::from)?;
-  let state = Arc::new(ServerContext::new(blueprint.clone()));
+  let blueprint_clone = blueprint.clone(); // Clone the blueprint here
+  let state = Arc::new(RwLock::new(ServerContext::new(blueprint)));
+  let state_clone = Arc::clone(&state);
+
   let make_svc = make_service_fn(move |_conn| {
     let state = Arc::clone(&state);
     async move { Ok::<_, anyhow::Error>(service_fn(move |req| handle_request(req, state.clone()))) }
   });
-  let addr = (blueprint.server.hostname, blueprint.server.port).into();
+
+  let addr = (blueprint_clone.server.hostname, blueprint_clone.server.port).into();
   let server = hyper::Server::try_bind(&addr).map_err(CLIError::from)?.serve(make_svc);
   log::info!("🚀 Tailcall launched at [{}]", addr);
-  if let Some(enable_graphiql) = blueprint.server.enable_graphiql {
+  if let Some(enable_graphiql) = blueprint_clone.server.enable_graphiql {
     log::info!("🌍 Playground: http://{}{}", addr, enable_graphiql);
+  }
+
+  if let (Some(file_path), Some(refresh_interval)) = (file_path, refresh_interval) {
+    let config_loader = config::config_poll::ConfigLoader::new(file_path, refresh_interval, Arc::clone(&state_clone));
+    config_loader?.start_polling().await;
   }
 
   Ok(server.await.map_err(CLIError::from)?)

--- a/tests/custom_resp_header_spec.rs
+++ b/tests/custom_resp_header_spec.rs
@@ -6,19 +6,28 @@ mod integration_tests {
     let config = tailcall::config::Config::from_file_paths([mock_schema_path].iter())
       .await
       .unwrap();
-    tailcall::http::start_server(config, None, None)
+    tailcall::http::start_server(config)
       .await
       .expect("Server failed to start");
     "Success"
   }
 
-  #[tokio::test]
-  async fn verify_response_headers() {
-    // Define the path to our mock GraphQL schema for testing.
-    let schema_path = "tests/graphql_mock/test-custom-headers.graphql";
+  async fn initiate_test_server_over_http(mock_schema_path: String, poll_interval: u64) -> &'static str {
+    let config = tailcall::config::Config::from_file_paths([mock_schema_path.clone()].iter())
+      .await
+      .unwrap();
+    tailcall::http::start_server_with_polling(config, mock_schema_path, poll_interval)
+      .await
+      .expect("Server failed to start");
+    "Success"
+  }
 
+  async fn verify_response_headers(schema_path: &str, poll_interval: Option<u64>) {
     // Start the background server with the provided schema.
-    tokio::spawn(initiate_test_server(schema_path.into()));
+    match poll_interval {
+      Some(interval) => tokio::spawn(initiate_test_server_over_http(schema_path.into(), interval)),
+      None => tokio::spawn(initiate_test_server(schema_path.into())),
+    };
 
     // Provide a small delay to ensure the server has started.
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
@@ -36,5 +45,18 @@ mod integration_tests {
     let response_headers = response.headers();
     assert_eq!(response_headers.get("x-id").unwrap(), "1");
     assert_eq!(response_headers.get("x-value").unwrap(), "value");
+  }
+
+  #[tokio::test]
+  async fn test_verify_response_headers() {
+    let schema_path = "tests/graphql_mock/test-custom-headers.graphql";
+    verify_response_headers(schema_path, None).await;
+  }
+
+  #[tokio::test]
+  async fn test_verify_response_headers_over_http() {
+    let schema_path = "https://raw.githubusercontent.com/tailcallhq/tailcall/main/examples/jsonplaceholder.json";
+    let poll_interval = 10;
+    verify_response_headers(schema_path, Some(poll_interval)).await;
   }
 }

--- a/tests/custom_resp_header_spec.rs
+++ b/tests/custom_resp_header_spec.rs
@@ -6,7 +6,7 @@ mod integration_tests {
     let config = tailcall::config::Config::from_file_paths([mock_schema_path].iter())
       .await
       .unwrap();
-    tailcall::http::start_server(config)
+    tailcall::http::start_server(config, None, None)
       .await
       .expect("Server failed to start");
     "Success"


### PR DESCRIPTION
This PR adds ability to load config over HTTP with polling.


https://github.com/tailcallhq/tailcall/assets/62795688/ae30250b-9958-4588-b314-479d9d044d8c




**Issue Reference(s):**  
Fixes #441

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.


/claim #441