### PR TITLE
refactor: remove unused library http-cache-semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,6 @@ checksum = "7aec9f678bca3f4a15194b980f20ed9bfe0dd38e8d298c65c559a93dfbd6380a"
 dependencies = [
  "http",
  "http-serde",
- "reqwest",
  "serde",
  "time",
 ]
@@ -3063,7 +3062,6 @@ dependencies = [
  "env_logger",
  "exitcode",
  "http-cache-reqwest",
- "http-cache-semantics",
  "httpmock",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ path = "src/main.rs"
 anyhow = "1.0.75"
 derive_setters = "0.1.6"
 thiserror = "1.0.50"
-http-cache-semantics = { version = "1.0.2", default-features = false, features = [
-   "reqwest"
-] }
 mimalloc = { version = "0.1.39", default-features = false }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use derive_setters::Setters;
-use http_cache_semantics::ResponseLike;
 
 #[derive(Clone, Debug, Default, Setters)]
 pub struct Response {
@@ -16,15 +15,5 @@ impl Response {
     let body = resp.bytes().await?;
     let json = serde_json::from_slice(&body)?;
     Ok(Response { status, headers, body: json })
-  }
-}
-
-impl ResponseLike for Response {
-  fn status(&self) -> reqwest::StatusCode {
-    self.status
-  }
-
-  fn headers(&self) -> &reqwest::header::HeaderMap {
-    &self.headers
   }
 }


### PR DESCRIPTION
**Summary:**  
The dep is not used in the project and can be removed

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have performed a self-review of my own code.
