### PR TITLE
chore: switch to FileIO from tokio fs

### DIFF
--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -324,7 +324,7 @@ mod test_proto_config {
             let path = file.path();
             let path_str =
                 path_to_file_name(path.as_path()).context("It must be able to extract path")?;
-            let source = file_rt.read(path.to_str().unwrap()).await?;
+            let source = file_rt.read(&path_str).await?;
             let expected = protox_parse::parse(&path_str, &source)?;
             let actual = helper_map
                 .iter()


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
