### PR TITLE
chore: run ci deploy step only on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,21 +88,6 @@ jobs:
       - name: Run Lint Script
         run: ./lint.sh --mode=check
 
-  deploy:
-    name: Deploy App
-    runs-on: ubuntu-latest
-    needs: [test, format, check_if_build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.check_if_build.outputs.check_if_build == 'true')
-    concurrency:
-      group: deploy-job
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
   draft_release:
     name: Draft Release
     if: (github.event_name == 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Deploy & Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Deploy App
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-job
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
**Summary:**  
We create a separate github action which runs only after a release is published. We also modify the original `ci` github action to remove the `deploy` step so we don't deploy on push to main

**Issue Reference(s):**  
Fixes #490 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
