### PR TITLE
fix: Removed [profile.release] cloudflare/Cargo.toml

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -24,9 +24,3 @@ serde_json = "1.0.113"
 serde_qs = "0.12.0"
 console_error_panic_hook = "0.1.7"
 protox = "0.5.1"
-
-[profile.release]
-lto = true
-strip = true
-codegen-units = 1
-opt-level = 'z'


### PR DESCRIPTION
**Summary:**  
This PR fixes warning: profiles for the non root package will be ignored, specify profiles at the workspace root:

**Issue Reference(s):**  
Fixes #1109
/claim #1109

**Build & Testing:**

- [X] I ran `cargo test` successfully.
- [X ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.
