### PR TITLE
chore(docs): fix 404 in docs link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@ Fixes #... _(Replace "..." with the issue number)_
 - [ ] I have performed a self-review of my code.
 - [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`
 
-[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
+[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


### PR DESCRIPTION
**Summary:**  
Fixes 404 link in the pull request template.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcall/tree/main/docs
