### PR TITLE
ci: added pr-convention workflow

### DIFF
--- a/.github/workflows/pr-convention.yml
+++ b/.github/workflows/pr-convention.yml
@@ -1,0 +1,14 @@
+name: PR Title Validation
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: naveenk1223/action-pr-title@master
+        with:
+          regex: '^[a-zA-Z]+(\([a-zA-Z]+\))?: .+'
+          allowed_prefixes: "feat,fix,docs,style,refactor,test,chore,ci,perf,revert"
+          prefix_case_sensitive: false


### PR DESCRIPTION
**Summary:**  
Add support for PR Title Validation

**Issue Reference(s):**  
Fixes #814 
/claim #814

**Description**
- Added `pr-convention.yml` workflow which will be triggered on each PR raised and will validate the title of the PR
- Test PRs on [ezhil56x/tailcall](https://github.com/ezhil56x/tailcall/pulls)
