### PR TITLE
fix(document): serialize @cache directives

### DIFF
--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -268,12 +268,13 @@ fn update_args<'a>(
     hasher: DefaultHasher,
 ) -> TryFold<'a, (&'a Config, &'a Field, &'a config::Type, &'a str), FieldDefinition, String> {
     TryFold::<(&Config, &Field, &config::Type, &str), FieldDefinition, String>::new(
-        move |(_, field, _, name), _| {
+        move |(_, field, typ, name), _| {
             let mut hasher = hasher.clone();
             name.hash(&mut hasher);
             let cache = field
                 .cache
                 .as_ref()
+                .or(typ.cache.as_ref())
                 .map(|config::Cache { max_age }| Cache { max_age: *max_age, hasher });
 
             // TODO! assert type name

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -118,9 +118,7 @@ fn to_types(
             )
             .some(),
             TypeKind::Enum(enum_type) => Valid::succeed(Some(to_enum(enum_type))),
-            TypeKind::InputObject(input_object_type) => {
-                to_input_object(input_object_type).some()
-            }
+            TypeKind::InputObject(input_object_type) => to_input_object(input_object_type).some(),
             TypeKind::Union(_) => Valid::none(),
             TypeKind::Scalar => Valid::succeed(Some(to_scalar_type())),
         }
@@ -197,9 +195,7 @@ fn to_enum(enum_type: EnumType) -> config::Type {
         .collect();
     config::Type { variants: Some(variants), ..Default::default() }
 }
-fn to_input_object(
-    input_object_type: InputObjectType,
-) -> Valid<config::Type, String> {
+fn to_input_object(input_object_type: InputObjectType) -> Valid<config::Type, String> {
     to_input_object_fields(&input_object_type.fields)
         .map(|fields| config::Type { fields, ..Default::default() })
 }
@@ -228,14 +224,10 @@ fn to_input_object_fields(
 ) -> Valid<BTreeMap<String, config::Field>, String> {
     to_fields_inner(input_object_fields, to_input_object_field)
 }
-fn to_field(
-    field_definition: &FieldDefinition,
-) -> Valid<config::Field, String> {
+fn to_field(field_definition: &FieldDefinition) -> Valid<config::Field, String> {
     to_common_field(field_definition, to_args(field_definition))
 }
-fn to_input_object_field(
-    field_definition: &InputValueDefinition,
-) -> Valid<config::Field, String> {
+fn to_input_object_field(field_definition: &InputValueDefinition) -> Valid<config::Field, String> {
     to_common_field(field_definition, BTreeMap::new())
 }
 fn to_common_field<F>(

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -104,31 +104,27 @@ fn to_types(
 ) -> Valid<BTreeMap<String, config::Type>, String> {
     Valid::from_iter(type_definitions, |type_definition| {
         let type_name = pos_name_to_string(&type_definition.node.name);
-        let directives = &type_definition.node.directives;
-        Cache::from_directives(directives.iter())
-            .and_then(|cache| match type_definition.node.kind.clone() {
-                TypeKind::Object(object_type) => to_object_type(
-                    &object_type,
-                    &type_definition.node.description,
-                    &type_definition.node.directives,
-                    cache,
-                )
-                .some(),
-                TypeKind::Interface(interface_type) => to_object_type(
-                    &interface_type,
-                    &type_definition.node.description,
-                    &type_definition.node.directives,
-                    cache,
-                )
-                .some(),
-                TypeKind::Enum(enum_type) => Valid::succeed(Some(to_enum(enum_type))),
-                TypeKind::InputObject(input_object_type) => {
-                    to_input_object(input_object_type, cache).some()
-                }
-                TypeKind::Union(_) => Valid::none(),
-                TypeKind::Scalar => Valid::succeed(Some(to_scalar_type())),
-            })
-            .map(|option| (type_name, option))
+        match type_definition.node.kind.clone() {
+            TypeKind::Object(object_type) => to_object_type(
+                &object_type,
+                &type_definition.node.description,
+                &type_definition.node.directives,
+            )
+            .some(),
+            TypeKind::Interface(interface_type) => to_object_type(
+                &interface_type,
+                &type_definition.node.description,
+                &type_definition.node.directives,
+            )
+            .some(),
+            TypeKind::Enum(enum_type) => Valid::succeed(Some(to_enum(enum_type))),
+            TypeKind::InputObject(input_object_type) => {
+                to_input_object(input_object_type).some()
+            }
+            TypeKind::Union(_) => Valid::none(),
+            TypeKind::Scalar => Valid::succeed(Some(to_scalar_type())),
+        }
+        .map(|option| (type_name, option))
     })
     .map(|vec| {
         BTreeMap::from_iter(
@@ -168,7 +164,6 @@ fn to_object_type<T>(
     object: &T,
     description: &Option<Positioned<String>>,
     directives: &[Positioned<ConstDirective>],
-    cache: Option<Cache>,
 ) -> Valid<config::Type, String>
 where
     T: ObjectLike,
@@ -177,19 +172,22 @@ where
     let implements = object.implements();
     let interface = object.is_interface();
 
-    to_fields(fields, cache).map(|fields| {
-        let doc = description.to_owned().map(|pos| pos.node);
-        let implements = implements.iter().map(|pos| pos.node.to_string()).collect();
-        let added_fields = to_add_fields_from_directives(directives);
-        config::Type {
-            fields,
-            added_fields,
-            doc,
-            interface,
-            implements,
-            ..Default::default()
-        }
-    })
+    Cache::from_directives(directives.iter())
+        .zip(to_fields(fields))
+        .map(|(cache, fields)| {
+            let doc = description.to_owned().map(|pos| pos.node);
+            let implements = implements.iter().map(|pos| pos.node.to_string()).collect();
+            let added_fields = to_add_fields_from_directives(directives);
+            config::Type {
+                fields,
+                added_fields,
+                doc,
+                interface,
+                implements,
+                cache,
+                ..Default::default()
+            }
+        })
 }
 fn to_enum(enum_type: EnumType) -> config::Type {
     let variants = enum_type
@@ -201,55 +199,48 @@ fn to_enum(enum_type: EnumType) -> config::Type {
 }
 fn to_input_object(
     input_object_type: InputObjectType,
-    cache: Option<Cache>,
 ) -> Valid<config::Type, String> {
-    to_input_object_fields(&input_object_type.fields, cache)
+    to_input_object_fields(&input_object_type.fields)
         .map(|fields| config::Type { fields, ..Default::default() })
 }
 
 fn to_fields_inner<T, F>(
     fields: &Vec<Positioned<T>>,
-    cache: Option<Cache>,
     transform: F,
 ) -> Valid<BTreeMap<String, config::Field>, String>
 where
-    F: Fn(&T, Option<Cache>) -> Valid<config::Field, String>,
+    F: Fn(&T) -> Valid<config::Field, String>,
     T: HasName,
 {
     Valid::from_iter(fields, |field| {
         let field_name = pos_name_to_string(field.node.name());
-        transform(&field.node, cache.clone()).map(|field| (field_name, field))
+        transform(&field.node).map(|field| (field_name, field))
     })
     .map(BTreeMap::from_iter)
 }
 fn to_fields(
     fields: &Vec<Positioned<FieldDefinition>>,
-    cache: Option<Cache>,
 ) -> Valid<BTreeMap<String, config::Field>, String> {
-    to_fields_inner(fields, cache, to_field)
+    to_fields_inner(fields, to_field)
 }
 fn to_input_object_fields(
     input_object_fields: &Vec<Positioned<InputValueDefinition>>,
-    cache: Option<Cache>,
 ) -> Valid<BTreeMap<String, config::Field>, String> {
-    to_fields_inner(input_object_fields, cache, to_input_object_field)
+    to_fields_inner(input_object_fields, to_input_object_field)
 }
 fn to_field(
     field_definition: &FieldDefinition,
-    cache: Option<Cache>,
 ) -> Valid<config::Field, String> {
-    to_common_field(field_definition, to_args(field_definition), cache)
+    to_common_field(field_definition, to_args(field_definition))
 }
 fn to_input_object_field(
     field_definition: &InputValueDefinition,
-    cache: Option<Cache>,
 ) -> Valid<config::Field, String> {
-    to_common_field(field_definition, BTreeMap::new(), cache)
+    to_common_field(field_definition, BTreeMap::new())
 }
 fn to_common_field<F>(
     field: &F,
     args: BTreeMap<String, config::Arg>,
-    parent_cache: Option<Cache>,
 ) -> Valid<config::Field, String>
 where
     F: Fieldlike,
@@ -290,7 +281,7 @@ where
                     const_field,
                     graphql,
                     expr,
-                    cache: cache.or(parent_cache),
+                    cache,
                 }
             },
         )

--- a/src/config/into_document.rs
+++ b/src/config/into_document.rs
@@ -182,19 +182,17 @@ fn config_document(config: &Config) -> ServiceDocument {
             extend: false,
             description: None,
             name: pos(Name::new(type_name.clone())),
-            directives: [
-                type_def
-                    .added_fields
-                    .iter()
-                    .map(|added_field: &super::AddField| pos(added_field.to_directive()))
-                    .collect::<Vec<_>>(),
-                if let Some(cache) = &type_def.cache {
-                    vec![pos(cache.to_directive())]
-                } else {
-                    vec![]
-                },
-            ]
-            .concat(),
+            directives: type_def
+                .added_fields
+                .iter()
+                .map(|added_field: &super::AddField| pos(added_field.to_directive()))
+                .chain(
+                    type_def
+                        .cache
+                        .as_ref()
+                        .map(|cache| pos(cache.to_directive())),
+                )
+                .collect::<Vec<_>>(),
             kind,
         })));
     }

--- a/src/config/into_document.rs
+++ b/src/config/into_document.rs
@@ -182,11 +182,18 @@ fn config_document(config: &Config) -> ServiceDocument {
             extend: false,
             description: None,
             name: pos(Name::new(type_name.clone())),
-            directives: type_def
-                .added_fields
-                .iter()
-                .map(|added_field| pos(added_field.to_directive()))
-                .collect::<Vec<_>>(),
+            directives: [
+                type_def
+                    .added_fields
+                    .iter()
+                    .map(|added_field: &super::AddField| pos(added_field.to_directive()))
+                    .collect::<Vec<_>>(),
+                if let Some(cache) = &type_def.cache {
+                    vec![pos(cache.to_directive())]
+                } else {
+                    vec![]
+                },
+            ].concat(),
             kind,
         })));
     }
@@ -219,6 +226,7 @@ fn get_directives(field: &crate::config::Field) -> Vec<Positioned<ConstDirective
         field.graphql.as_ref().map(|d| pos(d.to_directive())),
         field.grpc.as_ref().map(|d| pos(d.to_directive())),
         field.expr.as_ref().map(|d| pos(d.to_directive())),
+        field.cache.as_ref().map(|d| pos(d.to_directive())),
     ];
 
     directives.into_iter().flatten().collect()

--- a/src/config/into_document.rs
+++ b/src/config/into_document.rs
@@ -193,7 +193,8 @@ fn config_document(config: &Config) -> ServiceDocument {
                 } else {
                     vec![]
                 },
-            ].concat(),
+            ]
+            .concat(),
             kind,
         })));
     }

--- a/tests/graphql/test-cache.graphql
+++ b/tests/graphql/test-cache.graphql
@@ -1,0 +1,25 @@
+#> server-sdl
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  user: User @http(path: "/foo") @cache(maxAge: 300)
+}
+
+type User {
+  name: String
+}
+
+#> client-sdl
+type Query {
+  user: User
+}
+
+type User {
+  name: String
+}
+
+schema {
+  query: Query
+}

--- a/tests/graphql/test-cache.graphql
+++ b/tests/graphql/test-cache.graphql
@@ -7,7 +7,8 @@ type Query {
   user: User @http(path: "/foo") @cache(maxAge: 300)
 }
 
-type User {
+type User @cache(maxAge: 900) {
+  id: Int
   name: String
 }
 
@@ -17,6 +18,7 @@ type Query {
 }
 
 type User {
+  id: Int
   name: String
 }
 


### PR DESCRIPTION
**Summary:**  
`@cache` directives are not serialized when calling `config.to_sdl()`. This PR adds logic to `into_document.rs` to fix this.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
