### PR TITLE
ci: lint.sh scripts fail on warnings in fix mode

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -16,7 +16,14 @@ run_cargo_fmt() {
 run_cargo_clippy() {
     MODE=$1
     CMD="cargo +nightly clippy --all-targets --all-features"
-    [ "$MODE" == "check" ] || CMD="$CMD --fix --allow-staged --allow-dirty"
+    if [ "$MODE" == "fix" ]; then
+        # if mode is fix first run clippy with --fix flag as usual
+        $CMD --fix --allow-staged --allow-dirty
+    fi
+    # call anyway check command without --fix despite actual $MODE
+    # this is to show error as warnings similar to check mode
+    # since clippy won't fail on warnings when --fix and -D warnings are used together
+    # see https://github.com/rust-lang/rust-clippy/issues/11241
     CMD="$CMD -- -D warnings"
     $CMD
     return $?
@@ -25,9 +32,9 @@ run_cargo_clippy() {
 run_prettier() {
     MODE=$1
     if [ "$MODE" == "check" ]; then
-        prettier -c .prettierrc  --check "**/*.$FILE_TYPES"
+        prettier -c .prettierrc --check "**/*.$FILE_TYPES"
     else
-        prettier -c .prettierrc  --write "**/*.$FILE_TYPES"
+        prettier -c .prettierrc --write "**/*.$FILE_TYPES"
     fi
     return $?
 }


### PR DESCRIPTION
**Summary:**  
`bash lint.sh --mode=fix` wasn't failing when there were clippy warnings in the code, but `bash lint.sh --mode=check` was failing in that case. This pr will run clippy check after applied fix to fail the run in case there were clippy warnings. 


**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation website] accordingly.
- [x] I have performed a self-review of my own code.

[documentation website]: https://github.com/tailcallhq/tailcallhq.github.io
