### PR TITLE
fix: tokio runtime drop error on server start

### DIFF
--- a/src/cli/server/server.rs
+++ b/src/cli/server/server.rs
@@ -40,14 +40,12 @@ impl Server {
   }
 
   /// Starts the server in its own multithreaded Runtime
-  pub async fn fork_start(self) -> anyhow::Result<()> {
+  pub fn fork_start(self) -> anyhow::Result<()> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
       .worker_threads(self.config.server.get_workers())
       .enable_all()
       .build()?;
 
-    let _ = runtime.spawn(async { self.start().await }).await?;
-
-    Ok(())
+    runtime.block_on(async { self.start().await })
   }
 }

--- a/src/http/request_template.rs
+++ b/src/http/request_template.rs
@@ -32,6 +32,7 @@ impl RequestTemplate {
   /// Fills in all the mustache templates with required values.
   fn create_url<C: PathString>(&self, ctx: &C) -> anyhow::Result<Url> {
     let mut url = url::Url::parse(self.root_url.render(ctx).as_str())?;
+    println!("{:?}", self.query);
     if self.query.is_empty() && self.root_url.is_const() {
       return Ok(url);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,14 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 fn run_blocking() -> anyhow::Result<()> {
   let rt = tokio::runtime::Runtime::new()?;
-  rt.block_on(async { tailcall::cli::run().await })
+
+  let server = rt.block_on(async { tailcall::cli::run().await })?;
+
+  if let Some(server) = server {
+    server.fork_start()
+  } else {
+    Ok(())
+  }
 }
 
 fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
**Summary:**  
Fixing the runtime error on server start

**Issue Reference(s):**  
Fixes #971 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
