### PR TITLE
chore: cargo profile warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,11 @@ debug = false
 incremental = false
 overflow-checks = false
 
+[profile.release.package.cloudflare]
+strip = true
+codegen-units = 1
+opt-level = 'z'
+
 [[test]]
 name = "execution_spec"
 harness = false

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -25,8 +25,3 @@ serde_qs = "0.12.0"
 console_error_panic_hook = "0.1.7"
 protox = "0.5.1"
 
-[profile.release]
-lto = true
-strip = true
-codegen-units = 1
-opt-level = 'z'


### PR DESCRIPTION
This PR fixes `warning: profiles for the non root package will be ignored, specify profiles at the workspace root:`

**Issue Reference(s):**  
Fixes #1109
/claim #1109

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.