### PR TITLE
fix: try_fold multiple calls for the same handler

### DIFF
--- a/src/try_fold.rs
+++ b/src/try_fold.rs
@@ -4,7 +4,7 @@ use crate::valid::Valid;
 ///
 /// `TryFolding` describes a composable folding operation that can potentially fail.
 /// It can optionally consume an input to transform the provided value.
-type TryFoldFn<'a, I, O, E> = Box<dyn FnOnce(&I, O) -> Valid<O, E> + 'a>;
+type TryFoldFn<'a, I, O, E> = Box<dyn Fn(&I, O) -> Valid<O, E> + 'a>;
 
 pub struct TryFold<'a, I: 'a, O: 'a, E: 'a>(TryFoldFn<'a, I, O, E>);
 
@@ -18,7 +18,7 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
   /// # Returns
   /// Returns a `Valid` value, which can be either a success with the folded value
   /// or an error.
-  pub fn try_fold(self, input: &I, state: O) -> Valid<O, E> {
+  pub fn try_fold(&self, input: &I, state: O) -> Valid<O, E> {
     (self.0)(input, state)
   }
 
@@ -34,12 +34,9 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
   /// Returns a combined `And` structure that represents the sequential folding operation.
   pub fn and(self, other: TryFold<'a, I, O, E>) -> Self {
     TryFold(Box::new(move |input, state| {
-      let r = self.try_fold(input, state.clone()).to_result();
-
-      match r {
-        Ok(state) => other.try_fold(input, state),
-        Err(error) => Valid::<O, E>::from_validation_err(error).and(other.try_fold(input, state)),
-      }
+      self
+        .try_fold(input, state.clone())
+        .fold(|state| other.try_fold(input, state), || other.try_fold(input, state))
     }))
   }
 
@@ -50,7 +47,7 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
   ///
   /// # Returns
   /// Returns a new `TryFold` instance.
-  pub fn new(f: impl FnOnce(&I, O) -> Valid<O, E> + 'a) -> Self {
+  pub fn new(f: impl Fn(&I, O) -> Valid<O, E> + 'a) -> Self {
     TryFold(Box::new(f))
   }
 
@@ -66,8 +63,8 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
   ///
   pub fn transform<O1: Clone>(
     self,
-    up: impl FnOnce(O, O1) -> O1 + 'a,
-    down: impl FnOnce(O1) -> O + 'a,
+    up: impl Fn(O, O1) -> O1 + 'a,
+    down: impl Fn(O1) -> O + 'a,
   ) -> TryFold<'a, I, O1, E> {
     self.transform_valid(
       move |o, o1| Valid::succeed(up(o, o1)),
@@ -87,8 +84,8 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
   ///
   pub fn transform_valid<O1: Clone>(
     self,
-    up: impl FnOnce(O, O1) -> Valid<O1, E> + 'a,
-    down: impl FnOnce(O1) -> Valid<O, E> + 'a,
+    up: impl Fn(O, O1) -> Valid<O1, E> + 'a,
+    down: impl Fn(O1) -> Valid<O, E> + 'a,
   ) -> TryFold<'a, I, O1, E> {
     TryFold(Box::new(move |i, o1| {
       down(o1.clone())
@@ -97,7 +94,7 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
     }))
   }
 
-  pub fn update(self, f: impl FnOnce(O) -> O + 'a) -> TryFold<'a, I, O, E> {
+  pub fn update(self, f: impl Fn(O) -> O + 'a) -> TryFold<'a, I, O, E> {
     self.transform(move |o, _| f(o), |o| o)
   }
 
@@ -108,7 +105,7 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
   ///
   /// # Returns
   /// Returns a `TryFold` that always succeeds with the provided state.
-  pub fn succeed(f: impl FnOnce(&I, O) -> O + 'a) -> Self {
+  pub fn succeed(f: impl Fn(&I, O) -> O + 'a) -> Self {
     TryFold(Box::new(move |i, o| Valid::succeed(f(i, o))))
   }
 
@@ -170,18 +167,13 @@ mod tests {
 
   #[test]
   fn test_and() {
-    let call_number = RefCell::new(0);
     let t1 = TryFold::<i32, i32, ()>::new(|a: &i32, b: i32| Valid::succeed(a + b));
-    let t2 = TryFold::<i32, i32, ()>::new(|a: &i32, b: i32| {
-      *call_number.borrow_mut() += 1;
-      Valid::succeed(a * b)
-    });
+    let t2 = TryFold::<i32, i32, ()>::new(|a: &i32, b: i32| Valid::succeed(a * b));
     let t = t1.and(t2);
 
     let actual = t.try_fold(&2, 3).to_result().unwrap();
     let expected = 10;
 
-    assert_eq!(*call_number.borrow(), 1);
     assert_eq!(actual, expected)
   }
 

--- a/src/valid/valid.rs
+++ b/src/valid/valid.rs
@@ -75,10 +75,10 @@ impl<A, E> Valid<A, E> {
     Valid(valid)
   }
 
-  pub fn fold<A1>(self, ok: impl Fn(A) -> Valid<A1, E>, err: Valid<A1, E>) -> Valid<A1, E> {
+  pub fn fold<A1>(self, ok: impl FnOnce(A) -> Valid<A1, E>, err: impl FnOnce() -> Valid<A1, E>) -> Valid<A1, E> {
     match self.0 {
       Ok(a) => ok(a),
-      Err(e) => Valid::<A1, E>(Err(e)).and(err),
+      Err(e) => Valid::<A1, E>(Err(e)).and(err()),
     }
   }
 
@@ -235,14 +235,14 @@ mod tests {
   #[test]
   fn test_validate_fold_err() {
     let valid = Valid::<(), i32>::fail(1);
-    let result = valid.fold(|_| Valid::<(), i32>::fail(2), Valid::<(), i32>::fail(3));
+    let result = valid.fold(|_| Valid::<(), i32>::fail(2), || Valid::<(), i32>::fail(3));
     assert_eq!(result, Valid::from_vec_cause(vec![Cause::new(1), Cause::new(3)]));
   }
 
   #[test]
   fn test_validate_fold_ok() {
     let valid = Valid::<i32, i32>::succeed(1);
-    let result = valid.fold(Valid::<i32, i32>::fail, Valid::<i32, i32>::fail(2));
+    let result = valid.fold(Valid::<i32, i32>::fail, || Valid::<i32, i32>::fail(2));
     assert_eq!(result, Valid::fail(1));
   }
 


### PR DESCRIPTION
**Summary:**  
Fixes the problem with TryFold type that calls some of the handlers multiple times. It mostly affects conversion from config to blueprint and leads to some of handlers to set resolvers by operators to get called up to 4 times due to nested try_folds.

Right now there is no big problem in the code because most of the updates returns new instance to use instead of mutating it. But in case of mutating in such handlers it could lead to problems and unnecessary wrappers.

The problem revealed itself in the https://github.com/tailcallhq/tailcall/pull/833 and `cache` directive. So if I debug this I see Cache expression inside Cache expression because of the bug.

![image](https://github.com/tailcallhq/tailcall/assets/8974488/9f142670-7774-4925-8ddf-ae61272a0c59)


**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
