### PR TITLE
fix: make `omit` as option for `@modify` directive

### DIFF
--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -223,7 +223,7 @@ directive @link(
 
 directive @modify(
   name: String
-  omit: Boolean!
+  omit: Boolean
 ) on FIELD_DEFINITION
 
 """
@@ -666,7 +666,7 @@ enum Method {
 }
 input Modify {
   name: String
-  omit: Boolean!
+  omit: Boolean
 }
 """
 Output the opentelemetry data to otlp collector

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1385,7 +1385,10 @@
           ]
         },
         "omit": {
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -483,13 +483,7 @@ impl Field {
     }
 
     pub fn is_omitted(&self) -> bool {
-        self.omit.is_some()
-            || self
-                .modify
-                .as_ref()
-                .map(|m| m.omit)
-                .unwrap_or(None)
-                .is_some()
+        self.omit.is_some() || self.modify.as_ref().map(|m| m.omit).is_some()
     }
 }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -483,7 +483,12 @@ impl Field {
     }
 
     pub fn is_omitted(&self) -> bool {
-        self.omit.is_some() || self.modify.as_ref().map(|m| m.omit).is_some()
+        self.omit.is_some()
+            || self
+                .modify
+                .as_ref()
+                .and_then(|m| m.omit)
+                .unwrap_or_default()
     }
 }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -483,7 +483,13 @@ impl Field {
     }
 
     pub fn is_omitted(&self) -> bool {
-        self.omit.is_some() || self.modify.as_ref().map(|m| m.omit).unwrap_or(false)
+        self.omit.is_some()
+            || self
+                .modify
+                .as_ref()
+                .map(|m| m.omit)
+                .unwrap_or(None)
+                .is_some()
     }
 }
 
@@ -497,7 +503,7 @@ pub struct Modify {
     #[serde(default, skip_serializing_if = "is_default")]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "is_default")]
-    pub omit: bool,
+    pub omit: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1381
/claim 1381

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the `@modify` directive to allow the "omit" field to be optional, enhancing flexibility in configuration.
	- Improved handling of the "omit" property in configurations, allowing for more nuanced control over field omission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->