### PR TITLE
Feature: open playground in the browser automatically if enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ dependencies = [
  "slab",
  "tracing",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -379,7 +379,7 @@ dependencies = [
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
  "rustix 0.38.25",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -397,7 +397,7 @@ dependencies = [
  "rustix 0.38.25",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -657,6 +657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,7 +677,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -755,7 +761,17 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -940,7 +956,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1092,7 +1108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1437,7 +1453,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1687,7 +1703,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1704,7 +1720,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix 0.38.25",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1748,6 +1764,28 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
@@ -1918,6 +1956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,7 +2037,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2055,6 +2102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2149,15 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2163,7 +2225,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2326,7 +2388,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2340,7 +2402,7 @@ dependencies = [
  "pin-project-lite",
  "rustix 0.38.25",
  "tracing",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2464,6 +2526,12 @@ checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
@@ -2613,7 +2681,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2642,7 +2710,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2655,7 +2723,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.11",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2728,7 +2796,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2966,7 +3034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3119,6 +3187,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+ "webbrowser",
 ]
 
 [[package]]
@@ -3140,7 +3209,7 @@ dependencies = [
  "fastrand 2.0.1",
  "redox_syscall",
  "rustix 0.38.25",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3262,7 +3331,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3614,6 +3683,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b2391658b02c27719fc5a0a73d6e696285138e8b12fba9d4baa70451023c71"
+dependencies = [
+ "core-foundation",
+ "home",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc",
+ "raw-window-handle",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,7 +3754,16 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3677,7 +3772,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3686,14 +3796,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3703,9 +3819,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3715,9 +3843,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3727,9 +3867,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3753,7 +3905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ futures-channel = { version = "0.3.29" }
 futures-timer = { version = "3.0.2" }
 futures-util = { version = "0.3.29" }
 lru = { version = "0.12.1" }
-webbrowser = "0.8.12"
+webbrowser = { version = "0.8.12", features = ["hardened", "disable-wsl"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ futures-channel = { version = "0.3.29" }
 futures-timer = { version = "3.0.2" }
 futures-util = { version = "0.3.29" }
 lru = { version = "0.12.1" }
+webbrowser = "0.8.12"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/http/http_1.rs
+++ b/src/http/http_1.rs
@@ -4,7 +4,7 @@ use hyper::service::{make_service_fn, service_fn};
 use tokio::sync::oneshot;
 
 use super::server_config::ServerConfig;
-use super::{handle_request, log_launch};
+use super::{handle_request, log_launch_and_open_browser};
 use crate::async_graphql_hyper::{GraphQLBatchRequest, GraphQLRequest};
 use crate::cli::CLIError;
 
@@ -30,7 +30,7 @@ pub async fn start_http_1(sc: Arc<ServerConfig>, server_up_sender: Option<onesho
   let builder = hyper::Server::try_bind(&addr)
     .map_err(CLIError::from)?
     .http1_pipeline_flush(sc.server_context.blueprint.server.pipeline_flush);
-  log_launch(sc.as_ref());
+  log_launch_and_open_browser(sc.as_ref());
 
   if let Some(sender) = server_up_sender {
     sender.send(()).or(Err(anyhow::anyhow!("Failed to send message")))?;

--- a/src/http/http_2.rs
+++ b/src/http/http_2.rs
@@ -12,7 +12,7 @@ use tokio::fs::File;
 use tokio::sync::oneshot;
 
 use super::server_config::ServerConfig;
-use super::{handle_request, log_launch};
+use super::{handle_request, log_launch_and_open_browser};
 use crate::async_graphql_hyper::{GraphQLBatchRequest, GraphQLRequest};
 use crate::cli::CLIError;
 
@@ -81,7 +81,7 @@ pub async fn start_http_2(
 
   let builder = Server::builder(acceptor).http2_only(true);
 
-  log_launch(sc.as_ref());
+  log_launch_and_open_browser(sc.as_ref());
 
   if let Some(sender) = server_up_sender {
     sender.send(()).or(Err(anyhow::anyhow!("Failed to send message")))?;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -77,15 +77,9 @@ fn log_launch_and_open_browser(sc: &ServerConfig) {
     let url = sc.graphiql_url();
     log::info!("🌍 Playground: {}", url);
 
-    open_browser(url);
-  }
-}
-
-fn open_browser(graphiql_url: String) {
-  let opened = webbrowser::open_browser(webbrowser::Browser::Default, graphiql_url.as_str());
-
-  if opened.is_ok() {
-    log::info!("{} opened on your browser", graphiql_url);
+    if let Ok(_) = webbrowser::open(url.as_str()) {
+      log::info!("{} opened on your browser", url);
+    }
   }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -77,9 +77,7 @@ fn log_launch_and_open_browser(sc: &ServerConfig) {
     let url = sc.graphiql_url();
     log::info!("🌍 Playground: {}", url);
 
-    if webbrowser::open(url.as_str()).is_ok() {
-      log::info!("{} opened on your browser", url);
-    }
+    let _ = webbrowser::open(url.as_str());
   }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -88,7 +88,7 @@ fn open_browser(graphiql_url: String) {
 
   match opened {
     Ok(_) => log::info!("{} opened on your browser", graphiql_url),
-    Err(e) => log::error!("Failed to open default browser, error: {}", e)
+    Err(e) => log::error!("Failed to open default browser, error: {}", e),
   };
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -88,11 +88,7 @@ fn open_browser(graphiql_url: String) {
 
   match opened {
     Ok(_) => log::info!("{} opened on your browser", graphiql_url),
-    Err(e) => {
-      println!("error: {:?}", e);
-
-      log::error!("Failed to open default browser, error: {}", e);
-    }
+    Err(e) => log::error!("Failed to open default browser, error: {}", e)
   };
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -77,7 +77,7 @@ fn log_launch_and_open_browser(sc: &ServerConfig) {
     let url = sc.graphiql_url();
     log::info!("🌍 Playground: {}", url);
 
-    if let Ok(_) = webbrowser::open(url.as_str()) {
+    if webbrowser::open(url.as_str()).is_ok() {
       log::info!("{} opened on your browser", url);
     }
   }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -70,11 +70,16 @@ pub fn min_ttl<'a>(res_vec: impl Iterator<Item = &'a Response>) -> i32 {
   min
 }
 
-fn log_launch(sc: &ServerConfig) {
+fn log_launch_and_open_browser(sc: &ServerConfig) {
   let addr = sc.addr().to_string();
   log::info!("🚀 Tailcall launched at [{}] over {}", addr, sc.http_version());
   if sc.graphiql() {
-    log::info!("🌍 Playground: {}", sc.graphiql_url());
+    let url = sc.graphiql_url();
+    log::info!("🌍 Playground: {}", url);
+
+    log::info!("🌍 Opening playground on your default browser");
+
+    open_browser(url);
   }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -77,8 +77,6 @@ fn log_launch_and_open_browser(sc: &ServerConfig) {
     let url = sc.graphiql_url();
     log::info!("🌍 Playground: {}", url);
 
-    log::info!("🌍 Opening playground on your default browser");
-
     open_browser(url);
   }
 }
@@ -86,10 +84,9 @@ fn log_launch_and_open_browser(sc: &ServerConfig) {
 fn open_browser(graphiql_url: String) {
   let opened = webbrowser::open_browser(webbrowser::Browser::Default, graphiql_url.as_str());
 
-  match opened {
-    Ok(_) => log::info!("{} opened on your browser", graphiql_url),
-    Err(e) => log::error!("Failed to open default browser, error: {}", e),
-  };
+  if opened.is_ok() {
+    log::info!("{} opened on your browser", graphiql_url);
+  }
 }
 
 #[cfg(test)]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -78,6 +78,19 @@ fn log_launch(sc: &ServerConfig) {
   }
 }
 
+fn open_browser(graphiql_url: String) {
+  let opened = webbrowser::open_browser(webbrowser::Browser::Default, graphiql_url.as_str());
+
+  match opened {
+    Ok(_) => log::info!("{} opened on your browser", graphiql_url),
+    Err(e) => {
+      println!("error: {:?}", e);
+
+      log::error!("Failed to open default browser, error: {}", e);
+    }
+  };
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/tests/graphql/errors/test-hostname-faliure.graphql
+++ b/tests/graphql/errors/test-hostname-faliure.graphql
@@ -1,5 +1,5 @@
 #> server-sdl
-schema @server(graphiql: true, hostname: "abc") {
+schema @server(hostname: "abc") {
   query: Query
 }
 

--- a/tests/graphql/passed/test-batching-group-by.graphql
+++ b/tests/graphql/passed/test-batching-group-by.graphql
@@ -1,6 +1,6 @@
 #> server-sdl
 schema
-  @server(port: 8000, graphiql: true, queryValidation: false)
+  @server(port: 8000, queryValidation: false)
   @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true, batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/graphql/passed/test-batching.graphql
+++ b/tests/graphql/passed/test-batching.graphql
@@ -1,6 +1,6 @@
 #> server-sdl
 schema
-  @server(port: 8000, graphiql: true, queryValidation: false)
+  @server(port: 8000, queryValidation: false)
   @upstream(
     httpCache: true
     batch: {maxSize: 1000, delay: 0, headers: []}

--- a/tests/http/config/graphql-dataloader-batch-keys.graphql
+++ b/tests/http/config/graphql-dataloader-batch-keys.graphql
@@ -1,5 +1,5 @@
 schema
-  @server(port: 8001, graphiql: true, queryValidation: false, hostname: "0.0.0.0")
+  @server(port: 8001, queryValidation: false, hostname: "0.0.0.0")
   @upstream(baseURL: "http://upstream/graphql", httpCache: true, batch: {delay: 1}) {
   query: Query
 }

--- a/tests/server/config/server-start-http2.graphql
+++ b/tests/server/config/server-start-http2.graphql
@@ -5,7 +5,6 @@ schema
     hostname: "localhost"
     cert: "./tests/server/config/example.crt"
     key: "./tests/server/config/example.key"
-    graphiql: true
   ) {
   query: Query
 }

--- a/tests/server/config/server-start.graphql
+++ b/tests/server/config/server-start.graphql
@@ -1,4 +1,4 @@
-schema @server(port: 8800, graphiql: true) {
+schema @server(port: 8800) {
   query: Query
 }
 


### PR DESCRIPTION
- chore: install webbrowser
- chore: enable `hardened` and `disable-wsl` features
- feat: create a method to open browser
- feat: change `log_launch` to also open browser

**Summary:**  
This PR adds [webbrowser](https://github.com/amodm/webbrowser-rs) to open the default browser when the server starts.
I'm using [webbrowser](https://github.com/amodm/webbrowser-rs) instead [opener](https://github.com/Seeker14491/opener) for three main reasons:
- Option to turn off `file://` URLs, which is good for security (we only need to open `http://` and `https://`)
- Compatibility with multiple platforms
- According to them:
> **Browser guarantee** - This library guarantees that the browser is opened, even for local files - the only crate to make 
such guarantees at the time of this writing. Alternative libraries rely on existing system commands, which may lead to an editor being opened (instead of the browser) for local html files, leading to an inconsistent behaviour for users. 

**Issue Reference(s):**  
Fixes #735
/claim #735

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- ~[ ] I have added relevant unit & integration tests.~
I have not added tests, as it'd be too painful to ensure that the browser was opened with the expected URL, and this wouldn't have that high impact that pay the effort.
- [x] I have performed a self-review of my own code.
