### PR TITLE
fix: losing cache wrapper for expr from app_context

### DIFF
--- a/src/lambda/modify.rs
+++ b/src/lambda/modify.rs
@@ -38,8 +38,8 @@ impl Expression {
                         Expression::EqualTo(expr1.modify_box(modifier), expr2.modify_box(modifier))
                     }
                     Expression::IO(_) => expr,
-                    Expression::Cache(Cache { expr, .. }) => {
-                        Expression::IO(expr).modify_inner(modifier)
+                    Expression::Cache(Cache { expr, max_age }) => {
+                        Expression::Cache(Cache { expr: expr.modify_box(modifier), max_age })
                     }
                     Expression::Input(expr, path) => {
                         Expression::Input(expr.modify_box(modifier), path)


### PR DESCRIPTION
**Summary:**  
Cache was not working because it was cleaned when updating resolvers from app_context

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
