### PR TITLE
Feat/graphql datasource

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 target/
+test-graphqlsource.graphql

--- a/benches/impl_path_string_for_evaluation_context.rs
+++ b/benches/impl_path_string_for_evaluation_context.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
+use async_graphql::context::SelectionField;
 use async_graphql::{Name, Value};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use hyper::header::HeaderValue;
@@ -87,6 +88,10 @@ impl<'a> ResolverContextLike<'a> for MockGraphqlContext {
 
   fn args(&'a self) -> Option<&'a IndexMap<Name, Value>> {
     Some(&TEST_ARGS)
+  }
+
+  fn field(&'a self) -> Option<SelectionField> {
+    None
   }
 }
 

--- a/examples/tc-compose.graphql
+++ b/examples/tc-compose.graphql
@@ -1,0 +1,30 @@
+schema
+  @server(port: 8001, enableGraphiql: "/graphiql", enableQueryValidation: false, hostname: "0.0.0.0")
+  @upstream(baseURL: "http://jsonplaceholder.typicode.com", enableHttpCache: true) {
+  query: Query
+}
+
+type Query {
+  posts: [Post] @http(baseURL: "http://jsonplaceholder.typicode.com", path: "/posts")
+  post(id: Int!): Post @http(baseURL: "http://jsonplaceholder.typicode.com", path: "/posts/{{args.id}}")
+}
+
+type Post {
+  id: Int!
+  title: String!
+  body: String!
+  user: User
+    @graphql(
+      baseURL: "http://localhost:8000/graphql"
+      query: {name: "user", args: [{key: "id", value: "{{value.userId}}"}]}
+    )
+}
+
+type User {
+  id: Int!
+  name(id: Int): String!
+  username: String!
+  email: String!
+  phone: String
+  website: String
+}

--- a/src/config/into_document.rs
+++ b/src/config/into_document.rs
@@ -207,6 +207,10 @@ fn get_directives(field: &crate::config::Field) -> Vec<Positioned<ConstDirective
     let dir = modify.to_directive("modify".to_string());
     directives.push(pos(dir));
   }
+  if let Some(graphqlsource) = field.clone().graphql_source {
+    let graphql_dir = graphqlsource.to_directive("graphql".to_string());
+    directives.push(pos(graphql_dir));
+  }
   directives
 }
 

--- a/src/graphqlsource/graphql_data_loader.rs
+++ b/src/graphqlsource/graphql_data_loader.rs
@@ -1,0 +1,256 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_graphql::async_trait;
+use async_graphql::dataloader::{DataLoader, Loader, NoCache};
+use async_graphql::futures_util::future::join_all;
+use reqwest::Url;
+
+use crate::config::Batch;
+use crate::http::{DataLoaderRequest, HttpClient, Response};
+
+pub struct GraphqlDataLoader<C>
+where
+  C: HttpClient + Send + Sync + 'static + Clone,
+{
+  pub client: C,
+}
+impl<C: HttpClient + Send + Sync + 'static + Clone> GraphqlDataLoader<C> {
+  pub fn new(client: C) -> Self {
+    GraphqlDataLoader { client }
+  }
+
+  pub fn to_data_loader(self, batch: Batch) -> DataLoader<GraphqlDataLoader<C>, NoCache> {
+    DataLoader::new(self, tokio::spawn)
+      .delay(Duration::from_millis(batch.delay as u64))
+      .max_batch_size(batch.max_size)
+  }
+}
+
+#[async_trait::async_trait]
+impl<C: HttpClient + Send + Sync + 'static + Clone> Loader<DataLoaderRequest> for GraphqlDataLoader<C> {
+  type Value = Response;
+  type Error = Arc<anyhow::Error>;
+
+  #[allow(clippy::mutable_key_type)]
+  async fn load(
+    &self,
+    keys: &[DataLoaderRequest],
+  ) -> async_graphql::Result<HashMap<DataLoaderRequest, Self::Value>, Self::Error> {
+    let request_groups = group_requests_by_url(keys);
+
+    let results = request_groups.iter().map(|(group_key, requests_in_group)| async move {
+      let batched_req = create_batched_request(requests_in_group);
+      let result = self.client.execute(batched_req).await;
+      (group_key.clone(), result)
+    });
+    let results = join_all(results).await;
+
+    #[allow(clippy::mutable_key_type)]
+    let hashmap = extract_individual_responses(results, request_groups);
+    Ok(hashmap)
+  }
+}
+
+fn group_requests_by_url(dataloader_requests: &[DataLoaderRequest]) -> HashMap<Url, Vec<DataLoaderRequest>> {
+  let mut batch_key_groups: HashMap<Url, Vec<DataLoaderRequest>> = HashMap::new();
+  for dataloader_req in dataloader_requests.iter() {
+    if let Some(mut group) = batch_key_groups.get(dataloader_req.to_request().url()).cloned() {
+      group.push(dataloader_req.clone());
+      batch_key_groups.insert(dataloader_req.to_request().url().clone(), group);
+    } else {
+      batch_key_groups.insert(dataloader_req.to_request().url().clone(), vec![dataloader_req.clone()]);
+    }
+  }
+  batch_key_groups
+}
+
+fn collect_request_bodies(dataloader_requests: &[DataLoaderRequest]) -> String {
+  let batched_query = dataloader_requests
+    .iter()
+    .map(|dataloader_req| {
+      if let Some(body) = dataloader_req.to_request().body() {
+        if let Some(bytes) = body.as_bytes() {
+          if let Ok(body_str) = std::str::from_utf8(bytes) {
+            body_str.to_string().clone()
+          } else {
+            "".to_string()
+          }
+        } else {
+          "".to_string()
+        }
+      } else {
+        "".to_string()
+      }
+    })
+    .collect::<Vec<_>>()
+    .join(",");
+  format!("[{}]", batched_query)
+}
+
+fn create_batched_request(dataloader_requests: &[DataLoaderRequest]) -> reqwest::Request {
+  let batched_query = collect_request_bodies(dataloader_requests);
+
+  let first_req = dataloader_requests.get(0).unwrap(); // TODO fix!
+  let mut batched_req = first_req.to_request();
+  batched_req.body_mut().replace(reqwest::Body::from(batched_query));
+  batched_req
+}
+
+#[allow(clippy::mutable_key_type)]
+fn extract_individual_responses(
+  results: Vec<(Url, Result<Response, anyhow::Error>)>,
+  request_groups: HashMap<Url, Vec<DataLoaderRequest>>,
+) -> HashMap<DataLoaderRequest, Response> {
+  #[allow(clippy::mutable_key_type)]
+  let mut hashmap = HashMap::new();
+  for (key, result) in results {
+    let group = request_groups.get(&key);
+    if let Ok(res) = result {
+      if let async_graphql_value::ConstValue::List(values) = res.body {
+        for (i, request) in group.unwrap_or(&Vec::new()).iter().enumerate() {
+          let value = values.get(i).unwrap_or(&async_graphql_value::ConstValue::Null);
+          hashmap.insert(
+            request.clone(),
+            Response { status: res.status, headers: res.headers.clone(), body: value.clone() },
+          );
+        }
+      }
+    }
+  }
+  hashmap
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeSet;
+  use std::sync::atomic::{AtomicUsize, Ordering};
+  use std::sync::{Arc, Mutex};
+
+  use super::*;
+  use crate::http::DataLoaderRequest;
+
+  #[derive(Clone)]
+  struct MockHttpClient {
+    // To keep track of number of times execute is called
+    request_count: Arc<AtomicUsize>,
+    request_bodies: Arc<Mutex<Vec<String>>>,
+  }
+
+  #[async_trait::async_trait]
+  impl HttpClient for MockHttpClient {
+    async fn execute(&self, req: reqwest::Request) -> anyhow::Result<Response> {
+      self.request_count.fetch_add(1, Ordering::SeqCst);
+      let body_str = std::str::from_utf8(req.body().unwrap().as_bytes().unwrap())
+        .unwrap()
+        .to_string();
+      self.request_bodies.lock().unwrap().push(body_str);
+      // You can mock the actual response as per your need
+      Ok(Response::default())
+    }
+  }
+
+  #[test]
+  fn test_group_requests_by_url() {
+    let url1 = Url::parse("http://example1.com").unwrap();
+    let url2 = Url::parse("http://example2.com").unwrap();
+
+    let mut request1 = reqwest::Request::new(reqwest::Method::GET, url1.clone());
+    request1.body_mut().replace(reqwest::Body::from("a".to_string()));
+    let mut request2 = reqwest::Request::new(reqwest::Method::GET, url1.clone());
+    request2.body_mut().replace(reqwest::Body::from("b".to_string()));
+    let mut request3 = reqwest::Request::new(reqwest::Method::GET, url2.clone());
+    request3.body_mut().replace(reqwest::Body::from("c".to_string()));
+
+    let dl_req1 = DataLoaderRequest::new(request1, BTreeSet::new());
+    let dl_req2 = DataLoaderRequest::new(request2, BTreeSet::new());
+    let dl_req3 = DataLoaderRequest::new(request3, BTreeSet::new());
+
+    let grouped = group_requests_by_url(&[dl_req1, dl_req2, dl_req3]);
+
+    assert_eq!(grouped.keys().len(), 2);
+    assert_eq!(grouped.get(&url1.clone()).unwrap().len(), 2);
+    assert_eq!(grouped.get(&url2.clone()).unwrap().len(), 1);
+  }
+
+  #[test]
+  fn test_collect_request_bodies() {
+    let url = Url::parse("http://example.com").unwrap();
+    let mut request1 = reqwest::Request::new(reqwest::Method::GET, url.clone());
+    request1.body_mut().replace(reqwest::Body::from("a".to_string()));
+    let mut request2 = reqwest::Request::new(reqwest::Method::GET, url.clone());
+    request2.body_mut().replace(reqwest::Body::from("b".to_string()));
+    let mut request3 = reqwest::Request::new(reqwest::Method::GET, url.clone());
+    request3.body_mut().replace(reqwest::Body::from("c".to_string()));
+
+    let dl_req1 = DataLoaderRequest::new(request1, BTreeSet::new());
+    let dl_req2 = DataLoaderRequest::new(request2, BTreeSet::new());
+    let dl_req3 = DataLoaderRequest::new(request3, BTreeSet::new());
+
+    let body = collect_request_bodies(&[dl_req1, dl_req2, dl_req3]);
+    assert_eq!(body, "[a,b,c]");
+  }
+
+  #[tokio::test]
+  async fn test_load_function() {
+    let client =
+      MockHttpClient { request_count: Arc::new(AtomicUsize::new(0)), request_bodies: Arc::new(Mutex::new(Vec::new())) };
+    let loader = GraphqlDataLoader { client: client.clone() };
+    let loader = loader.to_data_loader(Batch::default().delay(1));
+
+    let url = Url::parse("http://example.com").unwrap();
+    let mut request = reqwest::Request::new(reqwest::Method::GET, url.clone());
+    request.body_mut().replace(reqwest::Body::from("a".to_string()));
+    let key = DataLoaderRequest::new(request, BTreeSet::new());
+    let futures: Vec<_> = (0..100).map(|_| loader.load_one(key.clone())).collect();
+    let _ = join_all(futures).await;
+    assert_eq!(
+      client.request_count.load(Ordering::SeqCst),
+      1,
+      "Only one request should be made for the same key"
+    );
+  }
+
+  #[tokio::test]
+  async fn test_load_many_function() {
+    let client =
+      MockHttpClient { request_count: Arc::new(AtomicUsize::new(0)), request_bodies: Arc::new(Mutex::new(Vec::new())) };
+    let loader = GraphqlDataLoader { client: client.clone() };
+    let loader = loader.to_data_loader(Batch::default().delay(1));
+
+    let url = Url::parse("http://example.com").unwrap();
+    let futures: Vec<_> = (1..10)
+      .map(|i| {
+        let mut request = reqwest::Request::new(reqwest::Method::GET, url.clone());
+        request.body_mut().replace(reqwest::Body::from(format!("a{}", i)));
+        let key = DataLoaderRequest::new(request, BTreeSet::new());
+        loader.load_one(key.clone())
+      })
+      .collect();
+    let _ = join_all(futures).await;
+    let mut request_body = client.request_bodies.lock().unwrap()[0].clone();
+    request_body.pop();
+    if !request_body.is_empty() {
+      request_body.remove(0);
+    }
+    let mut req_bodies = request_body.split(',').collect::<Vec<_>>();
+    req_bodies.sort();
+
+    assert_eq!(
+      client.request_count.load(Ordering::SeqCst),
+      1,
+      "Only one request should be made for the same url"
+    );
+    assert_eq!(
+      client.request_bodies.lock().unwrap().len(),
+      1,
+      "Only one request body should be present"
+    );
+    assert_eq!(
+      req_bodies,
+      ["a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"],
+      "Individual request bodies should be joined"
+    );
+  }
+}

--- a/src/graphqlsource/mod.rs
+++ b/src/graphqlsource/mod.rs
@@ -1,0 +1,142 @@
+mod graphql_data_loader;
+
+use std::collections::BTreeMap;
+
+use async_graphql::futures_util::future::join_all;
+pub use graphql_data_loader::*;
+use reqwest;
+
+const INTROSPECTION_QUERY: &str =
+  "{\"query\":\"query { __schema { queryType { name fields { name args { name type { name kind ofType {name }}} type { name kind ofType { name fields {name} } fields { name }}  } } } }\"}";
+
+// GraphQL introspection response types.
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct IntrospectionResult {
+  pub data: Option<IntrospectionData>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct IntrospectionData {
+  pub __schema: IntrospectionSchema,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct IntrospectionSchema {
+  #[serde(rename = "queryType")]
+  pub query_type: IntrospectionType,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct IntrospectionType {
+  pub fields: Vec<Field>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct Field {
+  pub name: String,
+  pub args: Option<Vec<Arg>>,
+  #[serde(rename = "type")]
+  pub type_: Option<Type_>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct Arg {
+  pub name: String,
+  #[serde(rename = "type")]
+  pub type_: Type_,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct Type_ {
+  pub name: Option<String>,
+  pub kind: Option<String>,
+  #[serde(rename = "ofType")]
+  pub of_type: Option<Box<Type_>>,
+  pub fields: Option<Vec<Field>>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TypeKind {
+  Scalar,
+  Object,
+  Interface,
+  Union,
+  Enum,
+  InputObject,
+  List,
+  NonNull,
+}
+
+pub async fn introspect(graphql_url: &String) -> Result<IntrospectionResult, Box<dyn std::error::Error>> {
+  let result = reqwest::Client::new()
+    .post(graphql_url)
+    .header("Content-Type", "application/json")
+    .body(INTROSPECTION_QUERY)
+    .send()
+    .await?
+    .json::<IntrospectionResult>()
+    .await?;
+  Ok(result)
+}
+
+pub async fn introspect_graphql_sources(graphql_urls: Vec<String>) -> BTreeMap<String, IntrospectionResult> {
+  let mut results = BTreeMap::new();
+  // let graphql_urls = graphql_urls.clone();
+  let introspect_futures = graphql_urls
+    .iter()
+    .map(|url| async move { (url.clone(), introspect(url).await.unwrap()) });
+  let joined = join_all(introspect_futures).await;
+  for (url, introspection_result) in joined {
+    results.insert(url.clone(), introspection_result.clone());
+  }
+  results
+}
+
+pub fn get_arg_type(
+  introspection_result: &IntrospectionResult,
+  query_name: &String,
+  arg_name: &String,
+) -> Option<String> {
+  match introspection_result {
+    IntrospectionResult {
+      data: Some(IntrospectionData { __schema: IntrospectionSchema { query_type: IntrospectionType { fields } } }),
+    } => {
+      let introspect_query_field = fields.iter().find(|field| field.name == *query_name);
+      match introspect_query_field {
+        Some(field) => match &field.args {
+          Some(args) => {
+            let introspect_arg = args.iter().find(|arg| arg.name == *arg_name);
+            match introspect_arg {
+              Some(arg) => match &arg.type_.name {
+                Some(name) => Some(name.clone()),
+                None => {
+                  let kind = arg.type_.kind.clone().unwrap_or_default();
+                  match &arg.type_.of_type {
+                    Some(type_) => match &type_.name {
+                      Some(name) => {
+                        if kind == "LIST" {
+                          Some(format!("[{}]", name))
+                        } else if kind == "NON_NULL" {
+                          Some(format!("{}!", name))
+                        } else {
+                          Some(name.clone())
+                        }
+                      }
+                      _ => None,
+                    },
+                    None => None,
+                  }
+                }
+              },
+              None => None,
+            }
+          }
+          None => None,
+        },
+        None => None,
+      }
+    }
+    _ => None,
+  }
+}

--- a/src/http/data_loader.rs
+++ b/src/http/data_loader.rs
@@ -91,7 +91,6 @@ impl<C: HttpClient + Send + Sync + 'static + Clone> Loader<DataLoaderRequest> fo
       for (key, value) in results {
         hashmap.insert(key, value?);
       }
-
       Ok(hashmap)
     }
   }

--- a/src/http/data_loader_request.rs
+++ b/src/http/data_loader_request.rs
@@ -19,6 +19,15 @@ impl DataLoaderRequest {
 impl Hash for DataLoaderRequest {
   fn hash<H: Hasher>(&self, state: &mut H) {
     self.0.url().hash(state);
+    if let Some(body) = self.0.body() {
+      if let Some(bytes) = body.as_bytes() {
+        if let Ok(body_str) = std::str::from_utf8(bytes) {
+          if !body_str.is_empty() {
+            body_str.to_string().hash(state);
+          }
+        }
+      }
+    }
     for name in &self.1 {
       if let Some(value) = self.0.headers().get(name) {
         name.hash(state);
@@ -44,8 +53,10 @@ impl PartialEq for DataLoaderRequest {
 
 impl Clone for DataLoaderRequest {
   fn clone(&self) -> Self {
-    let mut req = reqwest::Request::new(reqwest::Method::GET, self.0.url().clone());
-    req.headers_mut().extend(self.0.headers().clone());
+    let req = self.0.try_clone().unwrap();
+    // let mut req = reqwest::Request::new(reqwest::Method::GET, self.0.url().clone());
+    // req.headers_mut().extend(self.0.headers().clone());
+
     DataLoaderRequest(req, self.1.clone())
   }
 }

--- a/src/http/server_context.rs
+++ b/src/http/server_context.rs
@@ -4,6 +4,7 @@ use async_graphql::dynamic;
 use derive_setters::Setters;
 
 use crate::blueprint::{Blueprint, Definition};
+use crate::graphqlsource::GraphqlDataLoader;
 use crate::http::{DefaultHttpClient, HttpDataLoader};
 use crate::lambda::{Expression, Operation};
 
@@ -26,6 +27,15 @@ fn assign_data_loaders(blueprint: &mut Blueprint, http_client: DefaultHttpClient
             group_by.clone(),
             Some(Arc::new(data_loader)),
           )));
+        }
+        if let Some(Expression::Unsafe(Operation::GraphQLEndpoint(req_template, field_name, _))) = &mut field.resolver {
+          let graphql_data_loader = GraphqlDataLoader::new(http_client.clone())
+            .to_data_loader(blueprint.upstream.batch.clone().unwrap_or_default());
+          field.resolver = Some(Expression::Unsafe(Operation::GraphQLEndpoint(
+            req_template.clone(),
+            field_name.clone(),
+            Some(Arc::new(graphql_data_loader)),
+          )))
         }
       }
     }

--- a/src/lambda/lambda.rs
+++ b/src/lambda/lambda.rs
@@ -47,6 +47,14 @@ impl Lambda<serde_json::Value> {
   pub fn from_request_template(req_template: RequestTemplate) -> Lambda<serde_json::Value> {
     Lambda::new(Expression::Unsafe(Operation::Endpoint(req_template, None, None)))
   }
+
+  pub fn from_graphql_request_template(req_template: RequestTemplate, field_name: String) -> Lambda<serde_json::Value> {
+    Lambda::new(Expression::Unsafe(Operation::GraphQLEndpoint(
+      req_template,
+      field_name,
+      None,
+    )))
+  }
 }
 
 impl<A> From<A> for Lambda<A>

--- a/src/lambda/mod.rs
+++ b/src/lambda/mod.rs
@@ -3,7 +3,7 @@ mod expression;
 mod lambda;
 mod resolver_context_like;
 
-pub use evaluation_context::EvaluationContext;
+pub use evaluation_context::{get_path_value, EvaluationContext};
 pub use expression::{Expression, Operation};
 pub use lambda::Lambda;
 pub use resolver_context_like::{EmptyResolverContext, ResolverContextLike};

--- a/src/lambda/resolver_context_like.rs
+++ b/src/lambda/resolver_context_like.rs
@@ -1,3 +1,4 @@
+use async_graphql::context::SelectionField;
 use async_graphql::dynamic::ResolverContext;
 use async_graphql::{Name, Value};
 use indexmap::IndexMap;
@@ -5,6 +6,7 @@ use indexmap::IndexMap;
 pub trait ResolverContextLike<'a> {
   fn value(&'a self) -> Option<&'a Value>;
   fn args(&'a self) -> Option<&'a IndexMap<Name, Value>>;
+  fn field(&'a self) -> Option<SelectionField>;
 }
 
 pub struct EmptyResolverContext;
@@ -17,6 +19,10 @@ impl<'a> ResolverContextLike<'a> for EmptyResolverContext {
   fn args(&'a self) -> Option<&'a IndexMap<Name, Value>> {
     None
   }
+
+  fn field(&'a self) -> Option<SelectionField> {
+    None
+  }
 }
 
 impl<'a> ResolverContextLike<'a> for ResolverContext<'a> {
@@ -26,5 +32,9 @@ impl<'a> ResolverContextLike<'a> for ResolverContext<'a> {
 
   fn args(&'a self) -> Option<&'a IndexMap<Name, Value>> {
     Some(self.args.as_index_map())
+  }
+
+  fn field(&'a self) -> Option<SelectionField> {
+    Some(self.ctx.field())
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod directive;
 pub mod document;
 pub mod endpoint;
+pub mod graphqlsource;
 pub mod has_headers;
 pub mod http;
 #[cfg(feature = "unsafe-js")]

--- a/src/path_string.rs
+++ b/src/path_string.rs
@@ -44,6 +44,7 @@ impl<'a, Ctx: ResolverContextLike<'a>> PathString for EvaluationContext<'a, Ctx>
       "args" => convert_value(ctx.arg(tail)?),
       "headers" => ctx.header(tail[0].as_ref()).map(|v| v.into()),
       "vars" => ctx.var(tail[0].as_ref()).map(|v| v.into()),
+      "field" => Some(Cow::Owned(ctx.field(tail[0].as_ref()))),
       _ => None,
     })
   }

--- a/tests/data/upstream-introspection-result.json
+++ b/tests/data/upstream-introspection-result.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query",
+        "fields": [
+          {
+            "name": "user",
+            "args": [
+              {
+                "name": "id",
+                "type": {
+                  "name": "Int",
+                  "kind": "SCALAR",
+                  "ofType": null
+                }
+              }
+            ],
+            "type": {
+              "name": "User",
+              "kind": "OBJECT",
+              "ofType": null,
+              "fields": [
+                {
+                  "name": "email"
+                },
+                {
+                  "name": "id"
+                },
+                {
+                  "name": "name"
+                },
+                {
+                  "name": "phone"
+                },
+                {
+                  "name": "username"
+                },
+                {
+                  "name": "website"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/graphql/errors/test-graphqlsource-argtype.graphql
+++ b/tests/graphql/errors/test-graphqlsource-argtype.graphql
@@ -1,0 +1,26 @@
+#> server-sdl
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Post {
+  id: Int!
+  user: User
+    @graphql(
+      baseURL: "http://localhost:8000/graphql"
+      query: {args: [{key: "pid", value: "{{value.userId}}"}], name: "user"}
+    )
+}
+
+type Query {
+  post(id: Int): Post @http(path: "/posts/{{args.id}}")
+}
+
+type User {
+  id: Int
+  name: String
+}
+
+#> client-sdl
+type Failure
+  @error(message: "Could not find argument type for pid from introspection", trace: ["Post", "user", "@graphql"])

--- a/tests/graphql/test-graphqlsource.graphql
+++ b/tests/graphql/test-graphqlsource.graphql
@@ -1,0 +1,37 @@
+#> server-sdl
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Post {
+  id: Int!
+  user: User @graphql(baseURL: "http://localhost:8000/graphql", query: {args: [{key: "id", value: "{{value.userId}}"}], name: "user"})
+}
+
+type Query {
+  post(id: Int): Post @http(path: "/posts/{{args.id}}")
+}
+
+type User {
+  id: Int
+  name: String
+}
+
+#> client-sdl
+type Post {
+  id: Int!
+  user: User
+}
+
+type Query {
+  post(id: Int): Post
+}
+
+type User {
+  id: Int
+  name: String
+}
+
+schema {
+  query: Query
+}

--- a/tests/graphql_datasource_spec.rs
+++ b/tests/graphql_datasource_spec.rs
@@ -1,0 +1,58 @@
+mod integration_tests {
+  use serde::{Deserialize, Serialize};
+
+  async fn initiate_test_server(mock_schema_path: String) -> &'static str {
+    let config = tailcall::config::Config::from_file_paths([mock_schema_path].iter())
+      .await
+      .unwrap();
+    tailcall::http::start_server(config)
+      .await
+      .expect("Server failed to start");
+    "Success"
+  }
+
+  #[derive(Serialize, Deserialize, Debug)]
+  struct Resp {
+    pub data: Data,
+  }
+
+  #[derive(Serialize, Deserialize, Debug)]
+  struct Data {
+    pub post: Post,
+  }
+
+  #[derive(Serialize, Deserialize, Debug)]
+  struct Post {
+    pub title: String,
+    pub user: User,
+  }
+
+  #[derive(Serialize, Deserialize, Debug)]
+  struct User {
+    pub name: String,
+    pub username: String,
+  }
+
+  #[tokio::test]
+  async fn test_graphql_datasource() {
+    let upstream_schema_path = "tests/graphql_mock/graphql-datasource/upstream.graphql";
+    let composed_schema_path = "tests/graphql_mock/graphql-datasource/composed.graphql";
+
+    tokio::spawn(initiate_test_server(upstream_schema_path.into()));
+    tokio::spawn(initiate_test_server(composed_schema_path.into()));
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;
+
+    let http_client = reqwest::Client::new();
+    let query_data = "{\"query\":\"query { post(id: 1) { title user { name username } } }\"}";
+
+    let api_request = http_client
+      .post("http://localhost:8001/graphql")
+      .header("Content-Type", "application/json")
+      .body(query_data);
+
+    let response = api_request.send().await.expect("Failed to send request");
+    let json = response.json::<Resp>().await.unwrap();
+    assert_eq!(json.data.post.user.name, "Leanne Graham");
+  }
+}

--- a/tests/graphql_mock/graphql-datasource/composed.graphql
+++ b/tests/graphql_mock/graphql-datasource/composed.graphql
@@ -1,0 +1,30 @@
+schema
+  @server(port: 8001, enableGraphiql: "/graphiql", enableQueryValidation: false, hostname: "0.0.0.0")
+  @upstream(baseURL: "http://jsonplaceholder.typicode.com", enableHttpCache: true) {
+  query: Query
+}
+
+type Query {
+  posts: [Post] @http(path: "/posts?id=1")
+  post(id: Int!): Post @http(baseURL: "http://jsonplaceholder.typicode.com", path: "/posts/{{args.id}}")
+}
+
+type Post {
+  id: Int!
+  title: String!
+  body: String!
+  user: User
+    @graphql(
+      baseURL: "http://localhost:8000/graphql"
+      query: {name: "user", args: [{key: "id", value: "{{value.userId}}"}]}
+    )
+}
+
+type User {
+  id: Int!
+  name(id: Int): String!
+  username: String!
+  email: String!
+  phone: String
+  website: String
+}

--- a/tests/graphql_mock/graphql-datasource/upstream.graphql
+++ b/tests/graphql_mock/graphql-datasource/upstream.graphql
@@ -1,0 +1,18 @@
+schema
+  @server(port: 8000, enableGraphiql: "/graphiql", enableQueryValidation: false, hostname: "0.0.0.0")
+  @upstream(baseURL: "http://jsonplaceholder.typicode.com", enableHttpCache: true) {
+  query: Query
+}
+
+type Query {
+  user(id: Int): User @http(path: "/users/{{args.id}}")
+}
+
+type User {
+  id: Int!
+  name(id: Int): String!
+  username: String!
+  email: String!
+  phone: String
+  website: String
+}


### PR DESCRIPTION
**Summary:**  
Adds a `@graphql` directive (similar to `@http`) that allows composition of data from a graphql source.

**Issue Reference(s):**  
https://github.com/tailcallhq/tailcall/issues/461

**Build & Testing:**
An example end to end test is in `tests/graphql_datasource_spec.rs`

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.

TODO:
- Use batching for graphql requests.
- Add documentation on the website for the `@graphql` directive.
