### PR TITLE
test: add server start

### DIFF
--- a/tests/http/config/server-start.graphql
+++ b/tests/http/config/server-start.graphql
@@ -1,0 +1,7 @@
+schema @server(port: 8000) {
+  query: Query
+}
+
+type Query {
+  greet: String @const(data: "Hello World!")
+}

--- a/tests/http/server-start.yml
+++ b/tests/http/server-start.yml
@@ -1,0 +1,25 @@
+config: !file tests/http/config/server-start.graphql
+name: Server Start Test
+repeat: 100
+mock:
+  - request:
+      url: http://localhost:8000/graphql
+      method: POST
+      body:
+        query: query { greet }
+    response:
+      status: 200
+      body:
+        data:
+          greet: "Hello World!"
+assert:
+  - request:
+      method: POST
+      url: http://localhost:8000/graphql
+      body:
+        query: query { greet }
+    response:
+      status: 200
+      body:
+        data:
+          greet: "Hello World!"


### PR DESCRIPTION
Adds test for server start with the spec below:
```
Starts a GraphQL server on port 8000.
Make 100 requests to the server.
Assert the shape of the response received.
```

**Issue Reference(s):**  
Fixes #687

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

<img width="1009" alt="image" src="https://github.com/tailcallhq/tailcall/assets/62795688/2aedd6b6-0619-4e7c-85e6-d638e5482328">

/claim #687