### PR TITLE
feat: type checking for composition with `@graphQL` 

### DIFF
--- a/examples/composition-with-types.graphql
+++ b/examples/composition-with-types.graphql
@@ -1,0 +1,21 @@
+schema
+  @server(port: 8000, graphiql: true, hostname: "0.0.0.0")
+  @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true, query: UpstreamQuery) {
+  query: Query
+}
+
+type UpstreamQuery {
+  posts: [User]
+}
+
+type Query {
+  posts: [Post] @graphQL(name: "posts")
+}
+
+type User {
+  name: String!
+}
+
+type Post {
+  id: Int!
+}

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -25,7 +25,7 @@ pub struct Blueprint {
   pub upstream: Upstream,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Type {
   NamedType { name: String, non_null: bool },
   ListType { of_type: Box<Type>, non_null: bool },

--- a/src/blueprint/from_config/from_config.rs
+++ b/src/blueprint/from_config/from_config.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use super::{Server, TypeLike};
 use crate::blueprint::compress::compress;
 use crate::blueprint::*;
+use crate::blueprint::from_config::upstream;
 use crate::config::{Arg, Batch, Config, Field};
 use crate::json::JsonSchema;
 use crate::lambda::{Expression, Unsafe};
@@ -47,54 +48,59 @@ pub fn config_blueprint<'a>() -> TryFold<'a, Config, Blueprint, String> {
 }
 
 fn typecheck_definition(def: &Definition, blueprint: &Blueprint) -> Valid<(), String> {
-    let query_def = blueprint.definitions.iter().find(|d| d.name() == blueprint.schema.query);
-    match def {
-        Definition::ObjectTypeDefinition(ObjectTypeDefinition { name, fields, .. }) => {
-            if name != "Query" {
-                Valid::succeed(()) // TODO: handle other cases
-            } else {
-                fields.iter().fold(Valid::succeed(()), |acc, field| {
-                    let valid_field = if let Some(resolver) = &field.resolver {
-                        match resolver {
-                            Expression::Unsafe(Unsafe::GraphQLEndpoint { req_template, .. }) => {
-                                match query_def {
-                                     Some(Definition::ObjectTypeDefinition(ObjectTypeDefinition { fields, .. })) => {
-                                         if let Some(base_url) = &blueprint.upstream.base_url {
-                                             if base_url == &req_template.url {
-                                                 // this hits a user defined field
-                                                 if let Some(q) = fields.iter().find(|f| f.name == req_template.operation_name) {
-                                                     if q.of_type == field.of_type {
-                                                         Valid::succeed(())
-                                                     } else {
-                                                         Valid::from_validation_err(ValidationError::new(format!("Mismatched return type")))
-                                                     }
-                                                 } else {
-                                                     Valid::from_validation_err(ValidationError::new(format!("No GraphQL endpoint with name {}", req_template.operation_name)))
-                                                 }
-                                             } else {
-                                                 // this is an external call
-                                                 Valid::succeed(())
-                                             }
-                                         } else {
-                                             // no base url defined in upstream, this must be an
-                                             // external call
-                                             Valid::succeed(())
-                                         }
+    let maybe_upstream_query = &blueprint.upstream.query;
+    if let Some(upstream_query) = maybe_upstream_query {
+        let query_def = blueprint.definitions.iter().find(|d| d.name() == upstream_query);
+        match def {
+            Definition::ObjectTypeDefinition(ObjectTypeDefinition { name, fields, .. }) => {
+                if name != "Query" {
+                    Valid::succeed(()) // TODO: handle other cases
+                } else {
+                    fields.iter().fold(Valid::succeed(()), |acc, field| {
+                        let valid_field = if let Some(resolver) = &field.resolver {
+                            match resolver {
+                                Expression::Unsafe(Unsafe::GraphQLEndpoint { req_template, .. }) => {
+                                    match query_def {
+                                        Some(Definition::ObjectTypeDefinition(ObjectTypeDefinition { fields, .. })) => {
+                                            if let Some(base_url) = &blueprint.upstream.base_url {
+                                                if base_url == &req_template.url {
+                                                    // this hits a user defined field
+                                                    if let Some(q) = fields.iter().find(|f| f.name == req_template.operation_name) {
+                                                        if q.of_type == field.of_type {
+                                                            Valid::succeed(())
+                                                        } else {
+                                                            Valid::from_validation_err(ValidationError::new(format!("Mismatched return type")))
+                                                        }
+                                                    } else {
+                                                        Valid::from_validation_err(ValidationError::new(format!("No GraphQL endpoint with name {}", req_template.operation_name)))
+                                                    }
+                                                } else {
+                                                    // this is an external call
+                                                    Valid::succeed(())
+                                                }
+                                            } else {
+                                                // no base url defined in upstream, this must be an
+                                                // external call
+                                                Valid::succeed(())
+                                            }
+                                        }
+                                        None => Valid::from_validation_err(ValidationError::new(format!("No query object defined"))),
+                                        _ => Valid::succeed(())
                                     }
-                                    None => Valid::from_validation_err(ValidationError::new(format!("No query object defined"))),
-                                    _ => Valid::succeed(())
                                 }
+                                _ => Valid::succeed(()) // TODO
                             }
-                            _ => Valid::succeed(()) // TODO
-                        }
-                    } else {
-                        Valid::succeed(())
-                    };
-                    acc.and(valid_field)
-                })
+                        } else {
+                            Valid::succeed(())
+                        };
+                        acc.and(valid_field)
+                    })
+                }
             }
+            _ => Valid::succeed(()) // TODO: what should happen for other cases?
         }
-        _ => Valid::succeed(()) // TODO: what should happen for other cases?
+    } else {
+        Valid::from_validation_err(ValidationError::new(format!("No upstream schema defined")))
     }
 }
 

--- a/src/blueprint/from_config/from_config.rs
+++ b/src/blueprint/from_config/from_config.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, HashMap};
 use super::{Server, TypeLike};
 use crate::blueprint::compress::compress;
 use crate::blueprint::*;
-use crate::blueprint::from_config::upstream;
 use crate::config::{Arg, Batch, Config, Field};
 use crate::json::JsonSchema;
 use crate::lambda::{Expression, Unsafe};
@@ -31,11 +30,13 @@ pub fn config_blueprint<'a>() -> TryFold<'a, Config, Blueprint, String> {
   );
 
   let typecheck = TryFoldConfig::<Blueprint>::new(|_, blueprint| {
-      blueprint
-          .definitions
-          .iter()
-          .fold(Valid::succeed(()), |acc, def| acc.and(typecheck_definition(def, &blueprint)))
-          .map(|_| blueprint)
+    blueprint
+      .definitions
+      .iter()
+      .fold(Valid::succeed(()), |acc, def| {
+        acc.and(typecheck_definition(def, &blueprint))
+      })
+      .map(|_| blueprint)
   });
 
   server
@@ -48,60 +49,64 @@ pub fn config_blueprint<'a>() -> TryFold<'a, Config, Blueprint, String> {
 }
 
 fn typecheck_definition(def: &Definition, blueprint: &Blueprint) -> Valid<(), String> {
-    let maybe_upstream_query = &blueprint.upstream.query;
-    if let Some(upstream_query) = maybe_upstream_query {
-        let query_def = blueprint.definitions.iter().find(|d| d.name() == upstream_query);
-        match def {
-            Definition::ObjectTypeDefinition(ObjectTypeDefinition { name, fields, .. }) => {
-                if name != "Query" {
-                    Valid::succeed(()) // TODO: handle other cases
-                } else {
-                    fields.iter().fold(Valid::succeed(()), |acc, field| {
-                        let valid_field = if let Some(resolver) = &field.resolver {
-                            match resolver {
-                                Expression::Unsafe(Unsafe::GraphQLEndpoint { req_template, .. }) => {
-                                    match query_def {
-                                        Some(Definition::ObjectTypeDefinition(ObjectTypeDefinition { fields, .. })) => {
-                                            if let Some(base_url) = &blueprint.upstream.base_url {
-                                                if base_url == &req_template.url {
-                                                    // this hits a user defined field
-                                                    if let Some(q) = fields.iter().find(|f| f.name == req_template.operation_name) {
-                                                        if q.of_type == field.of_type {
-                                                            Valid::succeed(())
-                                                        } else {
-                                                            Valid::from_validation_err(ValidationError::new(format!("Mismatched return type")))
-                                                        }
-                                                    } else {
-                                                        Valid::from_validation_err(ValidationError::new(format!("No GraphQL endpoint with name {}", req_template.operation_name)))
-                                                    }
-                                                } else {
-                                                    // this is an external call
-                                                    Valid::succeed(())
-                                                }
-                                            } else {
-                                                // no base url defined in upstream, this must be an
-                                                // external call
-                                                Valid::succeed(())
-                                            }
-                                        }
-                                        None => Valid::from_validation_err(ValidationError::new(format!("No query object defined"))),
-                                        _ => Valid::succeed(())
-                                    }
-                                }
-                                _ => Valid::succeed(()) // TODO
+  let maybe_upstream_query = &blueprint.upstream.query;
+  if let Some(upstream_query) = maybe_upstream_query {
+    let query_def = blueprint.definitions.iter().find(|d| d.name() == upstream_query);
+    match def {
+      Definition::ObjectTypeDefinition(ObjectTypeDefinition { name, fields, .. }) => {
+        if name != "Query" {
+          Valid::succeed(()) // TODO: handle other cases
+        } else {
+          fields.iter().fold(Valid::succeed(()), |acc, field| {
+            let valid_field = if let Some(resolver) = &field.resolver {
+              match resolver {
+                Expression::Unsafe(Unsafe::GraphQLEndpoint { req_template, .. }) => {
+                  match query_def {
+                    Some(Definition::ObjectTypeDefinition(ObjectTypeDefinition { fields, .. })) => {
+                      if let Some(base_url) = &blueprint.upstream.base_url {
+                        if base_url == &req_template.url {
+                          // this hits a user defined field
+                          if let Some(q) = fields.iter().find(|f| f.name == req_template.operation_name) {
+                            if q.of_type == field.of_type {
+                              Valid::succeed(())
+                            } else {
+                              Valid::from_validation_err(ValidationError::new(format!("Mismatched return type")))
                             }
+                          } else {
+                            Valid::from_validation_err(ValidationError::new(format!(
+                              "No GraphQL endpoint with name {}",
+                              req_template.operation_name
+                            )))
+                          }
                         } else {
-                            Valid::succeed(())
-                        };
-                        acc.and(valid_field)
-                    })
+                          // this is an external call
+                          Valid::succeed(())
+                        }
+                      } else {
+                        // no base url defined in upstream, this must be an
+                        // external call
+                        Valid::succeed(())
+                      }
+                    }
+                    None => Valid::from_validation_err(ValidationError::new(format!("No query object defined"))),
+                    _ => Valid::succeed(()),
+                  }
                 }
-            }
-            _ => Valid::succeed(()) // TODO: what should happen for other cases?
+                _ => Valid::succeed(()), // TODO
+              }
+            } else {
+              Valid::succeed(())
+            };
+            acc.and(valid_field)
+          })
         }
-    } else {
-        Valid::from_validation_err(ValidationError::new(format!("No upstream schema defined")))
+      }
+      _ => Valid::succeed(()), // TODO: what should happen for other cases?
     }
+  } else {
+    log::warn!("No schema provided for upstream, skipping type check for @graphQL");
+    Valid::succeed(())
+  }
 }
 
 // Apply batching if any of the fields have a @http directive with groupBy field

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -180,6 +180,8 @@ pub struct Upstream {
   pub http_cache: Option<bool>,
   #[serde(default, skip_serializing_if = "is_default")]
   pub batch: Option<Batch>,
+  #[serde(default, skip_serializing_if = "is_default")]
+  pub query: Option<String>,
 }
 
 impl Upstream {
@@ -252,6 +254,7 @@ impl Upstream {
       batch.headers.extend(other.headers);
       batch
     });
+    self.query = other.query.or(self.query);
     self
   }
 }


### PR DESCRIPTION
**Summary:**  
Adds basic type-checking for `@graphQL` directives, given an upstream schema.

This directive fetches data and composes data from a given upstream endpoint, which is why we need a schema for what tailcall *receives* in addition to what tailcall *returns*. Upstream schema can be generated through an introspection query, but for this PR for now I ask the user to define it too. If a schema is not defined type-checking is skipped.

**Issue Reference(s):**  
Fixes #756 

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation website] accordingly.
- [ ] I have performed a self-review of my own code.

[documentation website]: https://github.com/tailcallhq/tailcallhq.github.io
