### PR TITLE
feat(cli): load environment variables from .env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,6 +3977,7 @@ dependencies = [
  "criterion",
  "deno_core",
  "derive_setters",
+ "dotenvy",
  "env_logger",
  "exitcode",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 # dependencies specific to CLI must have optional = true and the dep should be added to default feature.
 # one needs to add default feature tag if it is something IO related or might conflict with WASM
 
+dotenvy = { version = "0.15", optional = true }
 mimalloc = { version = "0.1.39", default-features = false, optional = true }
 http-cache-reqwest = { version = "0.13.0", features = [
     "manager-moka",
@@ -108,6 +109,7 @@ js = ["dep:deno_core", "dep:serde_v8"]
 cli = [
     "tokio/fs",
     "tokio/rt-multi-thread",
+    "dep:dotenvy",
     "dep:mimalloc",
     "dep:http-cache-reqwest",
     "dep:moka",

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -3,6 +3,7 @@ use std::{env, fs};
 
 use anyhow::Result;
 use clap::Parser;
+use dotenvy::dotenv;
 use env_logger::Env;
 use inquire::Confirm;
 use stripmargin::StripMargin;
@@ -22,6 +23,7 @@ const FILE_NAME: &str = ".tailcallrc.graphql";
 const YML_FILE_NAME: &str = ".graphqlrc.yml";
 
 pub async fn run() -> Result<()> {
+    let _ = dotenv(); // dotenvy fails if .env is not found, but we don't care if it doesn't exist.
     let cli = Cli::parse();
     logger_init();
     update_checker::check_for_update().await;


### PR DESCRIPTION
**Summary:**  
This PR adds code to the CLI that loads environment variables from a `.env` file, like requested in #859. It does **not** use `@link`, as needing to *specify* a `.env` file in a config that would be committed to Git goes against the versatility of `.env` files.

**Issue Reference(s):**  
Fixes #859 
/claim #859

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
