### PR TITLE
fix: validation error printing multiple times

### DIFF
--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -215,7 +215,6 @@ impl From<Box<dyn std::error::Error>> for CLIError {
 
 #[cfg(test)]
 mod tests {
-  use std::collections::VecDeque;
 
   use pretty_assertions::assert_eq;
   use stripmargin::StripMargin;
@@ -343,12 +342,7 @@ mod tests {
   fn test_from_validation() {
     let cause = Cause::new("Base URL needs to be specified")
       .description("Set `baseURL` in @http or @server directives")
-      .trace(VecDeque::from(vec![
-        "Query".to_string(),
-        "users".to_string(),
-        "@http".to_string(),
-        "baseURL".to_string(),
-      ]));
+      .trace(vec!["Query", "users", "@http", "baseURL"]);
     let valid = ValidationError::from(cause);
     let error = CLIError::from(valid);
     let expected = r"|Error: Invalid Configuration

--- a/src/valid/cause.rs
+++ b/src/valid/cause.rs
@@ -9,6 +9,7 @@ pub struct Cause<E> {
   pub message: E,
   #[setters(strip_option)]
   pub description: Option<E>,
+  #[setters(skip)]
   pub trace: VecDeque<String>,
 }
 
@@ -37,17 +38,20 @@ impl<E> Cause<E> {
   pub fn transform<E1>(self, e: impl Fn(E) -> E1) -> Cause<E1> {
     Cause { message: e(self.message), description: self.description.map(e), trace: self.trace }
   }
+
+  pub fn trace<T: Display>(mut self, trace: Vec<T>) -> Self {
+    self.trace = trace.iter().map(|t| t.to_string()).collect::<VecDeque<String>>();
+    self
+  }
 }
 
 #[cfg(test)]
 mod tests {
-  use std::collections::VecDeque;
-
   #[test]
   fn test_display() {
     use super::Cause;
     let cause = Cause::new("error")
-      .trace(VecDeque::from(vec!["trace0".to_owned(), "trace1".to_owned()]))
+      .trace(vec!["trace0", "trace1"])
       .description("description");
     assert_eq!(cause.to_string(), "[trace0, trace1] error: description");
   }

--- a/src/valid/error.rs
+++ b/src/valid/error.rs
@@ -114,7 +114,7 @@ impl From<serde_path_to_error::Error<serde_json::Error>> for ValidationError<Str
 mod tests {
   use pretty_assertions::assert_eq;
 
-  use crate::valid::{ValidationError, Cause};
+  use crate::valid::{Cause, ValidationError};
 
   #[derive(Debug, PartialEq, serde::Deserialize)]
   struct Foo {
@@ -123,7 +123,7 @@ mod tests {
 
   #[test]
   fn test_error_display_formatting() {
-    let error = ValidationError::from((1..=5).map(|i| Cause::new(i)).collect::<Vec<Cause<usize>>>());
+    let error = ValidationError::from((1..=5).map(Cause::new).collect::<Vec<Cause<usize>>>());
     let expected_output = "\
 Validation Error
 • 1 []

--- a/src/valid/error.rs
+++ b/src/valid/error.rs
@@ -114,11 +114,25 @@ impl From<serde_path_to_error::Error<serde_json::Error>> for ValidationError<Str
 mod tests {
   use pretty_assertions::assert_eq;
 
-  use crate::valid::ValidationError;
+  use crate::valid::{ValidationError, Cause};
 
   #[derive(Debug, PartialEq, serde::Deserialize)]
   struct Foo {
     a: i32,
+  }
+
+  #[test]
+  fn test_error_display_formatting() {
+    let error = ValidationError::from((1..=5).map(|i| Cause::new(i)).collect::<Vec<Cause<usize>>>());
+    let expected_output = "\
+Validation Error
+• 1 []
+• 2 []
+• 3 []
+• 4 []
+• 5 []
+";
+    assert_eq!(format!("{}", error), expected_output);
   }
 
   #[test]

--- a/src/valid/error.rs
+++ b/src/valid/error.rs
@@ -9,14 +9,12 @@ pub struct ValidationError<E>(Vec<Cause<E>>);
 
 impl<E: Display> Display for ValidationError<E> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    for _error in self.as_vec() {
-      f.write_str("Validation Error\n")?;
-      let errors = self.as_vec();
-      for error in errors {
-        f.write_str(format!("{} {}", '\u{2022}', error.message).as_str())?;
-        f.write_str(&(format!(" [{}]", error.trace.iter().cloned().collect::<Vec<String>>().join(", "))))?;
-        f.write_str("\n")?;
-      }
+    f.write_str("Validation Error\n")?;
+    let errors = self.as_vec();
+    for error in errors {
+      f.write_str(format!("{} {}", '\u{2022}', error.message).as_str())?;
+      f.write_str(&(format!(" [{}]", error.trace.iter().cloned().collect::<Vec<String>>().join(", "))))?;
+      f.write_str("\n")?;
     }
 
     Ok(())


### PR DESCRIPTION
This PR fixes validation error printing multiple times was caused by iterating twice

Before:
<img width="608" alt="SCR-20240108-rteo" src="https://github.com/tailcallhq/tailcall/assets/62795688/cbaec5f7-c4a1-47d4-b6e0-a77c0793f95c">

After:
<img width="499" alt="SCR-20240108-rstm" src="https://github.com/tailcallhq/tailcall/assets/62795688/a58ddd68-e3c4-43ba-bc8f-b92be4c7267b">

/fixes #906
/claim #906