### PR TITLE
chore: move autogen files to `/generated`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {},
+  },
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 target/
+generated/
 *.schema.json

--- a/examples/jsonplaceholder.graphql
+++ b/examples/jsonplaceholder.graphql
@@ -6,6 +6,7 @@ schema
 
 type Query {
   posts: [Post] @http(path: "/posts")
+  users: [User] @http(path: "/users")
   user(id: Int!): User @http(path: "/users/{{args.id}}")
 }
 


### PR DESCRIPTION
**Summary:**  
This PR moves the auto generation of schema files at `/generated` directory

**Issue Reference(s):**  
Fixes #1019

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
