### PR TITLE
perf: improve performance of path_string impl for EvaluationContext

### DIFF
--- a/src/json/json_like.rs
+++ b/src/json/json_like.rs
@@ -156,7 +156,7 @@ impl JsonLike for async_graphql::Value {
           let index = token.as_ref().parse::<usize>().ok()?;
           seq.get(index)?
         }
-        ConstValue::Object(map) => map.get(&async_graphql::Name::new(token))?,
+        ConstValue::Object(map) => map.get(token.as_ref())?,
         _ => return None,
       };
     }

--- a/src/json/json_schema.rs
+++ b/src/json/json_schema.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use async_graphql::Name;
 use prost_reflect::{FieldDescriptor, Kind, MessageDescriptor};
 use serde::{Deserialize, Serialize};
 
@@ -63,14 +62,13 @@ impl JsonSchema {
         let field_schema_list: Vec<(&String, &JsonSchema)> = fields.iter().collect();
         match value {
           async_graphql::Value::Object(map) => Valid::from_iter(field_schema_list, |(name, schema)| {
-            let key = Name::new(name);
             if schema.is_required() {
-              if let Some(field_value) = map.get(&key) {
+              if let Some(field_value) = map.get::<str>(name.as_ref()) {
                 schema.validate(field_value).trace(name)
               } else {
                 Valid::fail("expected field to be non-nullable").trace(name)
               }
-            } else if let Some(field_value) = map.get(&key) {
+            } else if let Some(field_value) = map.get::<str>(name.as_ref()) {
               schema.validate(field_value).trace(name)
             } else {
               Valid::succeed(())

--- a/src/lambda/evaluation_context.rs
+++ b/src/lambda/evaluation_context.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use async_graphql::{Name, SelectionField, ServerError, Value};
+use async_graphql::{SelectionField, ServerError, Value};
 use derive_setters::Setters;
 use reqwest::header::HeaderMap;
 
@@ -118,12 +118,13 @@ fn format_selection_field_arguments(field: SelectionField) -> Cow<'static, str> 
   Cow::Owned(format!("({})", args))
 }
 
+// TODO: this is the same code as src/json/json_like.rs::get_path
 pub fn get_path_value<'a, T: AsRef<str>>(input: &'a Value, path: &[T]) -> Option<&'a Value> {
   let mut value = Some(input);
   for name in path {
     match value {
       Some(Value::Object(map)) => {
-        value = map.get(&Name::new(name));
+        value = map.get(name.as_ref());
       }
 
       Some(Value::List(list)) => {


### PR DESCRIPTION
**Summary:**  

Improve the performance of fn `get_path_value` for `EvaluationContext`

Based on findings found from flamegraph - instead of creating async_graphql::Name to resolve values from hashmap use &str explicitly.

Before that change:

![image](https://github.com/tailcallhq/tailcall/assets/8974488/b1da10e1-0b2f-46c2-9484-5352083f4e24)

wrk bench:
```
wrk -d 30 -t 8 -c 100 -s ci-benchmark/wrk.lua http://localhost:8000/graphql
   Running 30s test @ http://localhost:8000/graphql
     8 threads and 100 connections
     Thread Stats   Avg      Stdev     Max   +/- Stdev
       Latency     1.58ms    1.16ms  81.53ms   88.14%
       Req/Sec     7.71k     1.16k   16.50k    92.93%
     1871300 requests in 30.05s, 9.38GB read
     Socket errors: connect 0, read 0, write 0, timeout 384
   Requests/sec:  62269.78
   Transfer/sec:    319.61MB
   ```
   
After:

![image](https://github.com/tailcallhq/tailcall/assets/8974488/48068281-d1db-4d19-84a8-e5f82363b615)

wrk bench:
```
wrk -d 30 -t 8 -c 100 -s ci-benchmark/wrk.lua http://localhost:8000/graphql
Running 30s test @ http://localhost:8000/graphql
  8 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.45ms    1.77ms 135.45ms   98.19%
    Req/Sec     8.62k     0.92k   21.49k    88.55%
  2070644 requests in 32.95s, 10.38GB read
  Socket errors: connect 0, read 0, write 0, timeout 95
Requests/sec:  62841.25
Transfer/sec:    322.54MB
```

criterion benchmarks shows up to 40% improvements

<details>
<pre>
cargo bench --bench impl_path_string_for_evaluation_context -- --baseline init
        Compiling tailcall v0.1.0 (/home/nixos/Projects/tailcall/tailcall)
         Finished bench [optimized] target(s) in 1m 03s
          Running benches/impl_path_string_for_evaluation_context.rs (target/release/deps/impl_path_string_for_evaluation_context-a36c6ff205ffa7ff)
     Gnuplot not found, using plotters backend
     input/value.root        time:   [23.600 ns 23.792 ns 24.005 ns]
                             change: [-23.818% -23.138% -22.468%] (p = 0.00 < 0.05)
                             Performance has improved.
     Found 4 outliers among 100 measurements (4.00%)
       2 (2.00%) high mild
       2 (2.00%) high severe
     
     input/value.nested.existing
                             time:   [42.331 ns 42.553 ns 42.808 ns]
                             change: [-29.196% -28.245% -27.382%] (p = 0.00 < 0.05)
                             Performance has improved.
     Found 7 outliers among 100 measurements (7.00%)
       2 (2.00%) high mild
       5 (5.00%) high severe
     
     input/value.missing     time:   [14.786 ns 14.945 ns 15.148 ns]
                             change: [-44.497% -43.413% -42.402%] (p = 0.00 < 0.05)
                             Performance has improved.
     Found 18 outliers among 100 measurements (18.00%)
       1 (1.00%) high mild
       17 (17.00%) high severe
     
     input/value.nested.missing
                             time:   [31.466 ns 31.732 ns 32.072 ns]
                             change: [-40.619% -40.124% -39.660%] (p = 0.00 < 0.05)
                             Performance has improved.
     Found 4 outliers among 100 measurements (4.00%)
       4 (4.00%) high severe
     
     input/args.root         time:   [23.720 ns 23.849 ns 23.998 ns]
                             change: [+2.1817% +2.9968% +3.8444%] (p = 0.00 < 0.05)
                             Performance has regressed.
     Found 6 outliers among 100 measurements (6.00%)
       3 (3.00%) high mild
       3 (3.00%) high severe
     
     input/args.nested.existing
                             time:   [43.990 ns 44.598 ns 45.400 ns]
                             change: [-8.3635% -4.6996% -0.9128%] (p = 0.02 < 0.05)
                             Change within noise threshold.
     
     input/args.missing      time:   [14.473 ns 14.606 ns 14.768 ns]
                             change: [+7.0455% +8.7336% +10.383%] (p = 0.00 < 0.05)
                             Performance has regressed.
     Found 8 outliers among 100 measurements (8.00%)
       4 (4.00%) high mild
       4 (4.00%) high severe
     
     input/args.nested.missing
                             time:   [30.808 ns 31.021 ns 31.287 ns]
                             change: [-37.875% -35.982% -34.093%] (p = 0.00 < 0.05)
                             Performance has improved.
     Found 5 outliers among 100 measurements (5.00%)
       1 (1.00%) high mild
       4 (4.00%) high severe
     
     input/headers.existing  time:   [19.652 ns 19.761 ns 19.885 ns]
                             change: [-7.5038% -4.7806% -2.0766%] (p = 0.00 < 0.05)
                             Performance has improved.
     Found 8 outliers among 100 measurements (8.00%)
       4 (4.00%) high mild
       4 (4.00%) high severe
     
     input/headers.missing   time:   [18.827 ns 18.927 ns 19.030 ns]
                             change: [+0.1527% +0.7466% +1.2915%] (p = 0.01 < 0.05)
                             Change within noise threshold.
     Found 5 outliers among 100 measurements (5.00%)
       5 (5.00%) high mild
     
     input/vars.existing     time:   [5.3069 ns 5.3687 ns 5.4451 ns]
                             change: [-11.347% -8.1060% -4.7090%] (p = 0.00 < 0.05)
                             Performance has improved.
     Found 9 outliers among 100 measurements (9.00%)
       1 (1.00%) high mild
       8 (8.00%) high severe
     
     input/vars.missing      time:   [5.3028 ns 5.3514 ns 5.4070 ns]
                             change: [+3.5854% +5.7584% +8.7402%] (p = 0.00 < 0.05)
                             Performance has regressed.
     Found 10 outliers among 100 measurements (10.00%)
       6 (6.00%) high mild
       4 (4.00%) high severe
</pre>
</details>

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation website] accordingly.
- [x] I have performed a self-review of my own code.

[documentation website]: https://github.com/tailcallhq/tailcallhq.github.io
