### PR TITLE
fix: `allowHeaders` should be case-insensitive

### DIFF
--- a/tests/execution/test-upstream-headers.md
+++ b/tests/execution/test-upstream-headers.md
@@ -1,0 +1,50 @@
+# test-upstream-headers
+
+#### server:
+
+```graphql
+schema @upstream(baseURL: "http://jsonplaceholder.typicode.com", allowedHeaders: ["x-foo", "X-bar"]) {
+  query: Query
+}
+type Query {
+  posts: [Post] @http(path: "/posts")
+}
+type Post {
+  id: Int
+}
+```
+
+#### mock:
+
+```yml
+- request:
+    method: GET
+    url: http://jsonplaceholder.typicode.com/posts
+    headers:
+      x-foo: bar
+      x-bar: baz
+    body: null
+  response:
+    status: 200
+    body:
+      - body: bar
+        id: 11
+        title: foo
+        userId: 1
+      - body: bar
+        id: 3
+        title: foo
+        userId: 2
+```
+
+#### assert:
+
+```yml
+- method: POST
+  url: http://localhost:8000/graphql
+  headers:
+    X-foo: bar
+    X-bar: baz
+  body:
+    query: query { posts { id } }
+```

--- a/tests/snapshots/execution_spec__test-upstream-headers.md_assert_0.snap
+++ b/tests/snapshots/execution_spec__test-upstream-headers.md_assert_0.snap
@@ -1,0 +1,22 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "posts": [
+        {
+          "id": 11
+        },
+        {
+          "id": 3
+        }
+      ]
+    }
+  }
+}

--- a/tests/snapshots/execution_spec__test-upstream-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__test-upstream-headers.md_client.snap
@@ -1,0 +1,15 @@
+---
+source: tests/execution_spec.rs
+expression: client
+---
+type Post {
+  id: Int
+}
+
+type Query {
+  posts: [Post]
+}
+
+schema {
+  query: Query
+}

--- a/tests/snapshots/execution_spec__test-upstream-headers.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-upstream-headers.md_merged.snap
@@ -1,0 +1,15 @@
+---
+source: tests/execution_spec.rs
+expression: merged
+---
+schema @server @upstream(allowedHeaders: ["X-bar", "x-foo"], baseURL: "http://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type Post {
+  id: Int
+}
+
+type Query {
+  posts: [Post] @http(path: "/posts")
+}


### PR DESCRIPTION
fixes #1384 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced header matching to be case-insensitive, improving flexibility in request handling.
- **Bug Fixes**
	- Corrected a formatting issue in logging request methods and URIs.
- **Tests**
	- Introduced tests for validating upstream headers in a GraphQL server environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->