### PR TITLE
rename binary to tailcall & fix libc detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The below file is a standard `.graphQL` file, with a few additions such as `@ser
 Now, run the following command to start the server with the full path to the jsonplaceholder.graphql file that you created above.
 
 ```bash
-tc start ./jsonplaceholder.graphql
+tailcall start ./jsonplaceholder.graphql
 ```
 
 Head out to [docs] to learn about other powerful tailcall features.

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ chmod +x "$INSTALL_DIR/tailcall-${OS}-${ARCH}"
 
 # Create symlinks in ~/.tailcall/bin
 mkdir -p "$HOME/.tailcall/bin"
-ln -sf "$INSTALL_DIR/tailcall-${OS}-${ARCH}" "$HOME/.tailcall/bin/tc"
+ln -sf "$INSTALL_DIR/tailcall-${OS}-${ARCH}" "$HOME/.tailcall/bin/tailcall"
 
 # Determine which shell the user is running and which profile file to update
 if [[ "$SHELL" == *"zsh"* ]]; then

--- a/npm/gen.ts
+++ b/npm/gen.ts
@@ -46,7 +46,7 @@ async function genPlatformPackage() {
     const binPath = `${packagePath}/bin`
 
     const targetPath = ext ? `../target/${target}/release/tailcall${ext}` : `../target/${target}/release/tailcall`
-    const tcPath = ext ? `${binPath}/tc${ext}` : `${binPath}/tc`
+    const tcPath = ext ? `${binPath}/tailcall${ext}` : `${binPath}/tailcall`
     const packageJsonPath = `${packagePath}/package.json`
     const readmePath = "../README.md"
 

--- a/npm/post-install.js
+++ b/npm/post-install.js
@@ -1,5 +1,6 @@
 // @ts-check
-import { family, GLIBC, MUSL } from "detect-libc"
+// @ts-ignore
+import { familySync, GLIBC, MUSL } from "detect-libc"
 import { exec } from 'child_process'
 import util from 'util'
 
@@ -7,11 +8,7 @@ const execa = util.promisify(exec)
 const platform = process.platform
 const arch = process.arch
 
-let libcFamily
-family().then((fam) => {
-  libcFamily = fam
-})
-
+const libcFamily = familySync()
 let libc
 if (platform === "win32") {
   libc = "-msvc"

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -12,7 +12,7 @@ const ABOUT: &str = r"
 \__/\__,_/_/_/\___/\__,_/_/_/";
 
 #[derive(Parser)]
-#[command(name ="tc",author, version = VERSION, about, long_about = Some(ABOUT))]
+#[command(name ="tailcall",author, version = VERSION, about, long_about = Some(ABOUT))]
 pub struct Cli {
   #[command(subcommand)]
   pub command: Command,


### PR DESCRIPTION
- Changed `libc` detection to use synchronous call instead of async
- Renamed binary to `tailcall` from `tc` as it clashes with built in utility with the same name on linux https://man7.org/linux/man-pages/man8/tc.8.html


/closes #628