### PR TITLE
perf: optimize set_body function

### DIFF
--- a/benches/request_template_bench.rs
+++ b/benches/request_template_bench.rs
@@ -12,71 +12,66 @@ use tailcall::path::PathString;
 
 #[derive(Setters)]
 struct Context {
-    pub value: serde_json::Value,
-    pub headers: HeaderMap,
+  pub value: serde_json::Value,
+  pub headers: HeaderMap,
 }
 
 impl Default for Context {
-    fn default() -> Self {
-        Self { value: serde_json::Value::Null, headers: HeaderMap::new() }
-    }
+  fn default() -> Self {
+    Self { value: serde_json::Value::Null, headers: HeaderMap::new() }
+  }
 }
 
 impl PathString for Context {
-    fn path_string<T: AsRef<str>>(&self, parts: &[T]) -> Option<Cow<'_, str>> {
-        self.value.path_string(parts)
-    }
+  fn path_string<T: AsRef<str>>(&self, parts: &[T]) -> Option<Cow<'_, str>> {
+    self.value.path_string(parts)
+  }
 }
 
 impl HasHeaders for Context {
-    fn headers(&self) -> &HeaderMap {
-        &self.headers
-    }
+  fn headers(&self) -> &HeaderMap {
+    &self.headers
+  }
 }
 
 fn initialize_templates() -> (RequestTemplate, RequestTemplate) {
-    // Placeholder values, replace with your actual initialization logic
-    let tmpl_literal = RequestTemplate::try_from(Endpoint::new(
-        "http://localhost:3000/foo?a=bar&b=foo&c=baz".to_string(),
-    ))
-    .unwrap();
+  // Placeholder values, replace with your actual initialization logic
+  let tmpl_literal =
+    RequestTemplate::try_from(Endpoint::new("http://localhost:3000/foo?a=bar&b=foo&c=baz".to_string())).unwrap();
 
-    let tmpl_mustache = RequestTemplate::try_from(Endpoint::new(
-        "http://localhost:3000/{{args.b}}?a={{args.a}}&b={{args.b}}&c={{args.c}}".to_string(),
-    ))
-    .unwrap();
+  let tmpl_mustache = RequestTemplate::try_from(Endpoint::new(
+    "http://localhost:3000/{{args.b}}?a={{args.a}}&b={{args.b}}&c={{args.c}}".to_string(),
+  ))
+  .unwrap();
 
-    (tmpl_literal, tmpl_mustache)
+  (tmpl_literal, tmpl_mustache)
 }
 
 fn benchmark_to_request(c: &mut Criterion) {
-    let (tmpl_literal, tmpl_mustache) = initialize_templates();
+  let (tmpl_literal, tmpl_mustache) = initialize_templates();
 
-    let ctx = Context::default().value(json!({
-        "args": {
-            "b": "foo"
-        }
-    }));
+  let ctx = Context::default().value(json!({
+      "args": {
+          "b": "foo"
+      }
+  }));
 
-    c.bench_function("with_mustache_literal", |b| {
-        b.iter(|| {
-            black_box(tmpl_literal.to_request(&ctx).unwrap());
-        })
-    });
+  c.bench_function("with_mustache_literal", |b| {
+    b.iter(|| {
+      black_box(tmpl_literal.to_request(&ctx).unwrap());
+    })
+  });
 
-    c.bench_function("with_mustache_expressions", |b| {
-        b.iter(|| {
-            black_box(tmpl_mustache.to_request(&ctx).unwrap());
-        })
-    });
+  c.bench_function("with_mustache_expressions", |b| {
+    b.iter(|| {
+      black_box(tmpl_mustache.to_request(&ctx).unwrap());
+    })
+  });
 }
 
 fn initialize_request_template() -> RequestTemplate {
-    // Placeholder value, replace with your actual initialization logic
-    RequestTemplate::try_from(Endpoint::new(
-        "http://localhost:3000/foo?a=bar&b=foo&c=baz".to_string(),
-    ))
-    .unwrap()
+  // Placeholder value, replace with your actual initialization logic
+  RequestTemplate::try_from(Endpoint::new("http://localhost:3000/foo?a=bar&b=foo&c=baz".to_string())).unwrap()
 }
 
 // Original set_body function
@@ -86,63 +81,72 @@ fn original_set_body<C: PathString + HasHeaders>(
   ctx: &C,
 ) -> reqwest::Request {
   if let Some(body) = &tmpl.body_path {
-      if let Encoding::ApplicationXWwwFormUrlencoded = &tmpl.encoding {
-          req.headers_mut()
-              .insert(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded".parse().unwrap());
+    if let Encoding::ApplicationXWwwFormUrlencoded = &tmpl.encoding {
+      req.headers_mut().insert(
+        reqwest::header::CONTENT_TYPE,
+        "application/x-www-form-urlencoded".parse().unwrap(),
+      );
 
-          let form_data = serde_urlencoded::to_string(body.render(ctx)).unwrap();
-          req.body_mut().replace(form_data.into());
-      } else {
-          req.body_mut().replace(body.render(ctx).into());
-      }
+      let form_data = serde_urlencoded::to_string(body.render(ctx)).unwrap();
+      req.body_mut().replace(form_data.into());
+    } else {
+      req.body_mut().replace(body.render(ctx).into());
+    }
   }
   req
 }
 
 // Optimized set_body function
 fn optimized_set_body<C: PathString + HasHeaders>(
-    tmpl: &RequestTemplate,
-    mut req: reqwest::Request,
-    ctx: &C,
+  tmpl: &RequestTemplate,
+  mut req: reqwest::Request,
+  ctx: &C,
 ) -> reqwest::Request {
-    if let Some(body) = &tmpl.body_path {
-        if let Encoding::ApplicationXWwwFormUrlencoded = &tmpl.encoding {
-            req.headers_mut()
-                .insert(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded".parse().unwrap());
+  if let Some(body) = &tmpl.body_path {
+    if let Encoding::ApplicationXWwwFormUrlencoded = &tmpl.encoding {
+      req.headers_mut().insert(
+        reqwest::header::CONTENT_TYPE,
+        "application/x-www-form-urlencoded".parse().unwrap(),
+      );
 
-            let form_data = serde_urlencoded::to_string(body.render(ctx)).unwrap();
-            req.body_mut().replace(form_data.into());
-        } else {
-            req.body_mut().replace(body.render(ctx).into());
-        }
+      let form_data = serde_urlencoded::to_string(body.render(ctx)).unwrap();
+      req.body_mut().replace(form_data.into());
+    } else {
+      req.body_mut().replace(body.render(ctx).into());
     }
-    req
+  }
+  req
 }
 
 fn benchmark_original_set_body(c: &mut Criterion) {
-    let request_template = initialize_request_template();
-    let ctx = Context::default().value(json!({"args": {"b": "foo"}}));
+  let request_template = initialize_request_template();
+  let ctx = Context::default().value(json!({"args": {"b": "foo"}}));
 
-    c.bench_function("original_set_body", |b| {
-        b.iter(|| {
-            let req = request_template.clone().to_request(&ctx).unwrap();
-            black_box(original_set_body(&request_template, req, &ctx));
-        })
-    });
+  c.bench_function("original_set_body", |b| {
+    b.iter(|| {
+      let req = request_template.clone().to_request(&ctx).unwrap();
+      black_box(original_set_body(&request_template, req, &ctx));
+    })
+  });
 }
 
 // Benchmark the updated optimized set_body function
 fn benchmark_optimized_set_body(c: &mut Criterion) {
-    let request_template = initialize_request_template();
-    let ctx = Context::default().value(json!({"args": {"b": "foo"}}));
+  let request_template = initialize_request_template();
+  let ctx = Context::default().value(json!({"args": {"b": "foo"}}));
 
-    c.bench_function("optimized_set_body", |b| {
-        b.iter(|| {
-            let req = request_template.clone().to_request(&ctx).unwrap();
-            black_box(optimized_set_body(&request_template, req, &ctx));
-        })
-    });
+  c.bench_function("optimized_set_body", |b| {
+    b.iter(|| {
+      let req = request_template.clone().to_request(&ctx).unwrap();
+      black_box(optimized_set_body(&request_template, req, &ctx));
+    })
+  });
 }
 
-criterion_group!(benches, benchmark_to_request, benchmark_original_set_body, benchmark_optimized_set_body);
+criterion_group!(
+  benches,
+  benchmark_to_request,
+  benchmark_original_set_body,
+  benchmark_optimized_set_body
+);
 criterion_main!(benches);

--- a/benches/request_template_bench.rs
+++ b/benches/request_template_bench.rs
@@ -4,6 +4,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use derive_setters::Setters;
 use hyper::HeaderMap;
 use serde_json::json;
+use tailcall::config::Encoding;
 use tailcall::endpoint::Endpoint;
 use tailcall::has_headers::HasHeaders;
 use tailcall::http::RequestTemplate;
@@ -11,56 +12,137 @@ use tailcall::path::PathString;
 
 #[derive(Setters)]
 struct Context {
-  pub value: serde_json::Value,
-  pub headers: HeaderMap,
+    pub value: serde_json::Value,
+    pub headers: HeaderMap,
 }
 
 impl Default for Context {
-  fn default() -> Self {
-    Self { value: serde_json::Value::Null, headers: HeaderMap::new() }
-  }
-}
-impl PathString for Context {
-  fn path_string<T: AsRef<str>>(&self, parts: &[T]) -> Option<Cow<'_, str>> {
-    self.value.path_string(parts)
-  }
-}
-impl HasHeaders for Context {
-  fn headers(&self) -> &HeaderMap {
-    &self.headers
-  }
-}
-fn benchmark_to_request(c: &mut Criterion) {
-  let tmpl_mustache = RequestTemplate::try_from(Endpoint::new(
-    "http://localhost:3000/{{args.b}}?a={{args.a}}&b={{args.b}}&c={{args.c}}".to_string(),
-  ))
-  .unwrap();
-
-  let tmpl_literal =
-    RequestTemplate::try_from(Endpoint::new("http://localhost:3000/foo?a=bar&b=foo&c=baz".to_string())).unwrap();
-
-  let ctx = Context::default().value(json!({
-    "args": {
-      "b": "foo"
+    fn default() -> Self {
+        Self { value: serde_json::Value::Null, headers: HeaderMap::new() }
     }
-  }));
-
-  c.bench_function("with_mustache_literal", |b| {
-    b.iter(|| {
-      black_box(tmpl_literal.to_request(&ctx).unwrap());
-    })
-  });
-
-  c.bench_function("with_mustache_expressions", |b| {
-    b.iter(|| {
-      black_box(tmpl_mustache.to_request(&ctx).unwrap());
-    })
-  });
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default();
-    targets = benchmark_to_request
+impl PathString for Context {
+    fn path_string<T: AsRef<str>>(&self, parts: &[T]) -> Option<Cow<'_, str>> {
+        self.value.path_string(parts)
+    }
 }
+
+impl HasHeaders for Context {
+    fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+}
+
+fn initialize_templates() -> (RequestTemplate, RequestTemplate) {
+    // Placeholder values, replace with your actual initialization logic
+    let tmpl_literal = RequestTemplate::try_from(Endpoint::new(
+        "http://localhost:3000/foo?a=bar&b=foo&c=baz".to_string(),
+    ))
+    .unwrap();
+
+    let tmpl_mustache = RequestTemplate::try_from(Endpoint::new(
+        "http://localhost:3000/{{args.b}}?a={{args.a}}&b={{args.b}}&c={{args.c}}".to_string(),
+    ))
+    .unwrap();
+
+    (tmpl_literal, tmpl_mustache)
+}
+
+fn benchmark_to_request(c: &mut Criterion) {
+    let (tmpl_literal, tmpl_mustache) = initialize_templates();
+
+    let ctx = Context::default().value(json!({
+        "args": {
+            "b": "foo"
+        }
+    }));
+
+    c.bench_function("with_mustache_literal", |b| {
+        b.iter(|| {
+            black_box(tmpl_literal.to_request(&ctx).unwrap());
+        })
+    });
+
+    c.bench_function("with_mustache_expressions", |b| {
+        b.iter(|| {
+            black_box(tmpl_mustache.to_request(&ctx).unwrap());
+        })
+    });
+}
+
+fn initialize_request_template() -> RequestTemplate {
+    // Placeholder value, replace with your actual initialization logic
+    RequestTemplate::try_from(Endpoint::new(
+        "http://localhost:3000/foo?a=bar&b=foo&c=baz".to_string(),
+    ))
+    .unwrap()
+}
+
+// Original set_body function
+fn original_set_body<C: PathString + HasHeaders>(
+  tmpl: &RequestTemplate,
+  mut req: reqwest::Request,
+  ctx: &C,
+) -> reqwest::Request {
+  if let Some(body) = &tmpl.body_path {
+      if let Encoding::ApplicationXWwwFormUrlencoded = &tmpl.encoding {
+          req.headers_mut()
+              .insert(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded".parse().unwrap());
+
+          let form_data = serde_urlencoded::to_string(body.render(ctx)).unwrap();
+          req.body_mut().replace(form_data.into());
+      } else {
+          req.body_mut().replace(body.render(ctx).into());
+      }
+  }
+  req
+}
+
+// Optimized set_body function
+fn optimized_set_body<C: PathString + HasHeaders>(
+    tmpl: &RequestTemplate,
+    mut req: reqwest::Request,
+    ctx: &C,
+) -> reqwest::Request {
+    if let Some(body) = &tmpl.body_path {
+        if let Encoding::ApplicationXWwwFormUrlencoded = &tmpl.encoding {
+            req.headers_mut()
+                .insert(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded".parse().unwrap());
+
+            let form_data = serde_urlencoded::to_string(body.render(ctx)).unwrap();
+            req.body_mut().replace(form_data.into());
+        } else {
+            req.body_mut().replace(body.render(ctx).into());
+        }
+    }
+    req
+}
+
+fn benchmark_original_set_body(c: &mut Criterion) {
+    let request_template = initialize_request_template();
+    let ctx = Context::default().value(json!({"args": {"b": "foo"}}));
+
+    c.bench_function("original_set_body", |b| {
+        b.iter(|| {
+            let req = request_template.clone().to_request(&ctx).unwrap();
+            black_box(original_set_body(&request_template, req, &ctx));
+        })
+    });
+}
+
+// Benchmark the updated optimized set_body function
+fn benchmark_optimized_set_body(c: &mut Criterion) {
+    let request_template = initialize_request_template();
+    let ctx = Context::default().value(json!({"args": {"b": "foo"}}));
+
+    c.bench_function("optimized_set_body", |b| {
+        b.iter(|| {
+            let req = request_template.clone().to_request(&ctx).unwrap();
+            black_box(optimized_set_body(&request_template, req, &ctx));
+        })
+    });
+}
+
+criterion_group!(benches, benchmark_to_request, benchmark_original_set_body, benchmark_optimized_set_body);
 criterion_main!(benches);

--- a/src/http/request_template.rs
+++ b/src/http/request_template.rs
@@ -117,7 +117,7 @@ impl RequestTemplate {
           let form_data = match serde_json::from_str::<serde_json::Value>(&body_path.render(ctx)) {
             Ok(deserialized_data) => serde_urlencoded::to_string(deserialized_data)?,
             Err(_) => body_path.render(ctx),
-        };
+          };
 
           req.body_mut().replace(form_data.into());
         }

--- a/src/http/request_template.rs
+++ b/src/http/request_template.rs
@@ -114,13 +114,10 @@ impl RequestTemplate {
           req.body_mut().replace(body_path.render(ctx).into());
         }
         Encoding::ApplicationXWwwFormUrlencoded => {
-          // TODO: this is a performance bottleneck
-          // We first encode everything to string and then back to form-urlencoded
-          let body: String = body_path.render(ctx);
-          let form_data = match serde_json::from_str::<serde_json::Value>(&body) {
+          let form_data = match serde_json::from_str::<serde_json::Value>(&body_path.render(ctx)) {
             Ok(deserialized_data) => serde_urlencoded::to_string(deserialized_data)?,
-            Err(_) => body,
-          };
+            Err(_) => body_path.render(ctx),
+        };
 
           req.body_mut().replace(form_data.into());
         }


### PR DESCRIPTION
**Summary:**  
This pull request optimizes the set_body function in the RequestTemplate module.

**Issue Reference(s):**  
Fixes #934 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs

/claim #934 