### PR TITLE
fix: just sort right before printing

### DIFF
--- a/autogen/src/gen_gql_schema.rs
+++ b/autogen/src/gen_gql_schema.rs
@@ -660,8 +660,8 @@ fn write_all_input_types(
             }
         }
     }
-
-    for name in scalar {
+    
+    for name in scalar.into_iter().collect().sort() {
         writeln!(writer, "scalar {name}")?;
     }
 


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._
sort scalar names just before printing
**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the processing order of scalar names by sorting them before output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->