### PR TITLE
fix: fix log format

### DIFF
--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::{env, fs};
+use std::io::Write;
 
 use anyhow::Result;
 use clap::Parser;
@@ -188,5 +189,12 @@ fn logger_init() {
     // use the log level from the env if there is one, otherwise use the default.
     let env = Env::new().filter_or(filter_env_name, "info");
 
-    env_logger::Builder::from_env(env).init();
+    env_logger::Builder::from_env(env)
+        .format(|buf, record| {
+            // Custom formatting for log messages
+            let level = record.level();
+            let args = record.args();
+            writeln!(buf, "[{}] {}", level, args)
+        })
+        .init();
 }

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -1,9 +1,10 @@
+use std::io::Write;
 use std::path::Path;
 use std::{env, fs};
-use std::io::Write;
 
 use anyhow::Result;
 use clap::Parser;
+use colored::*;
 use env_logger::Env;
 use inquire::Confirm;
 use stripmargin::StripMargin;
@@ -193,8 +194,16 @@ fn logger_init() {
         .format(|buf, record| {
             // Custom formatting for log messages
             let level = record.level();
+            let formatted_level = format!("[{}]", level);
+            let colored_level = match level {
+                log::Level::Error => formatted_level.red(),
+                log::Level::Warn => formatted_level.yellow(),
+                log::Level::Info => formatted_level.green(),
+                log::Level::Debug => formatted_level.blue(),
+                log::Level::Trace => formatted_level.magenta(),
+            };
             let args = record.args();
-            writeln!(buf, "[{}] {}", level, args)
+            writeln!(buf, "{} {}", colored_level, args)
         })
         .init();
 }


### PR DESCRIPTION
**Summary:**  
This PR tries to increase the readability of the log messages, by removing the timestamp and targets.

**Issue Reference(s):**  
Fixes #1270 
/claim #1270 

![image](https://github.com/tailcallhq/tailcall/assets/70096901/5b2e69ba-326f-4ebb-8697-1778427283e2)


**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
