### PR TITLE
chore: introduce and use `TargetRuntime`

### DIFF
--- a/cloudflare/src/handle.rs
+++ b/cloudflare/src/handle.rs
@@ -9,10 +9,10 @@ use tailcall::blueprint::Blueprint;
 use tailcall::config::reader::ConfigReader;
 use tailcall::config::ConfigSet;
 use tailcall::http::{graphiql, handle_request, AppContext};
-use tailcall::EnvIO;
+use tailcall::target_runtime::TargetRuntime;
 
 use crate::http::{to_request, to_response};
-use crate::{init_cache, init_env, init_file, init_http};
+use crate::init_runtime;
 
 lazy_static! {
     static ref APP_CTX: RwLock<Option<(String, Arc<AppContext>)>> = RwLock::new(None);
@@ -52,19 +52,8 @@ pub async fn fetch(req: worker::Request, env: worker::Env) -> anyhow::Result<wor
 ///
 /// Reads the configuration from the CONFIG environment variable.
 ///
-async fn get_config(
-    env_io: Arc<dyn EnvIO>,
-    env: Rc<worker::Env>,
-    file_path: &str,
-) -> anyhow::Result<ConfigSet> {
-    let bucket_id = env_io
-        .get("BUCKET")
-        .ok_or(anyhow!("BUCKET var is not set"))?;
-    log::debug!("R2 Bucket ID: {}", bucket_id);
-    let file_io = init_file(env.clone(), bucket_id)?;
-    let http_io = init_http();
-
-    let reader = ConfigReader::init(file_io, http_io);
+async fn get_config(runtime: TargetRuntime, file_path: &str) -> anyhow::Result<ConfigSet> {
+    let reader = ConfigReader::init(runtime);
     let config = reader.read(&file_path).await?;
     Ok(config)
 }
@@ -82,21 +71,13 @@ async fn get_app_ctx(env: Rc<worker::Env>, file_path: &str) -> anyhow::Result<Ar
         }
     }
     // Create new context
-    let env_io = init_env(env.clone());
-    let cfg = get_config(env_io.clone(), env.clone(), file_path).await?;
+    let runtime = init_runtime(env)?;
+    let cfg = get_config(runtime.clone(), file_path).await?;
     log::info!("Configuration read ... ok");
     log::debug!("\n{}", cfg.to_sdl());
     let blueprint = Blueprint::try_from(&cfg)?;
     log::info!("Blueprint generated ... ok");
-    let h_client = init_http();
-    let cache = init_cache(env);
-    let app_ctx = Arc::new(AppContext::new(
-        blueprint,
-        h_client.clone(),
-        h_client,
-        env_io,
-        cache,
-    ));
+    let app_ctx = Arc::new(AppContext::new(blueprint, runtime));
     *APP_CTX.write().unwrap() = Some((file_path.to_string(), app_ctx.clone()));
     log::info!("Initialized new application context");
     Ok(app_ctx)

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -7,32 +7,24 @@ use crate::blueprint::Type::ListType;
 use crate::blueprint::{Blueprint, Definition};
 use crate::data_loader::DataLoader;
 use crate::graphql::GraphqlDataLoader;
+use crate::grpc;
 use crate::grpc::data_loader::GrpcDataLoader;
 use crate::http::{DataLoaderRequest, HttpDataLoader};
 use crate::lambda::{DataLoaderId, Expression, IO};
-use crate::{grpc, EntityCache, EnvIO, HttpIO};
+use crate::target_runtime::TargetRuntime;
 
 pub struct AppContext {
     pub schema: dynamic::Schema,
-    pub universal_http_client: Arc<dyn HttpIO>,
-    pub http2_only_client: Arc<dyn HttpIO>,
+    pub runtime: TargetRuntime,
     pub blueprint: Blueprint,
     pub http_data_loaders: Arc<Vec<DataLoader<DataLoaderRequest, HttpDataLoader>>>,
     pub gql_data_loaders: Arc<Vec<DataLoader<DataLoaderRequest, GraphqlDataLoader>>>,
     pub grpc_data_loaders: Arc<Vec<DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>>>,
-    pub cache: Arc<EntityCache>,
-    pub env_vars: Arc<dyn EnvIO>,
 }
 
 impl AppContext {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        mut blueprint: Blueprint,
-        h_client: Arc<dyn HttpIO>,
-        h2_client: Arc<dyn HttpIO>,
-        env: Arc<dyn EnvIO>,
-        cache: Arc<EntityCache>,
-    ) -> Self {
+    pub fn new(mut blueprint: Blueprint, runtime: TargetRuntime) -> Self {
         let mut http_data_loaders = vec![];
         let mut gql_data_loaders = vec![];
         let mut grpc_data_loaders = vec![];
@@ -44,7 +36,7 @@ impl AppContext {
                         match expr {
                             IO::Http { req_template, group_by, .. } => {
                                 let data_loader = HttpDataLoader::new(
-                                    h_client.clone(),
+                                    runtime.http.clone(),
                                     group_by.clone(),
                                     matches!(&field.of_type, ListType { .. }),
                                 )
@@ -63,7 +55,7 @@ impl AppContext {
 
                             IO::GraphQLEndpoint { req_template, field_name, batch, .. } => {
                                 let graphql_data_loader =
-                                    GraphqlDataLoader::new(h_client.clone(), *batch)
+                                    GraphqlDataLoader::new(runtime.http.clone(), *batch)
                                         .to_data_loader(
                                             blueprint.upstream.batch.clone().unwrap_or_default(),
                                         );
@@ -80,7 +72,7 @@ impl AppContext {
 
                             IO::Grpc { req_template, group_by, .. } => {
                                 let data_loader = GrpcDataLoader {
-                                    client: h2_client.clone(),
+                                    client: runtime.http2_only.clone(),
                                     operation: req_template.operation.clone(),
                                     group_by: group_by.clone(),
                                 };
@@ -106,14 +98,11 @@ impl AppContext {
 
         AppContext {
             schema,
-            universal_http_client: h_client,
-            http2_only_client: h2_client,
+            runtime,
             blueprint,
             http_data_loaders: Arc::new(http_data_loaders),
             gql_data_loaders: Arc::new(gql_data_loaders),
-            cache,
             grpc_data_loaders: Arc::new(grpc_data_loaders),
-            env_vars: env,
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub use tc::run;
 
 use crate::cache::InMemoryCache;
 use crate::config::Upstream;
+use crate::target_runtime::TargetRuntime;
 use crate::{blueprint, EnvIO, FileIO, HttpIO};
 
 // Provides access to env in native rust environment
@@ -60,4 +61,14 @@ pub fn init_http2_only(upstream: &Upstream, script: Option<blueprint::Script>) -
 
 pub fn init_in_memory_cache<K: Hash + Eq, V: Clone>() -> InMemoryCache<K, V> {
     InMemoryCache::new()
+}
+
+pub fn init_runtime(upstream: &Upstream, script: Option<blueprint::Script>) -> TargetRuntime {
+    TargetRuntime {
+        http: init_http(upstream, script.clone()),
+        http2_only: init_http2_only(upstream, script),
+        env: init_env(),
+        file: init_file(),
+        cache: Arc::new(init_in_memory_cache()),
+    }
 }

--- a/src/cli/server/server_config.rs
+++ b/src/cli/server/server_config.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use crate::blueprint::{Blueprint, Http};
-use crate::cli::{init_env, init_http, init_http2_only, init_in_memory_cache};
+use crate::cli::init_runtime;
 use crate::http::AppContext;
 
 pub struct ServerConfig {
@@ -12,16 +12,9 @@ pub struct ServerConfig {
 
 impl ServerConfig {
     pub fn new(blueprint: Blueprint) -> Self {
-        let h_client = init_http(&blueprint.upstream, blueprint.server.script.clone());
-        let h2_client = init_http2_only(&blueprint.upstream, blueprint.server.script.clone());
-        let env = init_env();
-        let chrono_cache = Arc::new(init_in_memory_cache());
         let server_context = Arc::new(AppContext::new(
             blueprint.clone(),
-            h_client,
-            h2_client,
-            env,
-            chrono_cache,
+            init_runtime(&blueprint.upstream, blueprint.server.script.clone()),
         ));
         Self { app_ctx: server_context, blueprint }
     }

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::sync::Arc;
 use std::{env, fs};
 
 use anyhow::Result;
@@ -13,11 +12,11 @@ use super::update_checker;
 use crate::blueprint::{validate_operations, Blueprint, OperationQuery};
 use crate::cli::fmt::Fmt;
 use crate::cli::server::Server;
-use crate::cli::{init_file, init_http, CLIError};
+use crate::cli::{init_runtime, CLIError};
 use crate::config::reader::ConfigReader;
 use crate::config::{Config, Upstream};
+use crate::print_schema;
 use crate::valid::Validator;
-use crate::{print_schema, FileIO};
 
 const FILE_NAME: &str = ".tailcallrc.graphql";
 const YML_FILE_NAME: &str = ".graphqlrc.yml";
@@ -26,9 +25,8 @@ pub async fn run() -> Result<()> {
     let cli = Cli::parse();
     logger_init();
     update_checker::check_for_update().await;
-    let file_io: Arc<dyn FileIO> = init_file();
-    let default_http_io = init_http(&Upstream::default(), None);
-    let config_reader = ConfigReader::init(file_io.clone(), default_http_io);
+    let runtime = init_runtime(&Upstream::default(), None);
+    let config_reader = ConfigReader::init(runtime.clone());
     match cli.command {
         Command::Start { file_paths } => {
             let config_set = config_reader.read_all(&file_paths).await?;
@@ -51,7 +49,8 @@ pub async fn run() -> Result<()> {
 
                     let ops: Vec<OperationQuery> =
                         futures_util::future::join_all(operations.iter().map(|op| async {
-                            file_io
+                            runtime
+                                .file
                                 .read(op)
                                 .await
                                 .map(|query| OperationQuery::new(query, op.clone()))

--- a/src/grpc/data_loader_request.rs
+++ b/src/grpc/data_loader_request.rs
@@ -61,7 +61,7 @@ mod tests {
     use url::Url;
 
     use super::DataLoaderRequest;
-    use crate::cli::{init_file, init_http};
+    use crate::cli::init_runtime;
     use crate::config::reader::ConfigReader;
     use crate::config::{Config, Field, Grpc, Type, Upstream};
     use crate::grpc::protobuf::{ProtobufOperation, ProtobufSet};
@@ -75,8 +75,7 @@ mod tests {
         test_file.push("tests");
         test_file.push("greetings.proto");
 
-        let file_io = init_file();
-        let http_io = init_http(&Upstream::default(), None);
+        let runtime = init_runtime(&Upstream::default(), None);
         let mut config = Config::default();
         let grpc = Grpc {
             proto_path: test_file.to_str().unwrap().to_string(),
@@ -86,7 +85,7 @@ mod tests {
             "foo".to_string(),
             Type::default().fields(vec![("bar", Field::default().grpc(grpc))]),
         );
-        let reader = ConfigReader::init(file_io, http_io);
+        let reader = ConfigReader::init(runtime);
         let config_set = reader.resolve(config).await.unwrap();
 
         let protobuf_set =

--- a/src/grpc/protobuf.rs
+++ b/src/grpc/protobuf.rs
@@ -202,7 +202,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::cli::{init_file, init_http};
+    use crate::cli::init_runtime;
     use crate::config::reader::ConfigReader;
     use crate::config::{Config, Field, Grpc, Type, Upstream};
 
@@ -224,9 +224,8 @@ mod tests {
     }
 
     async fn get_proto_file(name: &str) -> Result<FileDescriptorSet> {
-        let file_io = init_file();
-        let http_io = init_http(&Upstream::default(), None);
-        let reader = ConfigReader::init(file_io, http_io);
+        let runtime = init_runtime(&Upstream::default(), None);
+        let reader = ConfigReader::init(runtime);
         let mut config = Config::default();
         let grpc = Grpc {
             proto_path: get_test_file(name)

--- a/src/grpc/request_template.rs
+++ b/src/grpc/request_template.rs
@@ -106,7 +106,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::RequestTemplate;
-    use crate::cli::{init_file, init_http};
+    use crate::cli::init_runtime;
     use crate::config::reader::ConfigReader;
     use crate::config::{Config, Field, GraphQLOperationType, Grpc, Type, Upstream};
     use crate::grpc::protobuf::{ProtobufOperation, ProtobufSet};
@@ -120,9 +120,8 @@ mod tests {
         test_file.push("tests");
         test_file.push("greetings.proto");
 
-        let file_io = init_file();
-        let http_io = init_http(&Upstream::default(), None);
-        let reader = ConfigReader::init(file_io, http_io);
+        let runtime = init_runtime(&Upstream::default(), None);
+        let reader = ConfigReader::init(runtime);
         let mut config = Config::default();
         let grpc = Grpc {
             proto_path: test_file.to_str().unwrap().to_string(),

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -102,18 +102,18 @@ impl RequestContext {
 impl From<&AppContext> for RequestContext {
     fn from(server_ctx: &AppContext) -> Self {
         Self {
-            h_client: server_ctx.universal_http_client.clone(),
-            h2_client: server_ctx.http2_only_client.clone(),
+            h_client: server_ctx.runtime.http.clone(),
+            h2_client: server_ctx.runtime.http2_only.clone(),
             server: server_ctx.blueprint.server.clone(),
             upstream: server_ctx.blueprint.upstream.clone(),
             req_headers: HeaderMap::new(),
             http_data_loaders: server_ctx.http_data_loaders.clone(),
             gql_data_loaders: server_ctx.gql_data_loaders.clone(),
-            cache: server_ctx.cache.clone(),
+            cache: server_ctx.runtime.cache.clone(),
             grpc_data_loaders: server_ctx.grpc_data_loaders.clone(),
             min_max_age: Arc::new(Mutex::new(None)),
             cache_public: Arc::new(Mutex::new(None)),
-            env_vars: server_ctx.env_vars.clone(),
+            env_vars: server_ctx.runtime.env.clone(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod lambda;
 pub mod mustache;
 pub mod path;
 pub mod print_schema;
+pub mod target_runtime;
 pub mod try_fold;
 pub mod valid;
 

--- a/src/target_runtime.rs
+++ b/src/target_runtime.rs
@@ -4,6 +4,9 @@ use async_graphql_value::ConstValue;
 
 use crate::{Cache, EnvIO, FileIO, HttpIO};
 
+/// The TargetRuntime struct unifies the available runtime-specific
+/// IO implementations. This is used to reduce piping IO structs all
+/// over the codebase.
 #[derive(Clone)]
 pub struct TargetRuntime {
     pub http: Arc<dyn HttpIO>,

--- a/src/target_runtime.rs
+++ b/src/target_runtime.rs
@@ -1,0 +1,14 @@
+use std::sync::Arc;
+
+use async_graphql_value::ConstValue;
+
+use crate::{Cache, EnvIO, FileIO, HttpIO};
+
+#[derive(Clone)]
+pub struct TargetRuntime {
+    pub http: Arc<dyn HttpIO>,
+    pub http2_only: Arc<dyn HttpIO>,
+    pub env: Arc<dyn EnvIO>,
+    pub file: Arc<dyn FileIO>,
+    pub cache: Arc<dyn Cache<Key = u64, Value = ConstValue>>,
+}

--- a/tests/graphql_spec.rs
+++ b/tests/graphql_spec.rs
@@ -15,13 +15,12 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tailcall::blueprint::Blueprint;
-use tailcall::cli::{init_env, init_file, init_http, init_in_memory_cache, init_runtime};
+use tailcall::cli::init_runtime;
 use tailcall::config::reader::ConfigReader;
 use tailcall::config::{Config, ConfigSet};
 use tailcall::directive::DirectiveCodec;
 use tailcall::http::{AppContext, RequestContext};
 use tailcall::print_schema;
-use tailcall::target_runtime::TargetRuntime;
 use tailcall::valid::{Cause, Valid, ValidationError, Validator};
 
 static INIT: Once = Once::new();
@@ -331,19 +330,8 @@ async fn test_execution() -> std::io::Result<()> {
                     .trace(spec.path.to_str().unwrap_or_default())
                     .to_result()
                     .unwrap();
-                let h_client = init_http(&blueprint.upstream, None);
-                let h2_client = init_http(&blueprint.upstream, None);
-                let chrono_cache = init_in_memory_cache();
-                let server_ctx = AppContext::new(
-                    blueprint,
-                    TargetRuntime {
-                        http: h_client,
-                        http2_only: h2_client,
-                        env: init_env(),
-                        cache: Arc::new(chrono_cache),
-                        file: init_file(),
-                    },
-                );
+                let runtime = init_runtime(&blueprint.upstream, None);
+                let server_ctx = AppContext::new(blueprint, runtime);
                 let schema = &server_ctx.schema;
 
                 for q in spec.test_queries {

--- a/tests/http_spec.rs
+++ b/tests/http_spec.rs
@@ -18,10 +18,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tailcall::async_graphql_hyper::{GraphQLBatchRequest, GraphQLRequest};
 use tailcall::blueprint::Blueprint;
-use tailcall::cli::{init_file, init_hook_http, init_http, init_in_memory_cache};
+use tailcall::cli::{init_hook_http, init_in_memory_cache, init_runtime};
 use tailcall::config::reader::ConfigReader;
 use tailcall::config::{Config, ConfigSet, Source, Upstream};
 use tailcall::http::{handle_request, AppContext, Method, Response};
+use tailcall::target_runtime::TargetRuntime;
 use tailcall::{EnvIO, HttpIO};
 use url::Url;
 
@@ -199,11 +200,10 @@ impl HttpSpec {
     }
 
     async fn server_context(&self) -> Arc<AppContext> {
-        let file_io = init_file();
-        let http_client = init_http(&Upstream::default(), None);
+        let runtime = init_runtime(&Upstream::default(), None);
         let config = match self.config.clone() {
             ConfigSource::File(file) => {
-                let reader = ConfigReader::init(file_io, http_client);
+                let reader = ConfigReader::init(runtime.clone());
                 reader.read_all(&[file]).await.unwrap()
             }
             ConfigSource::Inline(config) => ConfigSet::from(config),
@@ -216,7 +216,16 @@ impl HttpSpec {
         let http2_client = Arc::new(MockHttpClient::new(self.clone()));
         let env = Arc::new(Env::init(self.env.clone()));
         let chrono_cache = Arc::new(init_in_memory_cache());
-        let server_context = AppContext::new(blueprint, client, http2_client, env, chrono_cache);
+        let server_context = AppContext::new(
+            blueprint,
+            TargetRuntime {
+                http: client,
+                http2_only: http2_client,
+                env,
+                cache: chrono_cache,
+                file: runtime.file.clone(),
+            },
+        );
         Arc::new(server_context)
     }
 }

--- a/tests/server_spec.rs
+++ b/tests/server_spec.rs
@@ -1,14 +1,13 @@
 use reqwest::Client;
 use serde_json::json;
+use tailcall::cli::init_runtime;
 use tailcall::cli::server::Server;
-use tailcall::cli::{init_file, init_http};
 use tailcall::config::reader::ConfigReader;
 use tailcall::config::Upstream;
 
 async fn test_server(configs: &[&str], url: &str) {
-    let file_io = init_file();
-    let http_client = init_http(&Upstream::default(), None);
-    let reader = ConfigReader::init(file_io, http_client);
+    let runtime = init_runtime(&Upstream::default(), None);
+    let reader = ConfigReader::init(runtime);
     let config = reader.read_all(configs).await.unwrap();
     let mut server = Server::new(config);
     let server_up_receiver = server.server_up_receiver();
@@ -92,9 +91,8 @@ async fn server_start_http2_rsa() {
 #[tokio::test]
 async fn server_start_http2_nokey() {
     let configs = &["tests/server/config/server-start-http2-nokey.graphql"];
-    let file_io = init_file();
-    let http_client = init_http(&Upstream::default(), None);
-    let reader = ConfigReader::init(file_io, http_client);
+    let runtime = init_runtime(&Upstream::default(), None);
+    let reader = ConfigReader::init(runtime);
     let config = reader.read_all(configs).await.unwrap();
     let server = Server::new(config);
     assert!(server.start().await.is_err())


### PR DESCRIPTION
**Summary:**  
Adds `TargetRuntime` struct and uses it for `ConfigReader` and `AppContext` to simplify piping.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
