### PR TITLE
fix(grpc): allow nested package names

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -25,7 +25,7 @@
         "omit-many.md"
       ],
       "options": {
-        "printWidth": 210
+        "printWidth": 300
       }
     },
     {

--- a/examples/grpc.graphql
+++ b/examples/grpc.graphql
@@ -8,14 +8,9 @@ schema
 
 type Query {
   news: NewsData! @grpc(method: "news.news.NewsService.GetAllNews")
-  newsById(news: NewsInput!): News!
-    @grpc(method: "news.news.NewsService.GetNews", body: "{{args.news}}")
+  newsById(news: NewsInput!): News! @grpc(method: "news.news.NewsService.GetNews", body: "{{args.news}}")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(
-      method: "news.news.NewsService.GetMultipleNews"
-      body: "{{args.news}}"
-      groupBy: ["news", "id"]
-    )
+    @grpc(method: "news.news.NewsService.GetMultipleNews", body: "{{args.news}}", groupBy: ["news", "id"])
 }
 
 type News {

--- a/examples/grpc.graphql
+++ b/examples/grpc.graphql
@@ -7,15 +7,13 @@ schema
 }
 
 type Query {
-  news: NewsData! @grpc(service: "news.NewsService", method: "GetAllNews", protoId: "news")
+  news: NewsData! @grpc(method: "news.news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News!
-    @grpc(service: "news.NewsService", method: "GetNews", body: "{{args.news}}", protoId: "news")
+    @grpc(method: "news.news.NewsService.GetNews", body: "{{args.news}}")
   newsByIdBatch(news: NewsInput!): News!
     @grpc(
-      service: "news.NewsService"
-      method: "GetMultipleNews"
+      method: "news.news.NewsService.GetMultipleNews"
       body: "{{args.news}}"
-      protoId: "news"
       groupBy: ["news", "id"]
     )
 }

--- a/src/blueprint/operators/grpc.rs
+++ b/src/blueprint/operators/grpc.rs
@@ -241,7 +241,8 @@ mod tests {
     #[test]
     fn try_from_grpc_method() {
         let method =
-            GrpcMethod::try_from("link_id.package_name.space.ServiceName.MethodName".to_string()).unwrap();
+            GrpcMethod::try_from("link_id.package_name.space.ServiceName.MethodName".to_string())
+                .unwrap();
 
         assert_eq!(method.id, "link_id");
         assert_eq!(method.service, "package_name.space.ServiceName");

--- a/tests/execution/grpc-batch.md
+++ b/tests/execution/grpc-batch.md
@@ -7,8 +7,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;
@@ -81,14 +79,14 @@ type News {
 ```yml
 - request:
     method: POST
-    url: http://localhost:50051/news.NewsService/GetMultipleNews
+    url: http://localhost:50051/NewsService/GetMultipleNews
     body: \0\0\0\0\n\x02\x08\x02\n\x02\x08\x03
   response:
     status: 200
     body: \0\0\0\0t\n#\x08\x02\x12\x06Note 2\x1a\tContent 2\"\x0cPost image 2\n#\x08\x03\x12\x06Note 3\x1a\tContent 3\"\x0cPost image 3
 - request:
     method: POST
-    url: http://localhost:50051/news.NewsService/GetMultipleNews
+    url: http://localhost:50051/NewsService/GetMultipleNews
     body: \0\0\0\0\n\x02\x08\x03\n\x02\x08\x02
   response:
     status: 200

--- a/tests/execution/grpc-override-url-from-upstream.md
+++ b/tests/execution/grpc-override-url-from-upstream.md
@@ -7,8 +7,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;
@@ -76,7 +74,7 @@ type News {
 ```yml
 - request:
     method: POST
-    url: http://localhost:50051/news.NewsService/GetAllNews
+    url: http://localhost:50051/NewsService/GetAllNews
     body: null
   response:
     status: 200

--- a/tests/execution/grpc-simple.md
+++ b/tests/execution/grpc-simple.md
@@ -7,8 +7,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;
@@ -76,7 +74,7 @@ type News {
 ```yml
 - request:
     method: POST
-    url: http://localhost:50051/news.NewsService/GetAllNews
+    url: http://localhost:50051/NewsService/GetAllNews
     body: null
   response:
     status: 200

--- a/tests/execution/grpc-url-from-upstream.md
+++ b/tests/execution/grpc-url-from-upstream.md
@@ -7,8 +7,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;
@@ -75,7 +73,7 @@ type News {
 ```yml
 - request:
     method: POST
-    url: http://localhost:50051/news.NewsService/GetAllNews
+    url: http://localhost:50051/NewsService/GetAllNews
     body: null
   response:
     status: 200

--- a/tests/execution/test-expr-success.md
+++ b/tests/execution/test-expr-success.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc-group-by.md
+++ b/tests/execution/test-grpc-group-by.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc-missing-fields.md
+++ b/tests/execution/test-grpc-missing-fields.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc-nested-data.md
+++ b/tests/execution/test-grpc-nested-data.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc-nested-optional.md
+++ b/tests/execution/test-grpc-nested-optional.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc-optional.md
+++ b/tests/execution/test-grpc-optional.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc-proto-path.md
+++ b/tests/execution/test-grpc-proto-path.md
@@ -10,8 +10,7 @@ schema @link(id: "news", src: "tailcall/src/grpcnews.proto", type: Protobuf) {
 }
 
 type Query {
-  news: NewsData
-    @grpc(method: "news.NewsService.GetAllNews", baseURL: "http://localhost:4000")
+  news: NewsData @grpc(method: "news.NewsService.GetAllNews", baseURL: "http://localhost:4000")
 }
 
 type NewsData {

--- a/tests/execution/test-grpc-proto-path.md
+++ b/tests/execution/test-grpc-proto-path.md
@@ -11,7 +11,7 @@ schema @link(id: "news", src: "tailcall/src/grpcnews.proto", type: Protobuf) {
 
 type Query {
   news: NewsData
-    @grpc(service: "news.NewsService", method: "GetAllNews", baseURL: "http://localhost:4000", protoId: "news")
+    @grpc(method: "news.NewsService.GetAllNews", baseURL: "http://localhost:4000")
 }
 
 type NewsData {

--- a/tests/execution/test-grpc-service-method.md
+++ b/tests/execution/test-grpc-service-method.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc-service.md
+++ b/tests/execution/test-grpc-service.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/execution/test-grpc.md
+++ b/tests/execution/test-grpc.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;
@@ -40,11 +38,39 @@ message NewsList {
 }
 ```
 
+#### file:package.proto
+
+```
+syntax = "proto3";
+
+package com.protos.greetings;
+
+// The greeter service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}
+```
+
 #### server:
 
 ```graphql
-schema @server(port: 8000) @upstream(baseURL: "http://localhost:50051", batch: {delay: 10, headers: [], maxSize: 1000}) @link(id: "news", src: "news.proto", type: Protobuf) {
+schema @server(port: 8000) @upstream(baseURL: "http://localhost:50051", batch: {delay: 10, headers: [], maxSize: 1000}) @link(id: "news", src: "news.proto", type: Protobuf) @link(id: "package", src: "package.proto", type: Protobuf) {
   query: Query
+}
+
+input HelloRequest {
+  name: String!
 }
 
 input NewsInput {
@@ -52,6 +78,10 @@ input NewsInput {
   id: Int
   postImage: String
   title: String
+}
+
+type HelloReply {
+  message: String
 }
 
 type News {
@@ -66,6 +96,7 @@ type NewsData {
 }
 
 type Query {
+  greetings(request: HelloRequest): HelloReply! @grpc(method: "package.com.protos.greetings.Greeter.SayHello")
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(body: "{{args.news}}", method: "news.NewsService.GetNews")
   newsByIdBatch(news: NewsInput!): News! @grpc(body: "{{args.news}}", groupBy: ["news", "id"], method: "news.NewsService.GetMultipleNews")

--- a/tests/execution/test-missing-argument-on-all-resolvers.md
+++ b/tests/execution/test-missing-argument-on-all-resolvers.md
@@ -9,8 +9,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package news;
-
 message News {
     int32 id = 1;
     string title = 2;

--- a/tests/snapshots/execution_spec__test-grpc-invalid-method-format.md_errors.snap
+++ b/tests/snapshots/execution_spec__test-grpc-invalid-method-format.md_errors.snap
@@ -4,7 +4,7 @@ expression: errors
 ---
 [
   {
-    "message": "Invalid method format: abc.NewsService. Expected format is <package/proto_id>.<service>.<method>",
+    "message": "Invalid method format: abc.NewsService. Expected format is <link_id>.<package.service>.<method>",
     "trace": [
       "Query",
       "news",

--- a/tests/snapshots/execution_spec__test-grpc-service.md_errors.snap
+++ b/tests/snapshots/execution_spec__test-grpc-service.md_errors.snap
@@ -4,7 +4,7 @@ expression: errors
 ---
 [
   {
-    "message": "Couldn't find definitions for service news.YourServiceName",
+    "message": "Couldn't find definitions for service YourServiceName",
     "trace": [
       "Query",
       "news",

--- a/tests/snapshots/execution_spec__test-grpc.md_client.snap
+++ b/tests/snapshots/execution_spec__test-grpc.md_client.snap
@@ -1,7 +1,15 @@
 ---
 source: tests/execution_spec.rs
-expression: merged
+expression: client
 ---
+type HelloReply {
+  message: String
+}
+
+input HelloRequest {
+  name: String!
+}
+
 type News {
   body: String
   id: Int
@@ -21,6 +29,7 @@ input NewsInput {
 }
 
 type Query {
+  greetings(request: HelloRequest): HelloReply!
   news: NewsData!
   newsById(news: NewsInput!): News!
   newsByIdBatch(news: NewsInput!): News!

--- a/tests/snapshots/execution_spec__test-grpc.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-grpc.md_merged.snap
@@ -2,8 +2,12 @@
 source: tests/execution_spec.rs
 expression: merged
 ---
-schema @server(port: 8000) @upstream(baseURL: "http://localhost:50051", batch: {delay: 10, headers: [], maxSize: 1000}) @link(id: "news", src: "news.proto", type: Protobuf) {
+schema @server(port: 8000) @upstream(baseURL: "http://localhost:50051", batch: {delay: 10, headers: [], maxSize: 1000}) @link(id: "news", src: "news.proto", type: Protobuf) @link(id: "package", src: "package.proto", type: Protobuf) {
   query: Query
+}
+
+input HelloRequest {
+  name: String!
 }
 
 input NewsInput {
@@ -11,6 +15,10 @@ input NewsInput {
   id: Int
   postImage: String
   title: String
+}
+
+type HelloReply {
+  message: String
 }
 
 type News {
@@ -25,6 +33,7 @@ type NewsData {
 }
 
 type Query {
+  greetings(request: HelloRequest): HelloReply! @grpc(method: "package.com.protos.greetings.Greeter.SayHello")
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(body: "{{args.news}}", method: "news.NewsService.GetNews")
   newsByIdBatch(news: NewsInput!): News! @grpc(body: "{{args.news}}", groupBy: ["news", "id"], method: "news.NewsService.GetMultipleNews")


### PR DESCRIPTION
**Summary:**  
Fix usage of package definition inside proto file. Separate it from link id definition

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
