### PR TITLE
fix: batch merging in upstream operator

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -253,13 +253,7 @@ impl Upstream {
     self.tcp_keep_alive = other.tcp_keep_alive.or(self.tcp_keep_alive);
     self.timeout = other.timeout.or(self.timeout);
     self.user_agent = other.user_agent.or(self.user_agent);
-    self.batch = other.batch.map(|other| {
-      let mut batch = self.batch.unwrap_or_default();
-      batch.max_size = other.max_size;
-      batch.delay = other.delay;
-      batch.headers.extend(other.headers);
-      batch
-    });
+    self.batch = other.batch.or(self.batch);
 
     self.http2_only = other.http2_only.or(self.http2_only);
     self


### PR DESCRIPTION
**Summary:**  
Fixes batch object merging in upstream operator incase of multiple files.

**Issue Reference(s):**  
Fixes: #922 

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs

/claim #922 