### PR TITLE
ci(workflows): avoid running Rust-related workflows for markdown-only changes

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -2,9 +2,11 @@ name: Benchmark
 
 on:
   push:
+    paths-ignore: ['docs/**', '**.md']
     branches:
       - main
   pull_request:
+    paths-ignore: ['docs/**', '**.md']
     types: [opened, synchronize, labeled]
     branches:
       - main

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -2,11 +2,11 @@ name: Benchmark
 
 on:
   push:
-    paths-ignore: ['docs/**', '**.md']
+    paths-ignore: ["docs/**", "**.md"]
     branches:
       - main
   pull_request:
-    paths-ignore: ['docs/**', '**.md']
+    paths-ignore: ["docs/**", "**.md"]
     types: [opened, synchronize, labeled]
     branches:
       - main

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,28 @@
+name: Build docs
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - "docs/**"
+      - "**.md"
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+    paths:
+      - "docs/**"
+      - "**.md"
+
+jobs:
+  check_spelling:
+    name: Check spelling
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          skip: .git,*/package.json,*/package-lock.json,*.lock,.github,.vscode,assets
+          ignore_words_file: .codespellignore
+          check_hidden: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,24 +4,14 @@ on:
   push:
     branches:
       - "**"
+    paths-ignore: ['docs/**', '**.md']
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
+    paths-ignore: ['docs/**', '**.md']
   release:
     types: [published]
 jobs:
-  check_spelling:
-    name: Check spelling
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
-        with:
-          skip: .git,*/package.json,*/package-lock.json,*.lock,.github,.vscode,assets
-          ignore_words_file: .codespellignore
-          check_hidden: false
-
   check_if_build:
     name: Check if Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore: ['docs/**', '**.md']
+    paths-ignore: ["docs/**", "**.md"]
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
-    paths-ignore: ['docs/**', '**.md']
+    paths-ignore: ["docs/**", "**.md"]
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
- build: disable benchmarks for `docs` and `*.md` files
- build: remove spelling check from ci

**Issue Reference(s):**  
Fixes #860
/claim #860

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
