### PR TITLE
chore: various execution_spec/testconv hotfixes

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -2,7 +2,7 @@
 yj -t < Cargo.toml > Cargo.yaml
 
 # Modify Cargo.yaml
-yq e 'del(.workspace.members[] | select(. == "cloudflare" or . == "autogen"))' -i Cargo.yaml
+yq e 'del(.workspace.members[] | select(. == "cloudflare" or . == "autogen" or . == "testconv"))' -i Cargo.yaml
 
 # Convert Cargo.yaml back to TOML
 yj -yt < Cargo.yaml > Cargo.toml

--- a/testconv/src/http.rs
+++ b/testconv/src/http.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use derive_setters::Setters;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use tailcall::config::Config;
 
@@ -30,7 +29,7 @@ pub struct HttpSpec {
     pub mock: Vec<Mock>,
 
     #[serde(default)]
-    pub env: HashMap<String, String>,
+    pub env: IndexMap<String, String>,
 
     #[serde(default)]
     pub expected_upstream_requests: Vec<UpstreamRequest>,

--- a/testconv/src/main.rs
+++ b/testconv/src/main.rs
@@ -649,8 +649,14 @@ async fn main() {
 
     println!("Running prettier...");
 
+    let prettierrc = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../.prettierrc");
     let prettier = std::process::Command::new("prettier")
-        .args(["-c", ".prettierrc", "--write", "tests/execution/*.md"])
+        .args([
+            "-c",
+            prettierrc.to_string_lossy().as_ref(),
+            "--write",
+            "tests/execution/*.md",
+        ])
         .output()
         .expect("Failed to run prettier");
 

--- a/testconv/src/main.rs
+++ b/testconv/src/main.rs
@@ -236,44 +236,46 @@ async fn main() {
             f.write_all(spec.as_bytes())
                 .expect("Failed to write execution spec");
 
-            for (i, assert) in old.assert.iter().enumerate() {
-                let mut f = File::options()
-                    .create(true)
-                    .write(true)
-                    .truncate(true)
-                    .open(snapshots_dir.join(PathBuf::from(format!(
-                        "execution_spec__{}.md_assert_{}.snap",
-                        file_stem, i
-                    ))))
-                    .expect("Failed to open execution snapshot");
+            if !has_fail_annotation {
+                for (i, assert) in old.assert.iter().enumerate() {
+                    let mut f = File::options()
+                        .create(true)
+                        .write(true)
+                        .truncate(true)
+                        .open(snapshots_dir.join(PathBuf::from(format!(
+                            "execution_spec__{}.md_assert_{}.snap",
+                            file_stem, i
+                        ))))
+                        .expect("Failed to open execution snapshot");
 
-                let mut res = assert.response.to_owned();
+                    let mut res = assert.response.to_owned();
 
-                res.0.headers = res
-                    .0
-                    .headers
-                    .into_iter()
-                    .map(|(k, v)| (k.to_lowercase(), v.to_owned()))
-                    .collect();
+                    res.0.headers = res
+                        .0
+                        .headers
+                        .into_iter()
+                        .map(|(k, v)| (k.to_lowercase(), v.to_owned()))
+                        .collect();
 
-                if !res.0.headers.contains_key("content-type") {
+                    if !res.0.headers.contains_key("content-type") {
+                        res.0
+                            .headers
+                            .insert("content-type".to_string(), "application/json".to_string());
+                    }
+
                     res.0
                         .headers
-                        .insert("content-type".to_string(), "application/json".to_string());
+                        .sort_by(|a, _, b, _| a.partial_cmp(b).unwrap());
+
+                    let snap = format!(
+                        "---\nsource: tests/execution_spec.rs\nexpression: response\n---\n{}\n",
+                        serde_json::to_string_pretty(&res)
+                            .expect("Failed to serialize assert.response"),
+                    );
+
+                    f.write_all(snap.as_bytes())
+                        .expect("Failed to write exception spec");
                 }
-
-                res.0
-                    .headers
-                    .sort_by(|a, _, b, _| a.partial_cmp(b).unwrap());
-
-                let snap = format!(
-                    "---\nsource: tests/execution_spec.rs\nexpression: response\n---\n{}\n",
-                    serde_json::to_string_pretty(&res)
-                        .expect("Failed to serialize assert.response"),
-                );
-
-                f.write_all(snap.as_bytes())
-                    .expect("Failed to write exception spec");
             }
 
             if !bad_graphql_skip {
@@ -293,77 +295,6 @@ async fn main() {
                         generate_merged_snapshot(&file_stem, &config).await;
                     }
                 };
-            }
-
-            if has_fail_annotation {
-                let test = std::process::Command::new("cargo")
-                    .env("INSTA_FORCE_PASS", "1")
-                    .args([
-                        "test",
-                        "--no-fail-fast",
-                        "--no-default-features",
-                        "--features",
-                        "cli",
-                        "-p",
-                        "tailcall",
-                        "--test",
-                        "execution_spec",
-                        "--",
-                        execution_dir.join(&md_path).to_str().unwrap(),
-                    ])
-                    .output()
-                    .expect("Failed to run cargo test");
-
-                println!(
-                    "{}{}",
-                    String::from_utf8_lossy(&test.stdout),
-                    String::from_utf8_lossy(&test.stderr)
-                );
-
-                if !test.status.success() {
-                    panic!(
-                        "Running cargo test (needed for fail annotation conversion) failed:\n{}",
-                        String::from_utf8_lossy(&test.stderr)
-                    );
-                }
-
-                let mut patched = 0;
-
-                for i in 0..old.assert.len() {
-                    let old = snapshots_dir.join(PathBuf::from(format!(
-                        "execution_spec__{}.md_assert_{}.snap",
-                        file_stem, i
-                    )));
-
-                    let new = snapshots_dir.join(PathBuf::from(format!(
-                        "execution_spec__{}.md_assert_{}.snap.new",
-                        file_stem, i
-                    )));
-
-                    if new.exists() {
-                        std::fs::rename(new, &old).unwrap();
-
-                        let snap = fs::read_to_string(&old)
-                            .expect("Failed to read back snapshot for patching");
-
-                        let lines = snap
-                            .split('\n')
-                            .filter(|x| !x.starts_with("assertion_line"))
-                            .collect::<Vec<&str>>()
-                            .join("\n");
-
-                        std::fs::write(&old, lines).expect("Failed to write back patched snapshot");
-
-                        patched += 1;
-                    }
-                }
-
-                if patched == 0 {
-                    panic!(
-                        "Spec {:?} has a fail annotation but all tests passed.",
-                        path
-                    );
-                }
             }
 
             files_already_processed.insert(file_stem);

--- a/testconv/src/main.rs
+++ b/testconv/src/main.rs
@@ -314,7 +314,7 @@ async fn main() {
                     .output()
                     .expect("Failed to run cargo test");
 
-                print!(
+                println!(
                     "{}{}",
                     String::from_utf8_lossy(&test.stdout),
                     String::from_utf8_lossy(&test.stderr)
@@ -326,7 +326,6 @@ async fn main() {
                         String::from_utf8_lossy(&test.stderr)
                     );
                 }
-
 
                 let mut patched = 0;
 

--- a/testconv/src/main.rs
+++ b/testconv/src/main.rs
@@ -321,6 +321,10 @@ async fn main() {
                     );
                 }
 
+                print!("{}{}", &test.stdout, &test.stderr);
+
+                let mut patched = 0;
+
                 for i in 0..old.assert.len() {
                     let old = snapshots_dir.join(PathBuf::from(format!(
                         "execution_spec__{}.md_assert_{}.snap",
@@ -345,7 +349,16 @@ async fn main() {
                             .join("\n");
 
                         std::fs::write(&old, lines).expect("Failed to write back patched snapshot");
+
+                        patched += 1;
                     }
+                }
+
+                if patched == 0 {
+                    panic!(
+                        "Spec {:?} has a fail annotation but all tests passed.",
+                        path
+                    );
                 }
             }
 

--- a/testconv/src/main.rs
+++ b/testconv/src/main.rs
@@ -303,6 +303,9 @@ async fn main() {
                     .args([
                         "test",
                         "--no-fail-fast",
+                        "--no-default-features",
+                        "--features",
+                        "cli",
                         "-p",
                         "tailcall",
                         "--test",

--- a/testconv/src/main.rs
+++ b/testconv/src/main.rs
@@ -314,6 +314,12 @@ async fn main() {
                     .output()
                     .expect("Failed to run cargo test");
 
+                print!(
+                    "{}{}",
+                    String::from_utf8_lossy(&test.stdout),
+                    String::from_utf8_lossy(&test.stderr)
+                );
+
                 if !test.status.success() {
                     panic!(
                         "Running cargo test (needed for fail annotation conversion) failed:\n{}",
@@ -321,7 +327,6 @@ async fn main() {
                     );
                 }
 
-                print!("{}{}", &test.stdout, &test.stderr);
 
                 let mut patched = 0;
 

--- a/testconv/src/main.rs
+++ b/testconv/src/main.rs
@@ -293,8 +293,6 @@ async fn main() {
                         generate_merged_snapshot(&file_stem, &config).await;
                     }
                 };
-            } else {
-                println!("TODO: generate client snap for bad graphql skips")
             }
 
             if has_fail_annotation {
@@ -323,8 +321,6 @@ async fn main() {
                     );
                 }
 
-                let mut patched = 0;
-
                 for i in 0..old.assert.len() {
                     let old = snapshots_dir.join(PathBuf::from(format!(
                         "execution_spec__{}.md_assert_{}.snap",
@@ -349,16 +345,7 @@ async fn main() {
                             .join("\n");
 
                         std::fs::write(&old, lines).expect("Failed to write back patched snapshot");
-
-                        patched += 1;
                     }
-                }
-
-                if patched == 0 {
-                    panic!(
-                        "Spec {:?} has a fail annotation but all tests passed.",
-                        path
-                    );
                 }
             }
 

--- a/tests/execution_spec.rs
+++ b/tests/execution_spec.rs
@@ -756,7 +756,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Explicitly only run one test if specified in command line args
     // This is used by testconv to auto-apply the snapshots of unconvertable fail-annotated http specs
-    let explicit = std::env::args().skip(1).find(|x| !x.starts_with('-'));
+    let explicit = std::env::args().skip(1).find(|x| !x.starts_with('--'));
     let spec = if let Some(explicit) = explicit {
         let path = PathBuf::from(&explicit)
             .canonicalize()

--- a/tests/execution_spec.rs
+++ b/tests/execution_spec.rs
@@ -756,7 +756,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Explicitly only run one test if specified in command line args
     // This is used by testconv to auto-apply the snapshots of unconvertable fail-annotated http specs
-    let explicit = std::env::args().skip(1).find(|x| !x.starts_with('--'));
+    let explicit = std::env::args().skip(1).find(|x| !x.starts_with("--"));
     let spec = if let Some(explicit) = explicit {
         let path = PathBuf::from(&explicit)
             .canonicalize()

--- a/tests/execution_spec.rs
+++ b/tests/execution_spec.rs
@@ -756,7 +756,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Explicitly only run one test if specified in command line args
     // This is used by testconv to auto-apply the snapshots of unconvertable fail-annotated http specs
-    let explicit = std::env::args().skip(1).find(|x| x != "--color=auto");
+    let explicit = std::env::args().skip(1).find(|x| !x.starts_with('-'));
     let spec = if let Some(explicit) = explicit {
         let path = PathBuf::from(&explicit)
             .canonicalize()

--- a/tests/snapshots/execution_spec__graphql-dataloader-batch-keys.md_assert_0.snap
+++ b/tests/snapshots/execution_spec__graphql-dataloader-batch-keys.md_assert_0.snap
@@ -8,52 +8,17 @@ expression: response
     "content-type": "application/json"
   },
   "body": {
-    "a": [
+    "data": null,
+    "errors": [
       {
-        "b": {
-          "y": 1
-        },
-        "bid": 1,
-        "c": {
-          "x": 1
-        },
-        "cid": 1,
-        "id": 1
-      },
-      {
-        "b": {
-          "y": 1
-        },
-        "bid": 1,
-        "c": {
-          "x": 1
-        },
-        "cid": 1,
-        "id": 2
-      },
-      {
-        "b": {
-          "y": 1
-        },
-        "bid": 2,
-        "c": {
-          "x": 1
-        },
-        "cid": 2,
-        "id": 3
-      },
-      {
-        "b": {
-          "y": 1
-        },
-        "bid": 2,
-        "c": {
-          "x": 1
-        },
-        "cid": 2,
-        "id": 4
+        "locations": [
+          {
+            "column": 9,
+            "line": 1
+          }
+        ],
+        "message": "IOException: No mock found for request: POST http://upstream/graphql in tests/execution/graphql-dataloader-batch-keys.md"
       }
-    ],
-    "data": null
+    ]
   }
 }

--- a/tests/snapshots/execution_spec__graphql-dataloader-batch-keys.md_assert_0.snap
+++ b/tests/snapshots/execution_spec__graphql-dataloader-batch-keys.md_assert_0.snap
@@ -8,17 +8,52 @@ expression: response
     "content-type": "application/json"
   },
   "body": {
-    "data": null,
-    "errors": [
+    "a": [
       {
-        "locations": [
-          {
-            "column": 9,
-            "line": 1
-          }
-        ],
-        "message": "IOException: No mock found for request: POST http://upstream/graphql in tests/execution/graphql-dataloader-batch-keys.md"
+        "b": {
+          "y": 1
+        },
+        "bid": 1,
+        "c": {
+          "x": 1
+        },
+        "cid": 1,
+        "id": 1
+      },
+      {
+        "b": {
+          "y": 1
+        },
+        "bid": 1,
+        "c": {
+          "x": 1
+        },
+        "cid": 1,
+        "id": 2
+      },
+      {
+        "b": {
+          "y": 1
+        },
+        "bid": 2,
+        "c": {
+          "x": 1
+        },
+        "cid": 2,
+        "id": 3
+      },
+      {
+        "b": {
+          "y": 1
+        },
+        "bid": 2,
+        "c": {
+          "x": 1
+        },
+        "cid": 2,
+        "id": 4
       }
-    ]
+    ],
+    "data": null
   }
 }


### PR DESCRIPTION
**Summary:**  
This PR fixes:
- people can't use normal cargo test harness feature flags with cargo test anymore because execution_spec would try to look up a file with it.
- prettierrc file not located leading to lots of formatting changes that are useless
- properties in `env` dancing around resulting in useless diffs

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
