### PR TITLE
fix: open localhost in browser in case of using unspecified host

### DIFF
--- a/src/http/server_config.rs
+++ b/src/http/server_config.rs
@@ -1,4 +1,4 @@
-use std::net::{SocketAddr, Ipv4Addr, IpAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use super::ServerContext;

--- a/src/http/server_config.rs
+++ b/src/http/server_config.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{SocketAddr, Ipv4Addr, IpAddr};
 use std::sync::Arc;
 
 use super::ServerContext;
@@ -30,7 +30,12 @@ impl ServerConfig {
       "HTTP/2" => "https",
       _ => "http",
     };
-    let addr = self.addr().to_string();
+    let mut addr = self.addr();
+
+    if addr.ip().is_unspecified() {
+      addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port());
+    }
+
     format!("{}://{}", protocol, addr)
   }
 


### PR DESCRIPTION
**Summary:**  

Fix the problem when in config defined `hostname: "0.0.0.0"` and therefore graphql playground shows address `0.0.0.0` in the logs and open the browser on zeros ip. Instead of using broken address replace unspecified address with localhost.

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation website] accordingly.
- [ ] I have performed a self-review of my own code.

[documentation website]: https://github.com/tailcallhq/tailcallhq.github.io
