### PR TITLE
Issue with `http_spec` Configuration: Tests Panic Despite `fail` Annotation

### DIFF
--- a/tests/http_spec.rs
+++ b/tests/http_spec.rs
@@ -1,10 +1,11 @@
 extern crate core;
 
 use std::collections::BTreeMap;
-use std::fs;
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{Arc, Once};
+use std::{fs, panic};
 
 use anyhow::{anyhow, Context};
 use async_graphql_value::ConstValue;
@@ -229,13 +230,22 @@ async fn assert_downstream(spec: HttpSpec) {
     if let Some(Annotation::Fail) = spec.runner {
       let response = run(spec.clone(), &assertion).await.unwrap();
       let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-      assert_eq!(body, serde_json::to_string(&assertion.response.0.body).unwrap());
-      log::error!("{} {} ... failed", spec.name, spec.path.display());
-      panic!(
-        "Expected spec: {} {} to fail but it passed",
-        spec.name,
-        spec.path.display()
-      );
+      let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        assert_eq!(body, serde_json::to_string(&assertion.response.0.body).unwrap());
+      }));
+
+      match result {
+        Ok(_) => {
+          panic!(
+            "Expected spec: {} {} to fail but it passed",
+            spec.name,
+            spec.path.display()
+          );
+        }
+        Err(_) => {
+          log::error!("{} {} ... failed", spec.name, spec.path.display());
+        }
+      }
     } else {
       let response = run(spec.clone(), &assertion)
         .await


### PR DESCRIPTION
**Summary:**  
### Description

I've encountered a behavior inconsistency in the `http_spec` configuration concerning the handling of assertions when the `fail` annotation is used. According to the current functionality, the tests are expected to pass when the underlying assertions fail, and they should also fail if the assertions unexpectedly pass. However, I'm observing that the tests are panicking in scenarios where they should ideally pass while using `fail` annotation.

### Expected Behavior

With the `fail` annotation in the `http_spec` configuration, the expected behavior should be as follows:

* **On Assertion Failure:** The test should pass. This aligns with the intent of the `fail` annotation, where assertion failures are anticipated.
* **On Assertion Success:** If the assertion unexpectedly passes, the test should also fail. 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
