### PR TITLE
add types implementing interface to  dependencies

### DIFF
--- a/src/blueprint/compress.rs
+++ b/src/blueprint/compress.rs
@@ -57,6 +57,13 @@ fn build_dependency_graph(blueprint: &Blueprint) -> HashMap<&str, Vec<&str>> {
       }
       Definition::InterfaceTypeDefinition(def) => {
         dependencies.extend(def.fields.iter().map(|field| field.of_type.name()));
+        for def_inner in &blueprint.definitions {
+          if let Definition::ObjectTypeDefinition(def_inner) = def_inner {
+            if def_inner.implements.contains(&def.name) {
+              dependencies.push(&def_inner.name);
+            }
+          }
+        }
       }
       Definition::InputObjectTypeDefinition(def) => {
         dependencies.extend(def.fields.iter().map(|field| field.of_type.name()));

--- a/tests/graphql/test-interface-result.graphql
+++ b/tests/graphql/test-interface-result.graphql
@@ -1,0 +1,35 @@
+#> server-sdl
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+interface IA {
+  a: String
+}
+
+type B implements IA {
+  a: String
+  b: String
+}
+
+type Query {
+  bar: IA @http(path: "/user")
+}
+
+#> client-sdl
+type B implements IA {
+  a: String
+  b: String
+}
+
+interface IA {
+  a: String
+}
+
+type Query {
+  bar: IA
+}
+
+schema {
+  query: Query
+}


### PR DESCRIPTION
**Summary:**  
Prevent types implementing referenced interfaces, but not directly referenced in the schema, from getting dropped during compress

**Issue Reference(s):**  
Fixes #708 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have performed a self-review of my own code.
