### PR TITLE
chore(prettier): don't put trailing commas in devcontainer.json

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -25,6 +25,12 @@
       "options": {
         "printWidth": 200
       }
+    },
+    {
+      "files": ["devcontainer.json"],
+      "options": {
+        "trailingComma": "none"
+      }
     }
   ]
 }


### PR DESCRIPTION
**Summary:**  
This PR fixes the inconsistency in the rules for `devcontainer.json` between the CI and local environments.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
