### PR TITLE
feat: change block parsing

### DIFF
--- a/tests/execution/add-field-index-list.md
+++ b/tests/execution/add-field-index-list.md
@@ -1,8 +1,7 @@
 # Sending field index list
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -16,9 +15,8 @@ type Query @addField(name: "username", path: ["users", "0", "name"]) {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users
@@ -30,9 +28,8 @@ type Query @addField(name: "username", path: ["users", "0", "name"]) {
         name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/add-field-many-list.md
+++ b/tests/execution/add-field-many-list.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/add-field-many.md
+++ b/tests/execution/add-field-many.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/add-field-modify.md
+++ b/tests/execution/add-field-modify.md
@@ -1,8 +1,7 @@
 # Add field modify
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -26,9 +25,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -44,9 +42,8 @@ type Query {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/add-field-with-composition.md
+++ b/tests/execution/add-field-with-composition.md
@@ -1,8 +1,7 @@
 # Add field with composition
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -28,9 +27,8 @@ type Query
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -47,9 +45,8 @@ type Query
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/add-field-with-modify.md
+++ b/tests/execution/add-field-with-modify.md
@@ -1,8 +1,7 @@
 # Add field with modify
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -16,9 +15,8 @@ type Query @addField(name: "user1", path: ["person1", "name"]) @addField(name: "
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -39,9 +37,8 @@ type Query @addField(name: "user1", path: ["person1", "name"]) @addField(name: "
       name: Ervin Howell
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/add-field.md
+++ b/tests/execution/add-field.md
@@ -1,8 +1,7 @@
 # Add field
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -24,9 +23,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -41,9 +39,8 @@ type Query {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/batching-default.md
+++ b/tests/execution/batching-default.md
@@ -1,8 +1,7 @@
 # Batching default
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true, batch: {delay: 10}) {
   query: Query
 }
@@ -26,9 +25,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts?id=11&id=3&foo=1
@@ -51,9 +49,8 @@ type User {
       - id: 2
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/batching-disabled.md
+++ b/tests/execution/batching-disabled.md
@@ -1,8 +1,7 @@
 # Batching disabled
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {
@@ -57,9 +56,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -80,9 +78,8 @@
       name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/batching-group-by-default.md
+++ b/tests/execution/batching-group-by-default.md
@@ -1,8 +1,7 @@
 # Batching group by default
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server
   @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true, batch: {delay: 1, maxSize: 1000}) {
@@ -28,9 +27,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts?id=11&id=3&foo=1
@@ -59,9 +57,8 @@ type User {
         name: bar
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/batching-group-by.md
+++ b/tests/execution/batching-group-by.md
@@ -1,8 +1,7 @@
 # Batching group by
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, queryValidation: false)
   @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true, batch: {delay: 1, maxSize: 1000}) {
@@ -28,9 +27,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts?id=11&id=3&foo=1
@@ -59,9 +57,8 @@ type User {
         name: Ervin Howell
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/batching-nested-expr.md
+++ b/tests/execution/batching-nested-expr.md
@@ -1,8 +1,7 @@
 # Batching inside nested @expr
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true, batch: {delay: 10}) {
   query: Query
 }
@@ -47,9 +46,8 @@ type Value {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     url: http://jsonplaceholder.typicode.com/posts
   response:
@@ -81,9 +79,8 @@ type Value {
       - {id: 2, value: 9}
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/batching-post.md
+++ b/tests/execution/batching-post.md
@@ -1,8 +1,7 @@
 # Batching post
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, queryValidation: false)
   @upstream(
@@ -31,9 +30,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts?id=1
@@ -54,9 +52,8 @@ type User {
       name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/batching.md
+++ b/tests/execution/batching.md
@@ -1,8 +1,7 @@
 # Sending a batched graphql request
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {
     "batchRequests": true
@@ -42,9 +41,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -59,9 +57,8 @@
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/cache-control.md
+++ b/tests/execution/cache-control.md
@@ -1,8 +1,7 @@
 # Sending requests to verify Cache-Control behavior
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {
     "cacheControlHeader": true
@@ -53,9 +52,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users?id=1
@@ -113,9 +111,8 @@
       name: barfoo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/caching-collision.md
+++ b/tests/execution/caching-collision.md
@@ -1,8 +1,7 @@
 # Caching Collision
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "http://example.com", batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }
@@ -21,9 +20,8 @@ type Bar {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://example.com/bars
@@ -933,9 +931,8 @@ type Bar {
       id: 99
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/caching.md
+++ b/tests/execution/caching.md
@@ -1,8 +1,7 @@
 # Caching
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "http://example.com", batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }
@@ -24,9 +23,8 @@ type TypeCache @cache(maxAge: 1000) {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://example.com/field-cache
@@ -72,9 +70,8 @@ type TypeCache @cache(maxAge: 1000) {
       - id: 33
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 # the same request to validate caching
 - method: POST
   url: http://localhost:8080/graphql

--- a/tests/execution/call-graphql-datasource.md
+++ b/tests/execution/call-graphql-datasource.md
@@ -1,8 +1,7 @@
 # Call operator with graphQL datasource
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true, hostname: "0.0.0.0")
   @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true) {
@@ -33,9 +32,8 @@ type Post {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts
@@ -79,9 +77,8 @@ type Post {
           name: Ervin Howell
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/call-mutation.md
+++ b/tests/execution/call-mutation.md
@@ -1,8 +1,7 @@
 # Call mutation
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
   mutation: Mutation
@@ -53,9 +52,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://jsonplaceholder.typicode.com/posts
@@ -116,9 +114,8 @@ type User {
       userId: 1
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/call-operator.md
+++ b/tests/execution/call-operator.md
@@ -1,8 +1,7 @@
 # Test call operator
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -38,9 +37,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true, hostname: "0.0.0.0")
   @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true)
@@ -110,9 +108,8 @@ type Post {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     url: http://jsonplaceholder.typicode.com/users/1
   expected_hits: 4
@@ -174,9 +171,8 @@ type Post {
     body: \0\0\0\0t\n#\x08\x01\x12\x06Note 1\x1a\tContent 1\"\x0cPost image 1\n#\x08\x02\x12\x06Note 2\x1a\tContent 2\"\x0cPost image 2
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/custom-headers.md
+++ b/tests/execution/custom-headers.md
@@ -1,8 +1,7 @@
 # Custom Headers
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {
     "responseHeaders": [
@@ -37,9 +36,8 @@
 }
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/env-value.md
+++ b/tests/execution/env-value.md
@@ -1,8 +1,7 @@
 # Env value
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {
@@ -64,9 +63,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts/1
@@ -102,17 +100,15 @@
       userId: 3
 ```
 
-#### env:
-
-```yml
+####
+```yml @env
 ID: "1"
 POST_ID: "2"
 NESTED_POST_ID: "3"
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/graphql-dataloader-batch-keys.md
+++ b/tests/execution/graphql-dataloader-batch-keys.md
@@ -2,9 +2,8 @@
 
 **This test had an assertion with a fail annotation that testconv cannot convert losslessly.** If you need the original responses, you can find it in git history. (For example, at commit [1c32ca9](https://github.com/tailcallhq/tailcall/tree/1c32ca9e8080ae3b17e9cf41078d028d3e0289da))
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8001, queryValidation: false, hostname: "0.0.0.0")
   @upstream(baseURL: "http://upstream/graphql", httpCache: true, batch: {delay: 1}) {
@@ -34,9 +33,8 @@ type B {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://upstream/graphql
@@ -86,9 +84,8 @@ type B {
             y: 1
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/graphql-dataloader-batch-request.md
+++ b/tests/execution/graphql-dataloader-batch-request.md
@@ -1,8 +1,7 @@
 # Graphql datasource
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(batch: {delay: 1}) {
   query: Query
 }
@@ -30,9 +29,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts
@@ -80,9 +78,8 @@ type Query {
             name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/graphql-dataloader-no-batch-request.md
+++ b/tests/execution/graphql-dataloader-no-batch-request.md
@@ -1,8 +1,7 @@
 # Graphql datasource
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(batch: {delay: 1}) {
   query: Query
 }
@@ -24,9 +23,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts
@@ -68,9 +66,8 @@ type Query {
           name: Ervin Howell
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/graphql-datasource-errors.md
+++ b/tests/execution/graphql-datasource-errors.md
@@ -1,8 +1,7 @@
 # Graphql datasource
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -18,9 +17,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://upstream/graphql
@@ -54,9 +52,8 @@ type Query {
           message: Failed to resolve name
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/graphql-datasource-mutation.md
+++ b/tests/execution/graphql-datasource-mutation.md
@@ -1,8 +1,7 @@
 # Graphql datasource
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
   mutation: Mutation
@@ -29,9 +28,8 @@ type UserInput {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://upstream/graphql
@@ -44,9 +42,8 @@ type UserInput {
           name: Test Name
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/graphql-datasource-no-args.md
+++ b/tests/execution/graphql-datasource-no-args.md
@@ -1,8 +1,7 @@
 # Graphql datasource
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -17,9 +16,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://upstream/graphql
@@ -33,9 +31,8 @@ type Query {
           - name: Ervin Howell
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/graphql-datasource-with-args.md
+++ b/tests/execution/graphql-datasource-with-args.md
@@ -1,8 +1,7 @@
 # Graphql datasource
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -25,9 +24,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://upstream/graphql
@@ -52,9 +50,8 @@ type Query {
             name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/grpc-batch.md
+++ b/tests/execution/grpc-batch.md
@@ -1,8 +1,7 @@
 # Grpc datasource with batching
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -38,9 +37,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true)
   @upstream(httpCache: true, batch: {delay: 10})
@@ -76,9 +74,8 @@ type News {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://localhost:50051/news.NewsService/GetMultipleNews
@@ -88,9 +85,8 @@ type News {
     body: \0\0\0\0t\n#\x08\x02\x12\x06Note 2\x1a\tContent 2\"\x0cPost image 2\n#\x08\x03\x12\x06Note 3\x1a\tContent 3\"\x0cPost image 3
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/grpc-override-url-from-upstream.md
+++ b/tests/execution/grpc-override-url-from-upstream.md
@@ -1,8 +1,7 @@
 # Grpc datasource
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -38,9 +37,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true)
   @upstream(httpCache: true, batch: {delay: 10}, baseURL: "http://not-a-valid-grpc-url.com")
@@ -71,9 +69,8 @@ type News {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://localhost:50051/news.NewsService/GetAllNews
@@ -83,9 +80,8 @@ type News {
     body: \0\0\0\0t\n#\x08\x01\x12\x06Note 1\x1a\tContent 1\"\x0cPost image 1\n#\x08\x02\x12\x06Note 2\x1a\tContent 2\"\x0cPost image 2
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/grpc-simple.md
+++ b/tests/execution/grpc-simple.md
@@ -1,8 +1,7 @@
 # Grpc datasource
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -38,9 +37,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true)
   @upstream(httpCache: true, batch: {delay: 10})
@@ -71,9 +69,8 @@ type News {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://localhost:50051/news.NewsService/GetAllNews
@@ -83,9 +80,8 @@ type News {
     body: \0\0\0\0t\n#\x08\x01\x12\x06Note 1\x1a\tContent 1\"\x0cPost image 1\n#\x08\x02\x12\x06Note 2\x1a\tContent 2\"\x0cPost image 2
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/grpc-url-from-upstream.md
+++ b/tests/execution/grpc-url-from-upstream.md
@@ -1,8 +1,7 @@
 # Grpc datasource
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -38,9 +37,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true)
   @upstream(httpCache: true, batch: {delay: 10}, baseURL: "http://localhost:50051")
@@ -70,9 +68,8 @@ type News {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://localhost:50051/news.NewsService/GetAllNews
@@ -82,9 +79,8 @@ type News {
     body: \0\0\0\0t\n#\x08\x01\x12\x06Note 1\x1a\tContent 1\"\x0cPost image 1\n#\x08\x02\x12\x06Note 2\x1a\tContent 2\"\x0cPost image 2
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/https.md
+++ b/tests/execution/https.md
@@ -1,8 +1,7 @@
 # Against a server with HTTPS
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {
@@ -42,9 +41,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: https://jsonplaceholder.typicode.com/users/1
@@ -56,9 +54,8 @@
       name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/inline-field.md
+++ b/tests/execution/inline-field.md
@@ -1,8 +1,7 @@
 # Inline field
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -24,9 +23,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -41,9 +39,8 @@ type Query {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/inline-index-list.md
+++ b/tests/execution/inline-index-list.md
@@ -1,8 +1,7 @@
 # Test inline index list
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -16,9 +15,8 @@ type Query @addField(name: "username", path: ["username", "0", "name"]) {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users
@@ -30,9 +28,8 @@ type Query @addField(name: "username", path: ["username", "0", "name"]) {
         name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/inline-many-list.md
+++ b/tests/execution/inline-many-list.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/inline-many.md
+++ b/tests/execution/inline-many.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/modified-field.md
+++ b/tests/execution/modified-field.md
@@ -1,8 +1,7 @@
 # Modified field
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -16,9 +15,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -30,9 +28,8 @@ type Query {
       name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/mutation-put.md
+++ b/tests/execution/mutation-put.md
@@ -1,8 +1,7 @@
 # Mutation put
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
   mutation: Mutation
@@ -36,9 +35,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: PUT
     url: http://jsonplaceholder.typicode.com/posts/100
@@ -49,9 +47,8 @@ type User {
       body: abc
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/mutation.md
+++ b/tests/execution/mutation.md
@@ -1,8 +1,7 @@
 # Mutation
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
   mutation: Mutation
@@ -35,9 +34,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://jsonplaceholder.typicode.com/posts
@@ -50,9 +48,8 @@ type User {
       userId: 1
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/n-plus-one-list.md
+++ b/tests/execution/n-plus-one-list.md
@@ -1,8 +1,7 @@
 # n + 1 Request List
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "http://example.com", batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }
@@ -25,9 +24,8 @@ type Bar {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://example.com/bars
@@ -56,9 +54,8 @@ type Bar {
         name: foo2
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/n-plus-one.md
+++ b/tests/execution/n-plus-one.md
@@ -1,8 +1,7 @@
 # n + 1 Request
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "http://example.com", batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }
@@ -25,9 +24,8 @@ type Bar {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://example.com/foos
@@ -52,9 +50,8 @@ type Bar {
         id: 2
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/nested-objects.md
+++ b/tests/execution/nested-objects.md
@@ -1,8 +1,7 @@
 # Nested objects
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -26,9 +25,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -43,9 +41,8 @@ type Query {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/nesting-level3.md
+++ b/tests/execution/nesting-level3.md
@@ -1,8 +1,7 @@
 # Nesting level 3
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }
@@ -33,9 +32,8 @@ type Post {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts/1
@@ -68,9 +66,8 @@ type Post {
       - completed: false
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/nullable-arg-query.md
+++ b/tests/execution/nullable-arg-query.md
@@ -1,8 +1,7 @@
 # Nullable arg query
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -18,9 +17,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users
@@ -48,9 +46,8 @@ type User {
       - id: 1
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/omit-index-list.md
+++ b/tests/execution/omit-index-list.md
@@ -1,8 +1,7 @@
 # Test inline index list
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -16,9 +15,8 @@ type Query @addField(name: "username", path: ["username", "0", "name"]) {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users
@@ -30,9 +28,8 @@ type Query @addField(name: "username", path: ["username", "0", "name"]) {
         name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/omit-many.md
+++ b/tests/execution/omit-many.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/omit-resolved-by-parent.md
+++ b/tests/execution/omit-resolved-by-parent.md
@@ -1,8 +1,7 @@
 # Resolved by parent
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -20,9 +19,8 @@ type User @addField(name: "address", path: ["address", "street"]) {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -36,9 +34,8 @@ type User @addField(name: "address", path: ["address", "street"]) {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/ref-other-nested.md
+++ b/tests/execution/ref-other-nested.md
@@ -1,8 +1,7 @@
 # Ref other nested
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {
@@ -64,9 +63,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: https://jsonplaceholder.typicode.com/users/1
@@ -79,9 +77,8 @@
       name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/ref-other.md
+++ b/tests/execution/ref-other.md
@@ -1,8 +1,7 @@
 # Ref other
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "https://jsonplaceholder.typicode.com") {
   query: Query
 }
@@ -21,9 +20,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: https://jsonplaceholder.typicode.com/users/1
@@ -35,9 +33,8 @@ type Query {
       name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/rename-field.md
+++ b/tests/execution/rename-field.md
@@ -1,8 +1,7 @@
 # Rename field
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -16,9 +15,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -39,9 +37,8 @@ type Query {
       name: Ervin Howell
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/request-to-upstream-batching.md
+++ b/tests/execution/request-to-upstream-batching.md
@@ -1,8 +1,7 @@
 # Batched graphql request to batched upstream query
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {
     "batchRequests": true
@@ -61,9 +60,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users?id=1&id=2
@@ -79,9 +77,8 @@
         name: bar
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/resolve-with-headers.md
+++ b/tests/execution/resolve-with-headers.md
@@ -1,8 +1,7 @@
 # Resolve with headers
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(allowedHeaders: ["authorization"]) {
   query: Query
 }
@@ -19,9 +18,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/posts/1
@@ -36,9 +34,8 @@ type Query {
       title: post title
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   headers:

--- a/tests/execution/resolve-with-vars.md
+++ b/tests/execution/resolve-with-vars.md
@@ -1,8 +1,7 @@
 # Resolve with vars
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(vars: [{key: "id", value: "1"}]) {
   query: Query
 }
@@ -18,9 +17,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users?id=1
@@ -32,9 +30,8 @@ type Query {
         name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/resolved-by-parent.md
+++ b/tests/execution/resolved-by-parent.md
@@ -1,8 +1,7 @@
 # Resolved by parent
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -20,9 +19,8 @@ type User @addField(name: "address", path: ["address", "street"]) {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -36,9 +34,8 @@ type User @addField(name: "address", path: ["address", "street"]) {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/rest-api.md
+++ b/tests/execution/rest-api.md
@@ -1,8 +1,7 @@
 # Rest API
 
-#### file:operation-user.graphql
-
-```graphql
+####
+```graphql @file:operation-user.graphql
 query ($id: Int!) @rest(method: "get", path: "/user/$id") {
   user(id: $id) {
     id
@@ -11,9 +10,8 @@ query ($id: Int!) @rest(method: "get", path: "/user/$id") {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server
   @upstream(baseURL: "http://jsonplaceholder.typicode.com")
@@ -31,9 +29,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -47,9 +44,8 @@ type User {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: GET
   url: http://localhost:8080/api/user/1
 ```

--- a/tests/execution/showcase.md
+++ b/tests/execution/showcase.md
@@ -1,8 +1,7 @@
 # Showcase GraphQL Request
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(showcase: true) {
   query: Query
 }
@@ -17,9 +16,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -51,9 +49,8 @@ type Query {
     body: dsjfsjdfjdsfjkdskjfjkds
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/showcase/graphql?config=http%3A%2F%2Fexample.com%2Fsimple.graphql
   body:

--- a/tests/execution/simple-graphql.md
+++ b/tests/execution/simple-graphql.md
@@ -1,8 +1,7 @@
 # Simple GraphQL Request
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -17,9 +16,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -33,9 +31,8 @@ type Query {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/simple-query.md
+++ b/tests/execution/simple-query.md
@@ -1,8 +1,7 @@
 # Simple query
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {
@@ -41,9 +40,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -55,9 +53,8 @@
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-add-field-error.md
+++ b/tests/execution/test-add-field-error.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-add-field-list.md
+++ b/tests/execution/test-add-field-list.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-add-field.md
+++ b/tests/execution/test-add-field.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-add-link-to-empty-config.md
+++ b/tests/execution/test-add-link-to-empty-config.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### file:link-const.graphql
-
-```graphql
+####
+```graphql @file:link-const.graphql
 schema @server @upstream {
   query: Query
 }
@@ -14,9 +13,8 @@ type Query {
 }
 ```
 
-#### file:link-enum.graphql
-
-```graphql
+####
+```graphql @file:link-enum.graphql
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }
@@ -31,9 +29,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream @link(src: "link-const.graphql", type: Config) @link(src: "link-enum.graphql", type: Config) {
   query: Query
 }

--- a/tests/execution/test-all-blueprint-errors.md
+++ b/tests/execution/test-all-blueprint-errors.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server {
   query: Query
   mutation: Mutation

--- a/tests/execution/test-batch-operator-post.md
+++ b/tests/execution/test-batch-operator-post.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://localhost:3000", batch: {delay: 1}) {
   query: Query
 }

--- a/tests/execution/test-batching-group-by.md
+++ b/tests/execution/test-batching-group-by.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 4000) @upstream(baseURL: "http://abc.com", batch: {delay: 1, headers: [], maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/test-cache.md
+++ b/tests/execution/test-cache.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-call-operator-errors.md
+++ b/tests/execution/test-call-operator-errors.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://localhost:3000") {
   query: Query
 }

--- a/tests/execution/test-conflict-allowed-headers.md
+++ b/tests/execution/test-conflict-allowed-headers.md
@@ -1,8 +1,7 @@
 # test-conflict-allowed-headers
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(allowedHeaders: ["a", "b", "c"]) {
   query: Query
 }
@@ -12,9 +11,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(allowedHeaders: ["b", "c", "d"]) {
   query: Query
 }

--- a/tests/execution/test-conflict-vars.md
+++ b/tests/execution/test-conflict-vars.md
@@ -1,8 +1,7 @@
 # test-conflict-vars
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(vars: [{key: "a", value: "b"}, {key: "c", value: "d"}]) @upstream {
   query: Query
 }
@@ -12,9 +11,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(vars: [{key: "a", value: "b"}, {key: "p", value: "q"}]) @upstream {
   query: Query
 }

--- a/tests/execution/test-const-error.md
+++ b/tests/execution/test-const-error.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "https://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-const-with-add-field.md
+++ b/tests/execution/test-const-with-add-field.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-const-with-inline.md
+++ b/tests/execution/test-const-with-inline.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-const-with-mustache.md
+++ b/tests/execution/test-const-with-mustache.md
@@ -1,8 +1,7 @@
 # Test const with mustache
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -32,9 +31,8 @@ type D {
 }
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8000/graphql
   body:

--- a/tests/execution/test-const.md
+++ b/tests/execution/test-const.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-custom-scalar.md
+++ b/tests/execution/test-custom-scalar.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-custom-types.md
+++ b/tests/execution/test-custom-types.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Que
   mutation: Mut

--- a/tests/execution/test-dbl-usage-many.md
+++ b/tests/execution/test-dbl-usage-many.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-dbl-usage.md
+++ b/tests/execution/test-dbl-usage.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-description-many.md
+++ b/tests/execution/test-description-many.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-directives-undef-null-fields.md
+++ b/tests/execution/test-directives-undef-null-fields.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(vars: [{key: "a", value: "1"}, {key: "c", value: "d"}]) {
   query: Query
 }

--- a/tests/execution/test-duplicated-link.md
+++ b/tests/execution/test-duplicated-link.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:jsonplaceholder.graphql
-
-```graphql
+####
+```graphql @file:jsonplaceholder.graphql
 schema
   @server(port: 8000, graphiql: true, hostname: "0.0.0.0")
   @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true, batch: {delay: 100}) {
@@ -35,9 +34,8 @@ type Post {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder")
   @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder1")

--- a/tests/execution/test-empty-link.md
+++ b/tests/execution/test-empty-link.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "https://jsonplaceholder.typicode.com") @link(type: Config, src: "") @link(type: Config) {
   query: Query
 }

--- a/tests/execution/test-enum-merge.md
+++ b/tests/execution/test-enum-merge.md
@@ -1,8 +1,7 @@
 # test-enum-merge
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }
@@ -17,9 +16,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-enum.md
+++ b/tests/execution/test-enum.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-expr-concat.md
+++ b/tests/execution/test-expr-concat.md
@@ -1,8 +1,7 @@
 # expr concat
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -12,9 +11,8 @@ type Query {
 }
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-expr-errors.md
+++ b/tests/execution/test-expr-errors.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server {
   query: Query
 }

--- a/tests/execution/test-expr-if-errors.md
+++ b/tests/execution/test-expr-if-errors.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server {
   query: Query
 }

--- a/tests/execution/test-expr-intersection.md
+++ b/tests/execution/test-expr-intersection.md
@@ -1,8 +1,7 @@
 # expr intersection
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -12,9 +11,8 @@ type Query {
 }
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-expr-logic.md
+++ b/tests/execution/test-expr-logic.md
@@ -1,8 +1,7 @@
 # expr logic
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -44,9 +43,8 @@ type Query {
 }
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-expr-math.md
+++ b/tests/execution/test-expr-math.md
@@ -1,8 +1,7 @@
 # expr logic
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -21,9 +20,8 @@ type Query {
 }
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-expr-relation.md
+++ b/tests/execution/test-expr-relation.md
@@ -4,9 +4,8 @@ This test has invalid GraphQL that wasn't caught by http_spec before conversion.
 
 ##### skip
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "http://example.com") {
   query: Query
 }
@@ -77,9 +76,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://example.com/user
@@ -169,8 +167,7 @@ type User {
           - 1
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 []
 ```

--- a/tests/execution/test-expr-success.md
+++ b/tests/execution/test-expr-success.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 8000) @upstream(baseURL: "http://localhost:50051", batch: {delay: 10, headers: [], maxSize: 1000}) @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-field-already-implemented-from-Interface.md
+++ b/tests/execution/test-field-already-implemented-from-Interface.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-graphqlsource-no-base-url.md
+++ b/tests/execution/test-graphqlsource-no-base-url.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-graphqlsource.md
+++ b/tests/execution/test-graphqlsource.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://localhost:8000/graphql") {
   query: Query
 }

--- a/tests/execution/test-groupby-without-batching.md
+++ b/tests/execution/test-groupby-without-batching.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "http://jsonplaceholder.typicode.com", httpCache: true) {
   query: Query
 }

--- a/tests/execution/test-grpc-group-by.md
+++ b/tests/execution/test-grpc-group-by.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true)
   @upstream(httpCache: true, batch: {delay: 10})

--- a/tests/execution/test-grpc-invalid-method-format.md
+++ b/tests/execution/test-grpc-invalid-method-format.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-grpc-invalid-proto-id.md
+++ b/tests/execution/test-grpc-invalid-proto-id.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-grpc-missing-fields.md
+++ b/tests/execution/test-grpc-missing-fields.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-nested-data.md
+++ b/tests/execution/test-grpc-nested-data.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema
   @server(port: 8000, graphiql: true)
   @upstream(httpCache: true, batch: {delay: 10})

--- a/tests/execution/test-grpc-nested-optional.md
+++ b/tests/execution/test-grpc-nested-optional.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-optional.md
+++ b/tests/execution/test-grpc-optional.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-proto-path.md
+++ b/tests/execution/test-grpc-proto-path.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @link(id: "news", src: "tailcall/src/grpcnews.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-service-method.md
+++ b/tests/execution/test-grpc-service-method.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-service.md
+++ b/tests/execution/test-grpc-service.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc.md
+++ b/tests/execution/test-grpc.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 8000) @upstream(baseURL: "http://localhost:50051", batch: {delay: 10, headers: [], maxSize: 1000}) @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-hostname-faliure.md
+++ b/tests/execution/test-hostname-faliure.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(hostname: "abc") {
   query: Query
 }

--- a/tests/execution/test-http-baseurl.md
+++ b/tests/execution/test-http-baseurl.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://abc.com") {
   query: Query
 }

--- a/tests/execution/test-http-headers.md
+++ b/tests/execution/test-http-headers.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://localhost:4000") {
   query: Query
 }

--- a/tests/execution/test-http-tmpl.md
+++ b/tests/execution/test-http-tmpl.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-http-with-add-field.md
+++ b/tests/execution/test-http-with-add-field.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-http-with-inline.md
+++ b/tests/execution/test-http-with-inline.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-http-with-mustache-const.md
+++ b/tests/execution/test-http-with-mustache-const.md
@@ -1,8 +1,7 @@
 # Test const with mustache
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -27,9 +26,8 @@ type D {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     url: http://localhost:3000/a
   response:
@@ -41,9 +39,8 @@ type D {
       f: true
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8000/graphql
   body:

--- a/tests/execution/test-http.md
+++ b/tests/execution/test-http.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-inline-error.md
+++ b/tests/execution/test-inline-error.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-inline-list.md
+++ b/tests/execution/test-inline-list.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-inline.md
+++ b/tests/execution/test-inline.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-interface-result.md
+++ b/tests/execution/test-interface-result.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-interface.md
+++ b/tests/execution/test-interface.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-invalid-query-in-http.md
+++ b/tests/execution/test-invalid-query-in-http.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(vars: [{key: "id", value: "1"}]) {
   query: Query
 }

--- a/tests/execution/test-invalid-server.md
+++ b/tests/execution/test-invalid-server.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: "8000") {
   query: Query
 }

--- a/tests/execution/test-js-multiple-scripts.md
+++ b/tests/execution/test-js-multiple-scripts.md
@@ -2,21 +2,18 @@
 
 ###### sdl error
 
-#### file:test1.js
-
-```js
+####
+```js @file:test1.js
 function onRequest(request) {}
 ```
 
-#### file:test2.js
-
-```js
+####
+```js @file:test2.js
 function onRequest(request) {}
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @link(type: Script, src: "test1.js") @link(type: Script, src: "test2.js") {
   query: Query
 }

--- a/tests/execution/test-js-request-reponse.md
+++ b/tests/execution/test-js-request-reponse.md
@@ -1,8 +1,7 @@
 # Js Request Response Hello World
 
-#### file:test.js
-
-```js
+####
+```js @file:test.js
 function onRequest({request}) {
   if (request.url.endsWith("/hello")) {
     return {
@@ -27,9 +26,8 @@ function onRequest({request}) {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @link(type: Script, src: "test.js") {
   query: Query
 }
@@ -40,9 +38,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://localhost:3000/bye
@@ -51,9 +48,8 @@ type Query {
     body: hello world
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-lack-resolver.md
+++ b/tests/execution/test-lack-resolver.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 8000) @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-merge-batch.md
+++ b/tests/execution/test-merge-batch.md
@@ -1,8 +1,7 @@
 # test-merge-batch
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(batch: {delay: 0, maxSize: 1000, headers: ["a", "b"]}) {
   query: Query
 }
@@ -12,9 +11,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(batch: {delay: 5, maxSize: 100, headers: ["b", "c"]}) {
   query: Query
 }
@@ -24,9 +22,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-merge-nested.md
+++ b/tests/execution/test-merge-nested.md
@@ -1,8 +1,7 @@
 # test-merge-nested
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://abc.com") {
   query: Query
 }
@@ -19,9 +18,8 @@ type Foo {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server {
   query: Query
 }

--- a/tests/execution/test-merge-query.md
+++ b/tests/execution/test-merge-query.md
@@ -1,8 +1,7 @@
 # test-merge-query
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 3000) @upstream(baseURL: "http://abc.com") {
   query: Query
 }
@@ -12,9 +11,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 8000) @upstream(proxy: {url: "http://localhost:3000"}) {
   query: Query
 }

--- a/tests/execution/test-merge-server-sdl.md
+++ b/tests/execution/test-merge-server-sdl.md
@@ -1,8 +1,7 @@
 # test-merge-server-sdl
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-merge-union.md
+++ b/tests/execution/test-merge-union.md
@@ -1,8 +1,7 @@
 # test-merge-union
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }
@@ -22,9 +21,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-missing-argument-on-all-resolvers.md
+++ b/tests/execution/test-missing-argument-on-all-resolvers.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### file:news.proto
-
-```protobuf
+####
+```protobuf @file:news.proto
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -40,9 +39,8 @@ message NewsList {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @upstream(baseURL: "http://jsonplaceholder.typicode.com") @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-missing-mutation-resolver.md
+++ b/tests/execution/test-missing-mutation-resolver.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
   mutation: Mutation

--- a/tests/execution/test-missing-query-resolver.md
+++ b/tests/execution/test-missing-query-resolver.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-missing-root-types.md
+++ b/tests/execution/test-missing-root-types.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: QueryType
   mutation: MutationDef

--- a/tests/execution/test-missing-schema-query.md
+++ b/tests/execution/test-missing-schema-query.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   mutation: Mutation
 }

--- a/tests/execution/test-modify.md
+++ b/tests/execution/test-modify.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-multi-interface.md
+++ b/tests/execution/test-multi-interface.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-multiple-resolvable-directives-on-field.md
+++ b/tests/execution/test-multiple-resolvable-directives-on-field.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "https://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-nested-input.md
+++ b/tests/execution/test-nested-input.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-nested-link.md
+++ b/tests/execution/test-nested-link.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### file:link-enum.graphql
-
-```graphql
+####
+```graphql @file:link-enum.graphql
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }
@@ -19,9 +18,8 @@ type Query {
 }
 ```
 
-#### file:graphql-with-link.graphql
-
-```graphql
+####
+```graphql @file:graphql-with-link.graphql
 schema @server @upstream(baseURL: "http://localhost:8000/graphql") @link(src: "link-enum.graphql", type: Config) {
   query: Query
 }
@@ -42,9 +40,8 @@ type User {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream @link(src: "graphql-with-link.graphql", type: Config) {
   query: Query
 }

--- a/tests/execution/test-nested-value.md
+++ b/tests/execution/test-nested-value.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-no-base-url.md
+++ b/tests/execution/test-no-base-url.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }

--- a/tests/execution/test-omit-list.md
+++ b/tests/execution/test-omit-list.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-omit.md
+++ b/tests/execution/test-omit.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-params-as-body.md
+++ b/tests/execution/test-params-as-body.md
@@ -1,8 +1,7 @@
 # Http with args as body
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 8000, graphiql: true) @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }
@@ -17,9 +16,8 @@ type User {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: POST
     url: http://jsonplaceholder.typicode.com/users
@@ -31,9 +29,8 @@ type User {
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-query-documentation.md
+++ b/tests/execution/test-query-documentation.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-query.md
+++ b/tests/execution/test-query.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-ref-other.md
+++ b/tests/execution/test-ref-other.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 8000) @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-response-header-value.md
+++ b/tests/execution/test-response-header-value.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(responseHeaders: [{key: "a", value: "a \n b"}]) {
   query: Query
 }

--- a/tests/execution/test-response-headers-multi.md
+++ b/tests/execution/test-response-headers-multi.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(responseHeaders: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]) {
   query: Query
 }

--- a/tests/execution/test-response-headers-name.md
+++ b/tests/execution/test-response-headers-name.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(responseHeaders: [{key: "🤣", value: "a"}]) {
   query: Query
 }

--- a/tests/execution/test-scalars.md
+++ b/tests/execution/test-scalars.md
@@ -1,8 +1,7 @@
 # test-scalar-email
 
-#### server:
-
-```graphql
+####
+```graphql @server
 scalar Email
 scalar PhoneNumber
 scalar Date
@@ -20,9 +19,8 @@ type Query {
 }
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 # Valid value tests
 - method: POST
   url: http://localhost:8000/graphql

--- a/tests/execution/test-server-base-types.md
+++ b/tests/execution/test-server-base-types.md
@@ -1,8 +1,7 @@
 # test-server-base-types
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 3000) @upstream(baseURL: "http://abc.com") {
   query: Query
 }
@@ -12,9 +11,8 @@ type Query {
 }
 ```
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(port: 8000) @upstream(proxy: {url: "http://localhost:3000"}) {
   query: Query
 }

--- a/tests/execution/test-server-vars.md
+++ b/tests/execution/test-server-vars.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server(vars: [{key: "foo", value: "bar"}]) @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-static-value.md
+++ b/tests/execution/test-static-value.md
@@ -1,8 +1,7 @@
 # Static value
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {},
@@ -40,9 +39,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -54,9 +52,8 @@
       name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/test-undefined-query.md
+++ b/tests/execution/test-undefined-query.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-union.md
+++ b/tests/execution/test-union.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
   query: Query
 }

--- a/tests/execution/test-upstream.md
+++ b/tests/execution/test-upstream.md
@@ -2,9 +2,8 @@
 
 ###### check identity
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(proxy: {url: "http://localhost:8085"}) {
   query: Query
 }

--- a/tests/execution/undeclared-type-no-base-url.md
+++ b/tests/execution/undeclared-type-no-base-url.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server {
   query: Query
 }

--- a/tests/execution/undeclared-type.md
+++ b/tests/execution/undeclared-type.md
@@ -2,9 +2,8 @@
 
 ###### sdl error
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server {
   query: Query
 }

--- a/tests/execution/upstream-batching.md
+++ b/tests/execution/upstream-batching.md
@@ -1,8 +1,7 @@
 # Sending requests to be batched by the upstream server
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {
@@ -58,9 +57,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users?id=1&id=2
@@ -76,9 +74,8 @@
         name: bar
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/upstream-fail-request.md
+++ b/tests/execution/upstream-fail-request.md
@@ -1,8 +1,7 @@
 # Simple GraphQL Request
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -17,9 +16,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -29,9 +27,8 @@ type Query {
     body: {}
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/with-args-url.md
+++ b/tests/execution/with-args-url.md
@@ -1,8 +1,7 @@
 # With args URL
 
-#### server:
-
-```json
+####
+```json @server
 {
   "server": {},
   "upstream": {
@@ -48,9 +47,8 @@
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -64,9 +62,8 @@
       name: foo
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/with-args.md
+++ b/tests/execution/with-args.md
@@ -1,8 +1,7 @@
 # With args
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema {
   query: Query
 }
@@ -17,9 +16,8 @@ type Query {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users?id=1
@@ -31,9 +29,8 @@ type Query {
         name: Leanne Graham
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution/with-nesting.md
+++ b/tests/execution/with-nesting.md
@@ -1,8 +1,7 @@
 # With nesting
 
-#### server:
-
-```graphql
+####
+```graphql @server
 schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }
@@ -29,9 +28,8 @@ type Post {
 }
 ```
 
-#### mock:
-
-```yml
+####
+```yml @mock
 - request:
     method: GET
     url: http://jsonplaceholder.typicode.com/users/1
@@ -55,9 +53,8 @@ type Post {
       - title: title3
 ```
 
-#### assert:
-
-```yml
+####
+```yml @assert
 - method: POST
   url: http://localhost:8080/graphql
   body:

--- a/tests/execution_spec.rs
+++ b/tests/execution_spec.rs
@@ -472,98 +472,97 @@ impl ExecutionSpec {
                                 heading
                             ));
                         }
-                    } else if heading.depth == 4 {
-                        // Parse following code block
-                        let (content, lang) = if let Some(Node::Code(code)) = children.next() {
-                            (code.value.to_owned(), code.lang.to_owned())
-                        } else {
-                            return Err(anyhow!("Unexpected non-code block node or EOF after component definition in {:?}", path));
-                        };
-
-                        // Parse component name
-                        if let Some(Node::Text(text)) = heading.children.first() {
-                            let name = text.value.as_str();
-
-                            if let Some(name) = name.strip_prefix("file:") {
-                                if files.insert(name.to_string(), content).is_some() {
-                                    return Err(anyhow!(
-                                        "Double declaration of file {:?} in {:#?}",
-                                        name,
-                                        path
-                                    ));
-                                }
-                            } else {
-                                let lang = match lang {
-                                    Some(x) => Ok(x),
-                                    None => Err(anyhow!(
-                                        "Unexpected code block with no specific language in {:?}",
-                                        path
-                                    )),
-                                }?;
-
-                                let source = Source::from_str(&lang)?;
-
-                                match name {
-                                    "server:" => {
-                                        // Server configs are only parsed if the test isn't skipped.
-                                        server.push((source, content));
-                                    }
-                                    "mock:" => {
-                                        if mock.is_none() {
-                                            mock = match source {
-                                                Source::Json => Ok(serde_json::from_str(&content)?),
-                                                Source::Yml => Ok(serde_yaml::from_str(&content)?),
-                                                _ => Err(anyhow!("Unexpected language in mock block in {:?} (only JSON and YAML are supported)", path)),
-                                            }?;
-                                        } else {
-                                            return Err(anyhow!("Unexpected number of mock blocks in {:?} (only one is allowed)", path));
-                                        }
-                                    }
-                                    "env:" => {
-                                        if env.is_none() {
-                                            env = match source {
-                                                Source::Json => Ok(serde_json::from_str(&content)?),
-                                                Source::Yml => Ok(serde_yaml::from_str(&content)?),
-                                                _ => Err(anyhow!("Unexpected language in env block in {:?} (only JSON and YAML are supported)", path)),
-                                            }?;
-                                        } else {
-                                            return Err(anyhow!("Unexpected number of env blocks in {:?} (only one is allowed)", path));
-                                        }
-                                    }
-                                    "assert:" => {
-                                        if assert.is_none() {
-                                            assert = match source {
-                                                Source::Json => Ok(serde_json::from_str(&content)?),
-                                                Source::Yml => Ok(serde_yaml::from_str(&content)?),
-                                                _ => Err(anyhow!("Unexpected language in assert block in {:?} (only JSON and YAML are supported)", path)),
-                                            }?;
-                                        } else {
-                                            return Err(anyhow!("Unexpected number of assert blocks in {:?} (only one is allowed)", path));
-                                        }
-                                    }
-                                    _ => {
-                                        return Err(anyhow!(
-                                            "Unexpected component {:?} in {:?}: {:#?}",
-                                            name,
-                                            path,
-                                            heading
-                                        ));
-                                    }
-                                }
-                            }
-                        } else {
-                            return Err(anyhow!(
-                                "Unexpected content of level 4 heading in {:?}: {:#?}",
-                                path,
-                                heading
-                            ));
-                        }
-                    } else {
+                    } 
+                    else if heading.depth == 4 {}
+                    else {
                         return Err(anyhow!(
                             "Unexpected level {} heading in {:?}: {:#?}",
                             heading.depth,
                             path,
                             heading
+                        ));
+                    }
+                }
+                Node::Code(code) => {
+                    // Parse following code block
+                    let (content, lang, meta) = {
+                        (code.value.to_owned(), code.lang.to_owned(), code.meta.to_owned())
+                    };
+                    if let Some(meta_str) = meta.as_ref().filter(|s| s.contains('@')) {
+                        let temp_cleaned_meta  = meta_str.replace('@', "");
+                        let name: &str = &temp_cleaned_meta;
+                        if let Some(name) = name.strip_prefix("file:") {
+                            if files.insert(name.to_string(), content).is_some() {
+                                return Err(anyhow!(
+                                    "Double declaration of file {:?} in {:#?}",
+                                    name,
+                                    path
+                                ));
+                            }
+                        } else {
+                            let lang = match lang {
+                                Some(x) => Ok(x),
+                                None => Err(anyhow!(
+                                    "Unexpected code block with no specific language in {:?}",
+                                    path
+                                )),
+                            }?;
+                
+                            let source = Source::from_str(&lang)?;
+                
+                            match name {
+                                "server" => {
+                                    // Server configs are only parsed if the test isn't skipped.
+                                    server.push((source, content));
+                                }
+                                "mock" => {
+                                    if mock.is_none() {
+                                        mock = match source {
+                                            Source::Json => Ok(serde_json::from_str(&content)?),
+                                            Source::Yml => Ok(serde_yaml::from_str(&content)?),
+                                            _ => Err(anyhow!("Unexpected language in mock block in {:?} (only JSON and YAML are supported)", path)),
+                                        }?;
+                                    } else {
+                                        return Err(anyhow!("Unexpected number of mock blocks in {:?} (only one is allowed)", path));
+                                    }
+                                }
+                                "env" => {
+                                    if env.is_none() {
+                                        env = match source {
+                                            Source::Json => Ok(serde_json::from_str(&content)?),
+                                            Source::Yml => Ok(serde_yaml::from_str(&content)?),
+                                            _ => Err(anyhow!("Unexpected language in env block in {:?} (only JSON and YAML are supported)", path)),
+                                        }?;
+                                    } else {
+                                        return Err(anyhow!("Unexpected number of env blocks in {:?} (only one is allowed)", path));
+                                    }
+                                }
+                                "assert" => {
+                                    if assert.is_none() {
+                                        assert = match source {
+                                            Source::Json => Ok(serde_json::from_str(&content)?),
+                                            Source::Yml => Ok(serde_yaml::from_str(&content)?),
+                                            _ => Err(anyhow!("Unexpected language in assert block in {:?} (only JSON and YAML are supported)", path)),
+                                        }?;
+                                    } else {
+                                        return Err(anyhow!("Unexpected number of assert blocks in {:?} (only one is allowed)", path));
+                                    }
+                                }
+                                _ => {
+                                    return Err(anyhow!(
+                                        "Unexpected component {:?} in {:?}: {:#?}",
+                                        name,
+                                        path,
+                                        meta
+                                    ));
+                                }
+                            }
+                        }
+                    } else {
+                        return Err(anyhow!(
+                            "Unexpected content of code in {:?}: {:#?}",
+                            path, 
+                            meta
                         ));
                     }
                 }


### PR DESCRIPTION
**Summary:**  
Blocks are now in the format 
```yml  @assert
- method: POST
  url: http://localhost:8080/graphql
  body:
    query: query { username }
```

**Issue Reference(s):**  
Fixes #1213 
/claim #1213

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
