### PR TITLE
fix(aws): update lambda_http to fix AWS Lambda build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
  "async-trait",
  "hyper 0.14.28",
  "lambda_http",
- "lambda_runtime 0.9.1",
+ "lambda_runtime",
  "reqwest",
  "tailcall",
  "tokio",
@@ -531,15 +531,15 @@ dependencies = [
 
 [[package]]
 name = "aws_lambda_events"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03611508dd1e514e311caec235b581c99a4cb66fa1771bd502819eed69894f12"
+checksum = "d5af275f3e5801892c4295a919c5edbe8d24134f91458269a77a2da12622c123"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "http 0.2.11",
- "http-body 0.4.6",
- "http-serde 1.1.3",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-serde 2.0.0",
  "query_map",
  "serde",
  "serde_json",
@@ -565,12 +565,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -2208,50 +2202,29 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2505c4a24f5a8d8ac66a87691215ec1f79736c5bc6e62bb921788dca9753f650"
+checksum = "dacbb68e7ae5264884f114f79d4e0de33c66cb5a8f363ac93de7112f624d233d"
 dependencies = [
  "aws_lambda_events",
  "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures",
- "http 0.2.11",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "lambda_runtime 0.8.3",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "lambda_runtime",
  "mime",
  "percent-encoding",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio-stream",
  "url",
-]
-
-[[package]]
-name = "lambda_runtime"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deca8f65d7ce9a8bfddebb49d7d91b22e788a59ca0c5190f26794ab80ed7a702"
-dependencies = [
- "async-stream",
- "base64 0.20.0",
- "bytes",
- "futures",
- "http 0.2.11",
- "http-body 0.4.6",
- "http-serde 1.1.3",
- "hyper 0.14.28",
- "lambda_runtime_api_client 0.8.0",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
 ]
 
 [[package]]
@@ -2270,7 +2243,7 @@ dependencies = [
  "http-serde 2.0.0",
  "hyper 1.1.0",
  "hyper-util",
- "lambda_runtime_api_client 0.9.0",
+ "lambda_runtime_api_client",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2278,18 +2251,6 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
-]
-
-[[package]]
-name = "lambda_runtime_api_client"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690c5ae01f3acac8c9c3348b556fc443054e9b7f1deaf53e9ebab716282bf0ed"
-dependencies = [
- "http 0.2.11",
- "hyper 0.14.28",
- "tokio",
- "tower-service",
 ]
 
 [[package]]

--- a/aws-lambda/Cargo.toml
+++ b/aws-lambda/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 # and it will keep the alphabetic ordering for you.
 
 [dependencies]
-lambda_http = "0.8.3"
+lambda_http = "0.9.2"
 lambda_runtime = "0.9.1"
 tokio = { version = "1", features = ["macros", "fs"] }
 tracing = { version = "0.1", features = ["log"] }

--- a/aws-lambda/src/main.rs
+++ b/aws-lambda/src/main.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use http::to_request;
+use http::{to_request, to_response};
 use lambda_http::{run, service_fn, Error, Response};
 use runtime::init_runtime;
 use tailcall::async_graphql_hyper::GraphQLRequest;
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Error> {
 
     run(service_fn(|event| async {
         let resp = handle_request::<GraphQLRequest>(to_request(event)?, app_ctx.clone()).await?;
-        Ok::<Response<hyper::Body>, Error>(resp)
+        Ok::<Response<lambda_http::Body>, Error>(to_response(resp).await?)
     }))
     .await
 }

--- a/aws-lambda/src/main.rs
+++ b/aws-lambda/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use http::{to_request, to_response};
-use lambda_http::{run, service_fn, Error, Response};
+use lambda_http::{run, service_fn, Body, Error, Response};
 use runtime::init_runtime;
 use tailcall::async_graphql_hyper::GraphQLRequest;
 use tailcall::blueprint::Blueprint;
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Error> {
 
     run(service_fn(|event| async {
         let resp = handle_request::<GraphQLRequest>(to_request(event)?, app_ctx.clone()).await?;
-        Ok::<Response<lambda_http::Body>, Error>(to_response(resp).await?)
+        Ok::<Response<Body>, Error>(to_response(resp).await?)
     }))
     .await
 }


### PR DESCRIPTION
**Summary:**  
The disparity between the `lambda_runtime` and `lambda_http` versions broke the AWS build. This PR updates `lambda_http` to fix our AWS build.

This update is made more complex by the version disparity of the `http` crate in `lambda_http` and the version of `hyper` we are using. A lot of this code is temporary and we can get rid of it once we update `hyper`. However, we cannot avoid this code altogether, since this fix is needed.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
