### PR TITLE
fix: rename groupBy to batchKey

### DIFF
--- a/examples/grpc.graphql
+++ b/examples/grpc.graphql
@@ -10,7 +10,7 @@ type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(method: "news.NewsService.GetNews", body: "{{args.news}}")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{args.news}}", groupBy: ["news", "id"])
+    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{args.news}}", batchKey: ["news", "id"])
 }
 
 type News {

--- a/examples/jsonplaceholder_batch.graphql
+++ b/examples/jsonplaceholder_batch.graphql
@@ -22,5 +22,5 @@ type Post {
   userId: Int!
   title: String!
   body: String!
-  user: User @http(path: "/users", query: [{key: "id", value: "{{value.userId}}"}], groupBy: ["id"])
+  user: User @http(path: "/users", query: [{key: "id", value: "{{value.userId}}"}], batchKey: ["id"])
 }

--- a/examples/jsonplaceholder_batch.json
+++ b/examples/jsonplaceholder_batch.json
@@ -40,9 +40,7 @@
                 "value": "{{value.userId}}"
               }
             ],
-            "batchKey": [
-              "id"
-            ]
+            "batchKey": ["id"]
           }
         },
         "userId": {

--- a/examples/jsonplaceholder_batch.json
+++ b/examples/jsonplaceholder_batch.json
@@ -40,7 +40,9 @@
                 "value": "{{value.userId}}"
               }
             ],
-            "groupBy": ["id"]
+            "batchKey": [
+              "id"
+            ]
           }
         },
         "userId": {

--- a/examples/jsonplaceholder_batch.yml
+++ b/examples/jsonplaceholder_batch.yml
@@ -29,7 +29,7 @@ types:
           query:
             - key: id
               value: "{{value.userId}}"
-          groupBy:
+          batchKey:
             - id
       userId:
         type: Int

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -111,12 +111,12 @@ directive @grpc(
   """
   baseURL: String
   """
-  The key path in the response which should be used to group multiple requests. For
+  The key path in the response which should be used to group multiple requests. For 
   instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
   batchKey: [String!]
   """
-  This refers to the arguments of your gRPC call. You can pass it as a static object
+  This refers to the arguments of your gRPC call. You can pass it as a static object 
   or use Mustache template for dynamic parameters. These parameters will be added in 
   the body in `protobuf` format.
   """
@@ -148,12 +148,12 @@ directive @http(
   """
   baseURL: String
   """
-  The `batchKey` parameter groups multiple data requests into a single call. For more
+  The `batchKey` parameter groups multiple data requests into a single call. For more 
   details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
   batchKey: [String!]
   """
-  The body of the API call. It's used for methods like POST or PUT that send data to
+  The body of the API call. It's used for methods like POST or PUT that send data to 
   the server. You can pass it as a static object or use a Mustache template to substitute 
   variables from the GraphQL variables.
   """
@@ -541,12 +541,12 @@ input Grpc {
   """
   baseURL: String
   """
-  The key path in the response which should be used to group multiple requests. For
+  The key path in the response which should be used to group multiple requests. For 
   instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
   batchKey: [String!]
   """
-  This refers to the arguments of your gRPC call. You can pass it as a static object
+  This refers to the arguments of your gRPC call. You can pass it as a static object 
   or use Mustache template for dynamic parameters. These parameters will be added in 
   the body in `protobuf` format.
   """
@@ -577,12 +577,12 @@ input Http {
   """
   baseURL: String
   """
-  The `batchKey` parameter groups multiple data requests into a single call. For more
+  The `batchKey` parameter groups multiple data requests into a single call. For more 
   details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
   batchKey: [String!]
   """
-  The body of the API call. It's used for methods like POST or PUT that send data to
+  The body of the API call. It's used for methods like POST or PUT that send data to 
   the server. You can pass it as a static object or use a Mustache template to substitute 
   variables from the GraphQL variables.
   """
@@ -704,9 +704,9 @@ input Schema {
   Opt: Schema
 }
 scalar PhoneNumber
-scalar KeyValues
 scalar Url
 scalar Date
+scalar KeyValues
 scalar Email
 scalar JSON
 

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -703,10 +703,10 @@ input Schema {
   Arr: Schema
   Opt: Schema
 }
-scalar PhoneNumber
 scalar Url
-scalar Date
 scalar KeyValues
+scalar Date
 scalar Email
+scalar PhoneNumber
 scalar JSON
 

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -111,16 +111,16 @@ directive @grpc(
   """
   baseURL: String
   """
-  This refers to the arguments of your gRPC call. You can pass it as a static object 
+  The key path in the response which should be used to group multiple requests. For
+  instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+  """
+  batchKey: [String!]
+  """
+  This refers to the arguments of your gRPC call. You can pass it as a static object
   or use Mustache template for dynamic parameters. These parameters will be added in 
   the body in `protobuf` format.
   """
   body: String
-  """
-  The key path in the response which should be used to group multiple requests. For 
-  instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
-  """
-  groupBy: [String!]
   """
   The `headers` parameter allows you to customize the headers of the HTTP request made 
   by the `@grpc` operator. It is used by specifying a key-value map of header names 
@@ -148,7 +148,12 @@ directive @http(
   """
   baseURL: String
   """
-  The body of the API call. It's used for methods like POST or PUT that send data to 
+  The `batchKey` parameter groups multiple data requests into a single call. For more
+  details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+  """
+  batchKey: [String!]
+  """
+  The body of the API call. It's used for methods like POST or PUT that send data to
   the server. You can pass it as a static object or use a Mustache template to substitute 
   variables from the GraphQL variables.
   """
@@ -158,11 +163,6 @@ directive @http(
   or `ApplicationXWwwFormUrlEncoded`. @default `ApplicationJson`.
   """
   encoding: Encoding
-  """
-  The `groupBy` parameter groups multiple data requests into a single call. For more 
-  details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
-  """
-  groupBy: [String!]
   """
   The `headers` parameter allows you to customize the headers of the HTTP request made 
   by the `@http` operator. It is used by specifying a key-value map of header names 
@@ -541,16 +541,16 @@ input Grpc {
   """
   baseURL: String
   """
-  This refers to the arguments of your gRPC call. You can pass it as a static object 
+  The key path in the response which should be used to group multiple requests. For
+  instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+  """
+  batchKey: [String!]
+  """
+  This refers to the arguments of your gRPC call. You can pass it as a static object
   or use Mustache template for dynamic parameters. These parameters will be added in 
   the body in `protobuf` format.
   """
   body: String
-  """
-  The key path in the response which should be used to group multiple requests. For 
-  instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
-  """
-  groupBy: [String!]
   """
   The `headers` parameter allows you to customize the headers of the HTTP request made 
   by the `@grpc` operator. It is used by specifying a key-value map of header names 
@@ -577,7 +577,12 @@ input Http {
   """
   baseURL: String
   """
-  The body of the API call. It's used for methods like POST or PUT that send data to 
+  The `batchKey` parameter groups multiple data requests into a single call. For more
+  details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+  """
+  batchKey: [String!]
+  """
+  The body of the API call. It's used for methods like POST or PUT that send data to
   the server. You can pass it as a static object or use a Mustache template to substitute 
   variables from the GraphQL variables.
   """
@@ -587,11 +592,6 @@ input Http {
   or `ApplicationXWwwFormUrlEncoded`. @default `ApplicationJson`.
   """
   encoding: Encoding
-  """
-  The `groupBy` parameter groups multiple data requests into a single call. For more 
-  details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
-  """
-  groupBy: [String!]
   """
   The `headers` parameter allows you to customize the headers of the HTTP request made 
   by the `@http` operator. It is used by specifying a key-value map of header names 
@@ -703,10 +703,10 @@ input Schema {
   Arr: Schema
   Opt: Schema
 }
-scalar Date
-scalar Email
 scalar PhoneNumber
 scalar KeyValues
 scalar Url
+scalar Date
+scalar Email
 scalar JSON
 

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1181,19 +1181,19 @@
             "null"
           ]
         },
+        "batchKey": {
+          "description": "The key path in the response which should be used to group multiple requests. For instance `[\"news\",\"id\"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "body": {
           "description": "This refers to the arguments of your gRPC call. You can pass it as a static object or use Mustache template for dynamic parameters. These parameters will be added in the body in `protobuf` format.",
           "type": [
             "string",
             "null"
           ]
-        },
-        "groupBy": {
-          "description": "The key path in the response which should be used to group multiple requests. For instance `[\"news\",\"id\"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
         "headers": {
           "description": "The `headers` parameter allows you to customize the headers of the HTTP request made by the `@grpc` operator. It is used by specifying a key-value map of header names and their values. Note: content-type is automatically set to application/grpc",
@@ -1223,6 +1223,13 @@
             "null"
           ]
         },
+        "batchKey": {
+          "description": "The `batchKey` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "body": {
           "description": "The body of the API call. It's used for methods like POST or PUT that send data to the server. You can pass it as a static object or use a Mustache template to substitute variables from the GraphQL variables.",
           "type": [
@@ -1237,13 +1244,6 @@
               "$ref": "#/definitions/Encoding"
             }
           ]
-        },
-        "groupBy": {
-          "description": "The `groupBy` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
         "headers": {
           "description": "The `headers` parameter allows you to customize the headers of the HTTP request made by the `@http` operator. It is used by specifying a key-value map of header names and their values.",

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -61,6 +61,7 @@ pub struct Config {
     /// Enable [opentelemetry](https://opentelemetry.io) support
     pub opentelemetry: Telemetry,
 }
+
 impl Config {
     pub fn port(&self) -> u16 {
         self.server.port.unwrap_or(8000)
@@ -558,8 +559,8 @@ pub struct Http {
     /// `ApplicationJson`.
     pub encoding: Encoding,
 
-    #[serde(rename = "groupBy", default, skip_serializing_if = "is_default")]
-    /// The `groupBy` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+    #[serde(rename = "batchKey", default, skip_serializing_if = "is_default")]
+    /// The `batchKey` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
     pub group_by: Vec<String>,
 
     #[serde(default, skip_serializing_if = "is_default")]
@@ -639,7 +640,7 @@ pub struct Grpc {
     /// static object or use Mustache template for dynamic parameters. These
     /// parameters will be added in the body in `protobuf` format.
     pub body: Option<String>,
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(rename = "batchKey", default, skip_serializing_if = "is_default")]
     /// The key path in the response which should be used to group multiple requests. For instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
     pub group_by: Vec<String>,
     #[serde(default, skip_serializing_if = "is_default")]
@@ -761,7 +762,6 @@ pub enum Encoding {
 }
 
 #[cfg(test)]
-
 mod tests {
     use pretty_assertions::assert_eq;
 

--- a/tests/execution/batching-default.md
+++ b/tests/execution/batching-default.md
@@ -17,7 +17,7 @@ type Post {
   body: String
   userId: Int!
   user: User
-    @http(path: "/users", query: [{key: "id", value: "{{value.userId}}"}, {key: "foo", value: "bar"}], groupBy: ["id"])
+    @http(path: "/users", query: [{key: "id", value: "{{value.userId}}"}, {key: "foo", value: "bar"}], batchKey: ["id"])
 }
 
 type User {

--- a/tests/execution/batching-group-by-default.md
+++ b/tests/execution/batching-group-by-default.md
@@ -19,7 +19,7 @@ type Post {
   body: String
   userId: Int!
   user: User
-    @http(groupBy: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}, {key: "foo", value: "bar"}])
+    @http(batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}, {key: "foo", value: "bar"}])
 }
 
 type User {

--- a/tests/execution/batching-group-by.md
+++ b/tests/execution/batching-group-by.md
@@ -19,7 +19,7 @@ type Post {
   body: String
   userId: Int!
   user: User
-    @http(path: "/users", query: [{key: "id", value: "{{value.userId}}"}, {key: "foo", value: "bar"}], groupBy: ["id"])
+    @http(path: "/users", query: [{key: "id", value: "{{value.userId}}"}, {key: "foo", value: "bar"}], batchKey: ["id"])
 }
 
 type User {

--- a/tests/execution/batching-nested-expr.md
+++ b/tests/execution/batching-nested-expr.md
@@ -21,7 +21,7 @@ type Post {
       body: {
         if: {
           cond: {const: {data: true}}
-          then: {http: {path: "/users", query: [{key: "id", value: "{{value.userId}}"}], groupBy: ["id"]}}
+          then: {http: {path: "/users", query: [{key: "id", value: "{{value.userId}}"}], batchKey: ["id"]}}
           else: {const: {data: {}}}
         }
       }
@@ -35,8 +35,8 @@ type User {
     @expr(
       body: {
         concat: [
-          {http: {path: "/users-values-1", query: [{key: "id", value: "{{value.id}}"}], groupBy: ["id"]}}
-          {http: {path: "/users-values-2", query: [{key: "id", value: "{{value.id}}"}], groupBy: ["id"]}}
+          {http: {path: "/users-values-1", query: [{key: "id", value: "{{value.id}}"}], batchKey: ["id"]}}
+          {http: {path: "/users-values-2", query: [{key: "id", value: "{{value.id}}"}], batchKey: ["id"]}}
         ]
       }
     )

--- a/tests/execution/grpc-batch.md
+++ b/tests/execution/grpc-batch.md
@@ -55,7 +55,7 @@ type Query {
       method: "news.NewsService.GetMultipleNews"
       baseURL: "http://localhost:50051"
       body: "{{args.news}}"
-      groupBy: ["news", "id"]
+      batchKey: ["news", "id"]
     )
 }
 input NewsInput {

--- a/tests/execution/n-plus-one-list.md
+++ b/tests/execution/n-plus-one-list.md
@@ -15,13 +15,13 @@ type Query {
 type Foo {
   id: Int!
   name: String!
-  bar: Bar @http(path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}], groupBy: ["fooId"])
+  bar: Bar @http(path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}], batchKey: ["fooId"])
 }
 
 type Bar {
   id: Int!
   fooId: Int!
-  foo: [Foo] @http(path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}], groupBy: ["id"])
+  foo: [Foo] @http(path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}], batchKey: ["id"])
 }
 ```
 

--- a/tests/execution/n-plus-one.md
+++ b/tests/execution/n-plus-one.md
@@ -15,13 +15,13 @@ type Query {
 type Foo {
   id: Int!
   name: String!
-  bar: Bar @http(path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}], groupBy: ["fooId"])
+  bar: Bar @http(path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}], batchKey: ["fooId"])
 }
 
 type Bar {
   id: Int!
   fooId: Int!
-  foo: [Foo] @http(path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}], groupBy: ["id"])
+  foo: [Foo] @http(path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}], batchKey: ["id"])
 }
 ```
 

--- a/tests/execution/request-to-upstream-batching.md
+++ b/tests/execution/request-to-upstream-batching.md
@@ -37,9 +37,7 @@
               }
             ],
             "baseURL": "http://jsonplaceholder.typicode.com",
-            "batchKey": [
-              "id"
-            ]
+            "batchKey": ["id"]
           },
           "cache": null
         }

--- a/tests/execution/request-to-upstream-batching.md
+++ b/tests/execution/request-to-upstream-batching.md
@@ -37,7 +37,9 @@
               }
             ],
             "baseURL": "http://jsonplaceholder.typicode.com",
-            "groupBy": ["id"]
+            "batchKey": [
+              "id"
+            ]
           },
           "cache": null
         }

--- a/tests/execution/test-batch-operator-post.md
+++ b/tests/execution/test-batch-operator-post.md
@@ -15,6 +15,6 @@ type User {
 }
 
 type Query {
-  user: User @http(path: "/posts/1", method: "POST", groupBy: ["id"])
+  user: User @http(path: "/posts/1", method: "POST", batchKey: ["id"])
 }
 ```

--- a/tests/execution/test-batching-group-by.md
+++ b/tests/execution/test-batching-group-by.md
@@ -13,7 +13,7 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @http(groupBy: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}])
+  user: User @http(batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}])
   userId: Int!
 }
 

--- a/tests/execution/test-expr-success.md
+++ b/tests/execution/test-expr-success.md
@@ -69,7 +69,7 @@ type Post {
 type Query {
   cond: Post @expr(body: {if: {cond: {const: true}, else: {http: {path: "/posts/1"}}, then: {http: {path: "/posts/2"}}}})
   greeting: String @expr(body: {const: "hello from server"})
-  news(news: NewsInput!): News! @expr(body: {grpc: {body: "{{args.news}}", groupBy: ["news", "id"], method: "news.NewsService.GetMultipleNews"}})
+  news(news: NewsInput!): News! @expr(body: {grpc: {body: "{{args.news}}", batchKey: ["news", "id"], method: "news.NewsService.GetMultipleNews"}})
   post(id: Int!): Post @expr(body: {http: {baseURL: "http://jsonplacheholder.typicode.com", path: "/posts/{{args.id}}"}})
 }
 ```

--- a/tests/execution/test-groupby-without-batching.md
+++ b/tests/execution/test-groupby-without-batching.md
@@ -15,6 +15,6 @@ type User {
 }
 
 type Query {
-  user(id: Int!): User @http(path: "/users", query: [{key: "id", value: "{{args.id}}"}], groupBy: ["id"])
+  user(id: Int!): User @http(path: "/users", query: [{key: "id", value: "{{args.id}}"}], batchKey: ["id"])
 }
 ```

--- a/tests/execution/test-grpc-group-by.md
+++ b/tests/execution/test-grpc-group-by.md
@@ -56,7 +56,7 @@ type Query {
       method: "news.NewsService.GetMultipleNews"
       baseURL: "http://localhost:50051"
       body: "{{args.news}}"
-      groupBy: ["id"]
+      batchKey: ["id"]
     )
 }
 input NewsInput {

--- a/tests/execution/test-grpc.md
+++ b/tests/execution/test-grpc.md
@@ -68,6 +68,6 @@ type NewsData {
 type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(body: "{{args.news}}", method: "news.NewsService.GetNews")
-  newsByIdBatch(news: NewsInput!): News! @grpc(body: "{{args.news}}", groupBy: ["news", "id"], method: "news.NewsService.GetMultipleNews")
+  newsByIdBatch(news: NewsInput!): News! @grpc(body: "{{args.news}}", batchKey: ["news", "id"], method: "news.NewsService.GetMultipleNews")
 }
 ```

--- a/tests/execution/upstream-batching.md
+++ b/tests/execution/upstream-batching.md
@@ -34,7 +34,9 @@
               }
             ],
             "baseURL": "http://jsonplaceholder.typicode.com",
-            "groupBy": ["id"]
+            "batchKey": [
+              "id"
+            ]
           },
           "cache": null
         }

--- a/tests/execution/upstream-batching.md
+++ b/tests/execution/upstream-batching.md
@@ -34,9 +34,7 @@
               }
             ],
             "baseURL": "http://jsonplaceholder.typicode.com",
-            "batchKey": [
-              "id"
-            ]
+            "batchKey": ["id"]
           },
           "cache": null
         }

--- a/tests/snapshots/execution_spec__batching-default.md_merged.snap
+++ b/tests/snapshots/execution_spec__batching-default.md_merged.snap
@@ -10,7 +10,7 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @http(groupBy: ["id"], path: "/users", query: [{key: "foo", value: "bar"}, {key: "id", value: "{{value.userId}}"}])
+  user: User @http(batchKey: ["id"], path: "/users", query: [{key: "foo", value: "bar"}, {key: "id", value: "{{value.userId}}"}])
   userId: Int!
 }
 

--- a/tests/snapshots/execution_spec__batching-group-by-default.md_merged.snap
+++ b/tests/snapshots/execution_spec__batching-group-by-default.md_merged.snap
@@ -10,7 +10,7 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @http(groupBy: ["id"], path: "/users", query: [{key: "foo", value: "bar"}, {key: "id", value: "{{value.userId}}"}])
+  user: User @http(batchKey: ["id"], path: "/users", query: [{key: "foo", value: "bar"}, {key: "id", value: "{{value.userId}}"}])
   userId: Int!
 }
 

--- a/tests/snapshots/execution_spec__batching-group-by.md_merged.snap
+++ b/tests/snapshots/execution_spec__batching-group-by.md_merged.snap
@@ -10,7 +10,7 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @http(groupBy: ["id"], path: "/users", query: [{key: "foo", value: "bar"}, {key: "id", value: "{{value.userId}}"}])
+  user: User @http(batchKey: ["id"], path: "/users", query: [{key: "foo", value: "bar"}, {key: "id", value: "{{value.userId}}"}])
   userId: Int!
 }
 

--- a/tests/snapshots/execution_spec__batching-nested-expr.md_merged.snap
+++ b/tests/snapshots/execution_spec__batching-nested-expr.md_merged.snap
@@ -10,7 +10,7 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @expr(body: {if: {cond: {const: {data: true}}, else: {const: {data: {}}}, then: {http: {groupBy: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}]}}}})
+  user: User @expr(body: {if: {cond: {const: {data: true}}, else: {const: {data: {}}}, then: {http: {batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}]}}}})
   userId: Int!
 }
 
@@ -21,7 +21,7 @@ type Query {
 type User {
   id: Int
   name: String
-  values: [Value] @expr(body: {concat: [{http: {groupBy: ["id"], path: "/users-values-1", query: [{key: "id", value: "{{value.id}}"}]}}, {http: {groupBy: ["id"], path: "/users-values-2", query: [{key: "id", value: "{{value.id}}"}]}}]})
+  values: [Value] @expr(body: {concat: [{http: {batchKey: ["id"], path: "/users-values-1", query: [{key: "id", value: "{{value.id}}"}]}}, {http: {batchKey: ["id"], path: "/users-values-2", query: [{key: "id", value: "{{value.id}}"}]}}]})
 }
 
 type Value {

--- a/tests/snapshots/execution_spec__grpc-batch.md_merged.snap
+++ b/tests/snapshots/execution_spec__grpc-batch.md_merged.snap
@@ -26,5 +26,5 @@ type NewsData {
 
 type Query {
   news: NewsData! @grpc(baseURL: "http://localhost:50051", method: "news.NewsService.GetAllNews")
-  newsById(news: NewsInput!): News! @grpc(baseURL: "http://localhost:50051", body: "{{args.news}}", groupBy: ["news", "id"], method: "news.NewsService.GetMultipleNews")
+  newsById(news: NewsInput!): News! @grpc(baseURL: "http://localhost:50051", body: "{{args.news}}", batchKey: ["news", "id"], method: "news.NewsService.GetMultipleNews")
 }

--- a/tests/snapshots/execution_spec__n-plus-one-list.md_merged.snap
+++ b/tests/snapshots/execution_spec__n-plus-one-list.md_merged.snap
@@ -7,13 +7,13 @@ schema @server @upstream(baseURL: "http://example.com", batch: {delay: 1, header
 }
 
 type Bar {
-  foo: [Foo] @http(groupBy: ["id"], path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}])
+  foo: [Foo] @http(batchKey: ["id"], path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}])
   fooId: Int!
   id: Int!
 }
 
 type Foo {
-  bar: Bar @http(groupBy: ["fooId"], path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}])
+  bar: Bar @http(batchKey: ["fooId"], path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}])
   id: Int!
   name: String!
 }

--- a/tests/snapshots/execution_spec__n-plus-one.md_merged.snap
+++ b/tests/snapshots/execution_spec__n-plus-one.md_merged.snap
@@ -7,13 +7,13 @@ schema @server @upstream(baseURL: "http://example.com", batch: {delay: 1, header
 }
 
 type Bar {
-  foo: [Foo] @http(groupBy: ["id"], path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}])
+  foo: [Foo] @http(batchKey: ["id"], path: "/foos", query: [{key: "id", value: "{{value.fooId}}"}])
   fooId: Int!
   id: Int!
 }
 
 type Foo {
-  bar: Bar @http(groupBy: ["fooId"], path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}])
+  bar: Bar @http(batchKey: ["fooId"], path: "/bars", query: [{key: "fooId", value: "{{value.id}}"}])
   id: Int!
   name: String!
 }

--- a/tests/snapshots/execution_spec__request-to-upstream-batching.md_merged.snap
+++ b/tests/snapshots/execution_spec__request-to-upstream-batching.md_merged.snap
@@ -7,7 +7,7 @@ schema @server(batchRequests: true) @upstream(batch: {delay: 1, headers: [], max
 }
 
 type Query {
-  user(id: Int!): User @http(baseURL: "http://jsonplaceholder.typicode.com", groupBy: ["id"], path: "/users", query: [{key: "id", value: "{{args.id}}"}])
+  user(id: Int!): User @http(baseURL: "http://jsonplaceholder.typicode.com", batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{args.id}}"}])
 }
 
 type User {

--- a/tests/snapshots/execution_spec__test-batching-group-by.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-batching-group-by.md_merged.snap
@@ -10,7 +10,7 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @http(groupBy: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}])
+  user: User @http(batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{value.userId}}"}])
   userId: Int!
 }
 

--- a/tests/snapshots/execution_spec__test-expr-success.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-expr-success.md_merged.snap
@@ -28,6 +28,6 @@ type Post {
 type Query {
   cond: Post @expr(body: {if: {cond: {const: true}, else: {http: {path: "/posts/1"}}, then: {http: {path: "/posts/2"}}}})
   greeting: String @expr(body: {const: "hello from server"})
-  news(news: NewsInput!): News! @expr(body: {grpc: {body: "{{args.news}}", groupBy: ["news", "id"], method: "news.NewsService.GetMultipleNews"}})
+  news(news: NewsInput!): News! @expr(body: {grpc: {body: "{{args.news}}", batchKey: ["news", "id"], method: "news.NewsService.GetMultipleNews"}})
   post(id: Int!): Post @expr(body: {http: {baseURL: "http://jsonplacheholder.typicode.com", path: "/posts/{{args.id}}"}})
 }

--- a/tests/snapshots/execution_spec__test-grpc.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-grpc.md_merged.snap
@@ -27,5 +27,5 @@ type NewsData {
 type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(body: "{{args.news}}", method: "news.NewsService.GetNews")
-  newsByIdBatch(news: NewsInput!): News! @grpc(body: "{{args.news}}", groupBy: ["news", "id"], method: "news.NewsService.GetMultipleNews")
+  newsByIdBatch(news: NewsInput!): News! @grpc(body: "{{args.news}}", batchKey: ["news", "id"], method: "news.NewsService.GetMultipleNews")
 }

--- a/tests/snapshots/execution_spec__upstream-batching.md_merged.snap
+++ b/tests/snapshots/execution_spec__upstream-batching.md_merged.snap
@@ -7,7 +7,7 @@ schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 100}) {
 }
 
 type Query {
-  user(id: Int): User @http(baseURL: "http://jsonplaceholder.typicode.com", groupBy: ["id"], path: "/users", query: [{key: "id", value: "{{args.id}}"}])
+  user(id: Int): User @http(baseURL: "http://jsonplaceholder.typicode.com", batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{args.id}}"}])
 }
 
 type User {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the fetching of multiple news items by replacing `groupBy` with `batchKey` for more efficient data batching.
- **Refactor**
	- Updated GraphQL schema directives for consistency in data fetching.
	- Adjusted internal configuration to align with the new batching strategy.
- **Tests**
	- Modified tests to reflect changes in batching and data processing methodologies.
- **Documentation**
	- Updated relevant test documentation to reflect the use of `batchKey` instead of `groupBy`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->