### PR TITLE
feat: set the log level using env variable

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -53,28 +53,6 @@ jobs:
         run: |
           ./target/release/tailcall start ci-benchmark/benchmark.graphql --log-level error &
 
-      - name: Install Nginx
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y nginx
-
-      - name: Clean Up
-        run: |
-          sudo rm -rf /etc/nginx/sites-enabled/default
-
-      - name: Copy Nginx Configuration
-        working-directory: ci-benchmark
-        run: |
-          sudo cp nginx.conf /etc/nginx/
-
-      - name: Test Nginx Configuration
-        run: |
-          sudo nginx -t
-
-      - name: Start Nginx
-        run: |
-          sudo systemctl start nginx
-
       - name: Install Wrk
         run: |
           sudo apt-get install -y wrk

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run Tailcall
         run: |
-          ./target/release/tailcall start ci-benchmark/benchmark.graphql --log-level error &
+          TAILCALL_LOG_LEVEL=error ./target/release/tailcall start ci-benchmark/benchmark.graphql &
 
       - name: Install Wrk
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ FROM fedora:34 AS runner
 COPY --from=builder /prod/target/release/tailcall /bin
 COPY --from=builder /prod/jsonplaceholder.graphql /jsonplaceholder.graphql
 
-CMD ["/bin/tailcall", "start", "jsonplaceholder.graphql", "--log-level", "error"]
+CMD ["TAILCALL_LOG_LEVEL=error", "/bin/tailcall", "start", "jsonplaceholder.graphql"]
 

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -2,17 +2,18 @@
 title: Logging
 ---
 
-You can change the verbosity of the logs by using either `TAILCALL_LOG_LEVEL` or `TC_LOG_LEVEL` environment variables. The available levels are: 
-  * off
-  * error
-  * warn
-  * info
-  * debug
-  * trace
+You can change the verbosity of the logs by using either `TAILCALL_LOG_LEVEL` or `TC_LOG_LEVEL` environment variables. The available levels are:
 
-We accept both uppercase or lowercase, so both `TAILCALL_LOG_LEVEL=DEBUG` or `TAILCALL_LOG_LEVEL=debug` will work. 
+- off
+- error
+- warn
+- info
+- debug
+- trace
 
-The default log level is `info`. 
+We accept both uppercase or lowercase, so both `TAILCALL_LOG_LEVEL=DEBUG` or `TAILCALL_LOG_LEVEL=debug` will work.
 
-Example of starting the server with `debug` log level: 
-  ```TAILCALL_LOG_LEVEL=debug tailcall start ./examples/jsonplaceholder.graphql```
+The default log level is `info`.
+
+Example of starting the server with `debug` log level:
+`TAILCALL_LOG_LEVEL=debug tailcall start ./examples/jsonplaceholder.graphql`

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -1,0 +1,18 @@
+---
+title: Logging
+---
+
+You can change the verbosity of the logs by using either `TAILCALL_LOG_LEVEL` or `TC_LOG_LEVEL` environment variables. The available levels are: 
+  * off
+  * error
+  * warn
+  * info
+  * debug
+  * trace
+
+We accept both uppercase or lowercase, so both `TAILCALL_LOG_LEVEL=DEBUG` or `TAILCALL_LOG_LEVEL=debug` will work. 
+
+The default log level is `info`. 
+
+Example of starting the server with `debug` log level: 
+  ```TAILCALL_LOG_LEVEL=debug tailcall start ./examples/jsonplaceholder.graphql```

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -25,8 +25,6 @@ pub enum Command {
     /// Path for the configuration files or http(s) link to config files separated by spaces if more than one
     #[arg(required = true)]
     file_paths: Vec<String>,
-    #[arg(long)]
-    log_level: Option<log::Level>,
   },
 
   /// Validate a composition spec

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -18,20 +18,8 @@ use crate::print_schema;
 
 pub fn run() -> Result<()> {
   let cli = Cli::parse();
-  // set the log level
-  const LONG_ENV_FILTER_VAR_NAME: &str = "TAILCALL_LOG_LEVEL";
-  const SHORT_ENV_FILTER_VAR_NAME: &str = "TC_LOG_LEVEL";
 
-  // Check if TAILCALL_LOG_LEVEL is defined, otherwise use TC_LOG_LEVEL
-
-  let filter_env_name = env::var(LONG_ENV_FILTER_VAR_NAME)
-    .map(|_| LONG_ENV_FILTER_VAR_NAME)
-    .unwrap_or_else(|_| SHORT_ENV_FILTER_VAR_NAME);
-
-  // use the log level from the env if there is one, othwerise use the default.
-  let env = Env::new().filter_or(filter_env_name, "info");
-
-  env_logger::Builder::from_env(env).init();
+  logger_init();
 
   match cli.command {
     Command::Start { file_paths } => {
@@ -130,4 +118,21 @@ fn display_config(config: &Config, n_plus_one_queries: bool) {
   Fmt::display(Fmt::success(&"No errors found".to_string()));
   let seq = vec![Fmt::n_plus_one_data(n_plus_one_queries, config)];
   Fmt::display(Fmt::table(seq));
+}
+
+// initialize logger
+fn logger_init() {
+  // set the log level
+  const LONG_ENV_FILTER_VAR_NAME: &str = "TAILCALL_LOG_LEVEL";
+  const SHORT_ENV_FILTER_VAR_NAME: &str = "TC_LOG_LEVEL";
+
+  // Select which env variable to use for the log level filter. This is because filter_or doesn't allow picking between multiple env_var for the filter value
+  let filter_env_name = env::var(LONG_ENV_FILTER_VAR_NAME)
+    .map(|_| LONG_ENV_FILTER_VAR_NAME)
+    .unwrap_or_else(|_| SHORT_ENV_FILTER_VAR_NAME);
+
+  // use the log level from the env if there is one, othwerise use the default.
+  let env = Env::new().filter_or(filter_env_name, "info");
+
+  env_logger::Builder::from_env(env).init();
 }

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -19,14 +19,14 @@ use crate::print_schema;
 pub fn run() -> Result<()> {
   let cli = Cli::parse();
   // set the log level
-  let long_env_filter_var_name = "TAILCALL_LOG_LEVEL";
-  let short_env_filter_var_name = "TC_LOG_LEVEL";
+  const LONG_ENV_FILTER_VAR_NAME: &str = "TAILCALL_LOG_LEVEL";
+  const SHORT_ENV_FILTER_VAR_NAME: &str = "TC_LOG_LEVEL";
 
   // Check if TAILCALL_LOG_LEVEL is defined, otherwise use TC_LOG_LEVEL
-  let filter_env_name = if env::var(long_env_filter_var_name).is_ok() {
-    long_env_filter_var_name
+  let filter_env_name = if env::var(LONG_ENV_FILTER_VAR_NAME).is_ok() {
+    LONG_ENV_FILTER_VAR_NAME
   } else {
-    short_env_filter_var_name
+    SHORT_ENV_FILTER_VAR_NAME
   };
 
   // use the log level from the env if there is one, othwerise use the default.

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -23,11 +23,10 @@ pub fn run() -> Result<()> {
   const SHORT_ENV_FILTER_VAR_NAME: &str = "TC_LOG_LEVEL";
 
   // Check if TAILCALL_LOG_LEVEL is defined, otherwise use TC_LOG_LEVEL
-  let filter_env_name = if env::var(LONG_ENV_FILTER_VAR_NAME).is_ok() {
-    LONG_ENV_FILTER_VAR_NAME
-  } else {
-    SHORT_ENV_FILTER_VAR_NAME
-  };
+
+  let filter_env_name = env::var(LONG_ENV_FILTER_VAR_NAME)
+    .map(|_| LONG_ENV_FILTER_VAR_NAME)
+    .unwrap_or_else(|_| SHORT_ENV_FILTER_VAR_NAME);
 
   // use the log level from the env if there is one, othwerise use the default.
   let env = Env::new().filter_or(filter_env_name, "info");

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -23,9 +23,10 @@ pub fn run() -> Result<()> {
   let short_env_filter_var_name = "TC_LOG_LEVEL";
 
   // Check if TAILCALL_LOG_LEVEL is defined, otherwise use TC_LOG_LEVEL
-  let filter_env_name = match env::var(long_env_filter_var_name) {
-    Ok(_) => long_env_filter_var_name,
-    Err(_) => short_env_filter_var_name,
+  let filter_env_name = if env::var(long_env_filter_var_name).is_ok() {
+    long_env_filter_var_name
+  } else {
+    short_env_filter_var_name
   };
 
   // use the log level from the env if there is one, othwerise use the default.

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -18,22 +18,23 @@ use crate::print_schema;
 
 pub fn run() -> Result<()> {
   let cli = Cli::parse();
+  // set the log level
+  let long_env_filter_var_name = "TAILCALL_LOG_LEVEL";
+  let short_env_filter_var_name = "TC_LOG_LEVEL";
+
+  // Check if TAILCALL_LOG_LEVEL is defined, otherwise use TC_LOG_LEVEL
+  let filter_env_name = match env::var(long_env_filter_var_name) {
+    Ok(_) => long_env_filter_var_name,
+    Err(_) => short_env_filter_var_name,
+  };
+
+  // use the log level from the env if there is one, othwerise use the default.
+  let env = Env::new().filter_or(filter_env_name, "info");
+
+  env_logger::Builder::from_env(env).init();
 
   match cli.command {
     Command::Start { file_paths } => {
-      let long_env_filter_var_name = "TAILCALL_LOG_LEVEL";
-      let short_env_filter_var_name = "TC_LOG_LEVEL";
-
-      // Check if TAILCALL_LOG_LEVEL is defined, otherwise use TC_LOG_LEVEL
-      let filter_env_name = match env::var(long_env_filter_var_name) {
-        Ok(_) => long_env_filter_var_name,
-        Err(_) => short_env_filter_var_name,
-      };
-
-      // use the log level from the env if there is one, othwerise use the default.
-      let env = Env::new().filter_or(filter_env_name, "info");
-
-      env_logger::Builder::from_env(env).init();
       let config =
         tokio::runtime::Runtime::new()?.block_on(async { Config::read_from_files(file_paths.iter()).await })?;
       log::info!("N + 1: {}", config.n_plus_one().len().to_string());


### PR DESCRIPTION
**Summary:**  
Use either `TAILCALL_LOG_LEVEL` or `TC_LOG_LEVEL` as a place to set the log level. 

**Issue Reference(s):**  
Fixes #791 
/claim #791 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
---- there seems to be no tests of the log level, so nothing to be updated
- [ ] I have updated the [documentation website] accordingly.
----- Can't find where/how. Let me know where I can make this change, if I can 
- [x] I have performed a self-review of my own code.

[documentation website]: https://github.com/tailcallhq/tailcallhq.github.io
