### PR TITLE
updated cache benchmarks from actions/cache@v2 to actions/cache@v3 

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -160,6 +160,7 @@ jobs:
   Cache_Benchmarks:
     name: Micro Benchmarks
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -177,9 +178,7 @@ jobs:
           rust-script benches/parse_json_benchmark benches/main_benchmarks.json
 
       - name: Cache Criterion Benchmarks Json
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: benches/main_benchmarks.json
           key: criterion_benchmarks_${{ github.sha }}
-          restore-keys: |
-            criterion_benchmarks_

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -159,8 +159,11 @@ jobs:
 
   Cache_Benchmarks:
     name: Micro Benchmarks
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
**Summary:**  
currently in bot.yml we use 
```
      - name: Cache Criterion Benchmarks Json
        uses: actions/cache@v2
        with:
          path: benches/main_benchmarks.json
          key: criterion_benchmarks_${{ github.sha }}
          restore-keys: |
            criterion_benchmarks_
```
to cache the benchmarks in json file 
so whenever we need to restore this cache we generally use the following  or the cache id  :

```
      - name: Restore file
        uses: actions/cache@v2
        with:
          path: benches/main_benchmarks.json
          key: criterion_benchmarks_${{ github.event.pull_request.base.sha }}
          fail-on-cache-miss: true
```

but it always restore the same json file for all the cache id' s 
thats why we were getting error in  while comparing benchmarks 

So i changed `actions/cache@v2` to `actions/cache@v3`
and everything works file 

i have created a pr to update the changes

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation website] accordingly.
- [x] I have performed a self-review of my own code.

[documentation website]: https://github.com/tailcallhq/tailcallhq.github.io
