### PR TITLE
chore: fix app version warning 

### DIFF
--- a/src/cli/update_checker.rs
+++ b/src/cli/update_checker.rs
@@ -42,8 +42,8 @@ pub async fn check_for_update() {
             return;
         };
 
-        let informer = update_informer::new(registry::GitHub, name, current_version)
-            .interval(Duration::ZERO);
+        let informer =
+            update_informer::new(registry::GitHub, name, current_version).interval(Duration::ZERO);
 
         if let Some(latest_version) = informer.check_version().ok().flatten() {
             let github_release_url =

--- a/src/cli/update_checker.rs
+++ b/src/cli/update_checker.rs
@@ -43,7 +43,7 @@ pub async fn check_for_update() {
         };
 
         let informer = update_informer::new(registry::GitHub, name, current_version)
-            .interval(Duration::from_secs(60 * 60 * 24));
+            .interval(Duration::ZERO);
 
         if let Some(latest_version) = informer.check_version().ok().flatten() {
             let github_release_url =


### PR DESCRIPTION
Tailcall should print a warning when installed version is not the latest version (#930), but these warnings never get printed.

This pr fixes that problem (probably)