### PR TITLE
fix: inner fields in nested input type was considered as output type

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -38,6 +38,7 @@ impl Config {
 
   pub fn output_types(&self) -> HashSet<&String> {
     let mut types = HashSet::new();
+    let input_types = self.input_types();
 
     if let Some(ref query) = &self.schema.query {
       types.insert(query);
@@ -46,9 +47,8 @@ impl Config {
     if let Some(ref mutation) = &self.schema.mutation {
       types.insert(mutation);
     }
-
-    for (_, type_of) in self.types.iter() {
-      if type_of.interface || !type_of.fields.is_empty() {
+    for (type_name, type_of) in self.types.iter() {
+      if (type_of.interface || !type_of.fields.is_empty()) && !input_types.contains(&type_name) {
         for (_, field) in type_of.fields.iter() {
           types.insert(&field.type_of);
         }
@@ -57,12 +57,29 @@ impl Config {
     types
   }
 
+  pub fn recurse_type<'a>(&'a self, type_of: &str, types: &mut HashSet<&'a String>) {
+    if let Some(type_) = self.find_type(type_of) {
+      for (_, field) in type_.fields.iter() {
+        if !types.contains(&field.type_of) {
+          types.insert(&field.type_of);
+          self.recurse_type(&field.type_of, types);
+        }
+      }
+    }
+  }
+
   pub fn input_types(&self) -> HashSet<&String> {
     let mut types = HashSet::new();
     for (_, type_of) in self.types.iter() {
       if !type_of.interface {
         for (_, field) in type_of.fields.iter() {
           for (_, arg) in field.args.iter() {
+            if let Some(t) = self.find_type(&arg.type_of) {
+              t.fields.iter().for_each(|(_, f)| {
+                types.insert(&f.type_of);
+                self.recurse_type(&f.type_of, &mut types)
+              })
+            }
             types.insert(&arg.type_of);
           }
         }
@@ -70,7 +87,6 @@ impl Config {
     }
     types
   }
-
   pub fn find_type(&self, name: &str) -> Option<&Type> {
     self.types.get(name)
   }

--- a/tests/graphql/test-nested-input.graphql
+++ b/tests/graphql/test-nested-input.graphql
@@ -1,0 +1,57 @@
+#> server-sdl
+schema @server @upstream {
+  query: Query
+}
+
+input A {
+  b: B
+}
+
+input B {
+  c: C
+}
+
+input C {
+  d: D
+}
+
+input D {
+  e: Int
+}
+
+type Query {
+  a(a: A!): X @const(data: {a: "hello"})
+}
+
+type X {
+  a: String
+}
+
+#> client-sdl
+input A {
+  b: B
+}
+
+input B {
+  c: C
+}
+
+input C {
+  d: D
+}
+
+input D {
+  e: Int
+}
+
+type Query {
+  a(a: A!): X
+}
+
+type X {
+  a: String
+}
+
+schema {
+  query: Query
+}


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
