### PR TITLE
standardises the check/start commands to use the same functions

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -6,11 +6,8 @@ use super::http_1::start_http_1;
 use super::http_2::start_http_2;
 use super::server_config::ServerConfig;
 use crate::blueprint::{Blueprint, Http};
-use crate::cli::CLIError;
-use crate::config::Config;
 
-pub async fn start_server(config: Config) -> Result<()> {
-  let blueprint = Blueprint::try_from(&config).map_err(CLIError::from)?;
+pub async fn start_server(blueprint: Blueprint) -> Result<()> {
   let server_config = Arc::new(ServerConfig::new(blueprint.clone()));
 
   match blueprint.server.http.clone() {


### PR DESCRIPTION
**Summary:**  
Following on from the other simplification PR #701 , this has check and start go through the same function calls so there's a smaller chance of split when refactoring changes in the future.

**Issue Reference(s):**  
None, just minor cleanup

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
