### PR TITLE
feat: push docker image to ghcr.io

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,9 +1,5 @@
 name: GHCR Docker Image
 
-# Configures this workflow to run every time a change is pushed to the branch called `main`.
-on:
-  push:
-    branches: ['feat/docker']
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUBTOKEN }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract Metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,58 @@
+name: GHCR Docker Image
+
+# Configures this workflow to run every time a change is pushed to the branch called `main`.
+on:
+  push:
+    branches: ['feat/docker']
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'v0.13.0'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/tc-server
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract Metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and Push the Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract Metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,16 +1,15 @@
 name: GHCR Docker Image
-
 on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
-      - 'v0.13.0'
+      - "main"
+      - "v0.13.0"
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     branches:
-      - 'main'
+      - "main"
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -25,7 +24,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # 
+      #
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract Metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
**Summary:**  
_Build and push a Docker image to GHCR.io._

**Issue Reference(s):**  
Fixes #502. Please also see https://github.com/tailcallhq/tailcallhq.github.io/pull/22 to update the [docs](https://tailcall.run/docs/guides/installation/#docker) where the Docker image is used.

When you push a new tag, say v0.13.0, the action will apply the tags `v0.13.0` and `latest` to it. Please refer to the [documentation](https://github.com/docker/metadata-action#basic).

### Below are examples from my account 
I tested using my account so it is published at`ayewo/tailcall/tc-server:v0.13.0` but once merged, it will be published at `tailcallhq/tailcall/tc-server:v0.13.0`.
The published package:
* https://github.com/ayewo/tailcall/pkgs/container/tailcall%2Ftc-server/138387740?tag=v0.13.0
The successful job run:
* https://github.com/ayewo/tailcall/actions/runs/6552618536/job/17796304111
 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh` to address and fix linting issues.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.

/claim #502 