### PR TITLE
fix: show log info instead of error when expected failure happens

### DIFF
--- a/tests/http_spec.rs
+++ b/tests/http_spec.rs
@@ -354,7 +354,7 @@ async fn assert_downstream(spec: HttpSpec) {
           );
         }
         Err(_) => {
-          log::info!("{} {} ... ok", spec.name, spec.path.display());
+          log::info!("{} {} ... failed (expected)", spec.name, spec.path.display());
         }
       }
     } else {

--- a/tests/http_spec.rs
+++ b/tests/http_spec.rs
@@ -354,7 +354,7 @@ async fn assert_downstream(spec: HttpSpec) {
           );
         }
         Err(_) => {
-          log::error!("{} {} ... failed", spec.name, spec.path.display());
+          log::info!("{} {} ... ok", spec.name, spec.path.display());
         }
       }
     } else {


### PR DESCRIPTION
**Summary:**  
Show log info instead of error

**Issue Reference(s):**  
Fixes #738
/claim #738

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
