### PR TITLE
fix: omit operator not displayed in generated files

### DIFF
--- a/autogen/src/gen_gql_schema.rs
+++ b/autogen/src/gen_gql_schema.rs
@@ -23,6 +23,7 @@ lazy_static! {
         ("grpc", vec![Entity::FieldDefinition], false),
         ("addField", vec![Entity::Object], true),
         ("modify", vec![Entity::FieldDefinition], false),
+        ("omit", vec![Entity::FieldDefinition], false),
         ("groupBy", vec![Entity::FieldDefinition], false),
         ("const", vec![Entity::FieldDefinition], false),
         ("graphQL", vec![Entity::FieldDefinition], false),

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -227,6 +227,11 @@ directive @modify(
 ) on FIELD_DEFINITION
 
 """
+Used to omit a field from public consumption.
+"""
+directive @omit on FIELD_DEFINITION
+
+"""
 The `@server` directive, when applied at the schema level, offers a comprehensive 
 set of server configurations. It dictates how the server behaves and helps tune tailcall 
 for various use-cases.
@@ -698,10 +703,10 @@ input Schema {
   Arr: Schema
   Opt: Schema
 }
-scalar Url
-scalar Email
-scalar KeyValues
 scalar Date
+scalar Email
 scalar PhoneNumber
+scalar KeyValues
+scalar Url
 scalar JSON
 

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1386,6 +1386,7 @@
       }
     },
     "Omit": {
+      "description": "Used to omit a field from public consumption.",
       "type": "object"
     },
     "OtlpExporter": {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -323,6 +323,7 @@ impl RootSchema {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]
+/// Used to omit a field from public consumption.
 pub struct Omit {}
 
 ///


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1339
/claim 1339

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `@omit` directive to enhance schema customization by allowing certain fields to be omitted from public consumption.
- **Documentation**
	- Added clarifying documentation on the purpose and usage of the `@omit` feature in schema generation and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->