### PR TITLE
fix: add telemetry directive to autogen

### DIFF
--- a/autogen/src/gen_gql_schema.rs
+++ b/autogen/src/gen_gql_schema.rs
@@ -21,6 +21,7 @@ lazy_static! {
         ("http", vec![Entity::FieldDefinition], false),
         ("call", vec![Entity::FieldDefinition], false),
         ("grpc", vec![Entity::FieldDefinition], false),
+        ("telemetry", vec![Entity::FieldDefinition], false),
         ("addField", vec![Entity::Object], true),
         ("modify", vec![Entity::FieldDefinition], false),
         ("omit", vec![Entity::FieldDefinition], false),

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -61,6 +61,10 @@ directive @expr(
   body: ExprBody
 ) on FIELD_DEFINITION
 
+directive @telemetry(
+  export: TelemetryExporter
+) on FIELD_DEFINITION
+
 """
 The @graphQL operator allows to specify GraphQL API server request to fetch data 
 from.


### PR DESCRIPTION
/claim #1349

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for telemetry data in the GraphQL schema, including a new `@telemetry` directive to specify telemetry data export options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->