### PR TITLE
fix: add telemetry directive to autogen

### DIFF
--- a/autogen/src/gen_gql_schema.rs
+++ b/autogen/src/gen_gql_schema.rs
@@ -23,6 +23,7 @@ lazy_static! {
         ("grpc", vec![Entity::FieldDefinition], false),
         ("addField", vec![Entity::Object], true),
         ("modify", vec![Entity::FieldDefinition], false),
+        ("telemetry", vec![Entity::FieldDefinition], false),
         ("omit", vec![Entity::FieldDefinition], false),
         ("groupBy", vec![Entity::FieldDefinition], false),
         ("const", vec![Entity::FieldDefinition], false),

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -321,6 +321,12 @@ directive @server(
   workers: Int
 ) on SCHEMA
 
+"""
+The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing 
+the observability of your GraphQL services powered by Tailcall. By leveraging this 
+directive, developers gain access to valuable insights into the performance and behavior 
+of their applications.
+"""
 directive @telemetry(
   export: TelemetryExporter
 ) on FIELD_DEFINITION
@@ -694,6 +700,12 @@ input StdoutExporter {
   """
   pretty: Boolean!
 }
+"""
+The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing 
+the observability of your GraphQL services powered by Tailcall. By leveraging this 
+directive, developers gain access to valuable insights into the performance and behavior 
+of their applications.
+"""
 input Telemetry {
   export: TelemetryExporter
 }

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -323,7 +323,7 @@ directive @server(
 
 """
 The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing 
-the observability of your GraphQL services powered by Tailcall. By leveraging this 
+the observability of your GraphQL services powered by Tailcall.  By leveraging this 
 directive, developers gain access to valuable insights into the performance and behavior 
 of their applications.
 """
@@ -702,7 +702,7 @@ input StdoutExporter {
 }
 """
 The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing 
-the observability of your GraphQL services powered by Tailcall. By leveraging this 
+the observability of your GraphQL services powered by Tailcall.  By leveraging this 
 directive, developers gain access to valuable insights into the performance and behavior 
 of their applications.
 """

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -321,6 +321,10 @@ directive @server(
   workers: Int
 ) on SCHEMA
 
+directive @telemetry(
+  export: TelemetryExporter
+) on FIELD_DEFINITION
+
 """
 The `upstream` directive allows you to control various aspects of the upstream server 
 connection. This includes settings like connection timeouts, keep-alive intervals, 

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1636,6 +1636,7 @@
       }
     },
     "Telemetry": {
+      "description": "The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing the observability of your GraphQL services powered by Tailcall. By leveraging this directive, developers gain access to valuable insights into the performance and behavior of their applications.",
       "type": "object",
       "properties": {
         "export": {

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1636,7 +1636,7 @@
       }
     },
     "Telemetry": {
-      "description": "The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing the observability of your GraphQL services powered by Tailcall. By leveraging this directive, developers gain access to valuable insights into the performance and behavior of their applications.",
+      "description": "The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing the observability of your GraphQL services powered by Tailcall.  By leveraging this directive, developers gain access to valuable insights into the performance and behavior of their applications.",
       "type": "object",
       "properties": {
         "export": {

--- a/src/config/telemetry.rs
+++ b/src/config/telemetry.rs
@@ -104,8 +104,10 @@ impl TelemetryExporter {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-/// The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing the observability of your GraphQL services powered by Tailcall.
-///  By leveraging this directive, developers gain access to valuable insights into the performance and behavior of their applications.
+/// The @telemetry directive facilitates seamless integration with
+/// OpenTelemetry, enhancing the observability of your GraphQL services powered
+/// by Tailcall.  By leveraging this directive, developers gain access to
+/// valuable insights into the performance and behavior of their applications.
 pub struct Telemetry {
     pub export: Option<TelemetryExporter>,
 }

--- a/src/config/telemetry.rs
+++ b/src/config/telemetry.rs
@@ -104,6 +104,8 @@ impl TelemetryExporter {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
+/// The @telemetry directive facilitates seamless integration with OpenTelemetry, enhancing the observability of your GraphQL services powered by Tailcall.
+///  By leveraging this directive, developers gain access to valuable insights into the performance and behavior of their applications.
 pub struct Telemetry {
     pub export: Option<TelemetryExporter>,
 }


### PR DESCRIPTION

**Issue Reference(s):**  
Fixes #1349
**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.



/claim #1349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced telemetry capabilities in the GraphQL schema, allowing for enhanced data analysis and monitoring.
	- Added a new directive `@telemetry` for improved observability in GraphQL services powered by Tailcall.
	- Enhanced integration with OpenTelemetry for better monitoring and analysis.
	- Improved documentation for the `Telemetry` struct to facilitate understanding of its role in enhancing observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->