### PR TITLE
fix: Bug in {{args}} rendering

### DIFF
--- a/src/lambda/evaluation_context.rs
+++ b/src/lambda/evaluation_context.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use async_graphql::{Name, SelectionField, ServerError, Value};
@@ -52,6 +53,10 @@ impl<'a, Ctx: ResolverContextLike<'a>> EvaluationContext<'a, Ctx> {
     let vars = &self.req_ctx.server.vars;
 
     vars.get(key).map(|v| v.as_str())
+  }
+
+  pub fn vars(&self) -> &BTreeMap<String, String> {
+    &self.req_ctx.server.vars
   }
 
   pub fn add_error(&self, error: ServerError) {

--- a/tests/http/config/args-body.graphql
+++ b/tests/http/config/args-body.graphql
@@ -1,0 +1,12 @@
+schema @server(port: 8000, graphiql: true) @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  firstUser(id: Int, name: String): User @http(method: POST, path: "/users", body: "{{args}}")
+}
+
+type User {
+  id: Int
+  name: String
+}

--- a/tests/http/test-params-as-body.yml
+++ b/tests/http/test-params-as-body.yml
@@ -1,0 +1,28 @@
+---
+name: Http with args as body
+runner: fail
+config: !file tests/http/config/args-body.graphql
+
+mock:
+  - request:
+      url: http://jsonplaceholder.typicode.com/users
+      method: POST
+      body:
+        id: 1
+        name: foo
+    response:
+      body:
+        id: 1
+        name: foo
+
+assert:
+  - request:
+      method: POST
+      url: http://localhost:8080/graphql
+      body:
+        query: "{\n  firstUser(id: 1, name:\"foo\") {\n    id\n    name\n  }\n}"
+    response:
+      body:
+        data:
+          firstUser:
+            name: foo

--- a/tests/http/test-params-as-body.yml
+++ b/tests/http/test-params-as-body.yml
@@ -1,15 +1,12 @@
 ---
 name: Http with args as body
-runner: fail
 config: !file tests/http/config/args-body.graphql
 
 mock:
   - request:
       url: http://jsonplaceholder.typicode.com/users
       method: POST
-      body:
-        id: 1
-        name: foo
+      body: '{"id":1,"name":"foo"}'
     response:
       body:
         id: 1
@@ -25,4 +22,5 @@ assert:
       body:
         data:
           firstUser:
+            id: 1
             name: foo


### PR DESCRIPTION
**Summary:**  
Modifies `path_string` to handle path with length 1.

**Issue Reference(s):**  
Fixes #774

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation website] accordingly.
- [x] I have performed a self-review of my own code.

[documentation website]: https://github.com/tailcallhq/tailcallhq.github.io

/claim #774
/split @ologbonowiwi 30%