### PR TITLE
fix(docker): fix build being broken by AWS

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -2,7 +2,7 @@
 yj -t < Cargo.toml > Cargo.yaml
 
 # Modify Cargo.yaml
-yq e 'del(.workspace.members[] | select(. == "cloudflare" or . == "autogen" or . == "testconv"))' -i Cargo.yaml
+yq e 'del(.workspace.members[] | select(. == "cloudflare" or . == "autogen" or . == "testconv" or . == "aws-lambda"))' -i Cargo.yaml
 
 # Convert Cargo.yaml back to TOML
 yj -yt < Cargo.yaml > Cargo.toml


### PR DESCRIPTION
**Summary:**  
This PR adds a missing workspace member removal to `docker.sh` which fixes the docker image build in the CI.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
