### PR TITLE
feat: Use TextCase enum

### DIFF
--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -273,6 +273,7 @@ directive @server(
   `true`.
   """
   introspection: Boolean
+  lint: Lint
   """
   `pipelineFlush` allows to control flushing behavior of the server pipeline.
   """
@@ -653,6 +654,31 @@ enum LinkType {
   Key
   Operation
 }
+"""
+The @lint directive allows you to configure linting.
+"""
+input Lint {
+  """
+  To autoFix the lint. Example Usage lint:{autoFix:true}
+  """
+  autoFix: Boolean
+  """
+  This enum is provided with appropriate TextCase. Example Usage: lint:{enum:Pascal}
+  """
+  enum: TextCase
+  """
+  This enumValue is provided with appropriate TextCase. Example Usage: lint:{enumValue:ScreamingSnake}
+  """
+  enumValue: TextCase
+  """
+  This field is provided with appropriate TextCase. Example Usage: lint:{field:Camel}
+  """
+  field: TextCase
+  """
+  This type is provided with appropriate TextCase. Example Usage: lint:{type:Pascal}
+  """
+  type: TextCase
+}
 enum Method {
   GET
   POST
@@ -717,6 +743,12 @@ input TelemetryExporter {
   stdout: StdoutExporter
   otlp: OtlpExporter
   prometheus: PrometheusExporter
+}
+enum TextCase {
+  Camel
+  Pascal
+  Snake
+  ScreamingSnake
 }
 input Schema {
   Obj: JSON

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -31,7 +31,9 @@
     },
     "server": {
       "description": "Dictates how the server behaves and helps tune tailcall for all ingress requests. Features such as request batching, SSL, HTTP2 etc. can be configured here.",
-      "default": {},
+      "default": {
+        "lint": null
+      },
       "allOf": [
         {
           "$ref": "#/definitions/Server"
@@ -1361,6 +1363,63 @@
         "Operation"
       ]
     },
+    "Lint": {
+      "description": "The @lint directive allows you to configure linting.",
+      "type": "object",
+      "properties": {
+        "autoFix": {
+          "description": "To autoFix the lint. Example Usage lint:{autoFix:true}",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "enum": {
+          "description": "This enum is provided with appropriate TextCase. Example Usage: lint:{enum:Pascal}",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enumValue": {
+          "description": "This enumValue is provided with appropriate TextCase. Example Usage: lint:{enumValue:ScreamingSnake}",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "field": {
+          "description": "This field is provided with appropriate TextCase. Example Usage: lint:{field:Camel}",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "description": "This type is provided with appropriate TextCase. Example Usage: lint:{type:Pascal}",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
     "Method": {
       "type": "string",
       "enum": [
@@ -1549,6 +1608,16 @@
             "null"
           ]
         },
+        "lint": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Lint"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "pipelineFlush": {
           "description": "`pipelineFlush` allows to control flushing behavior of the server pipeline.",
           "type": [
@@ -1697,6 +1766,15 @@
           },
           "additionalProperties": false
         }
+      ]
+    },
+    "TextCase": {
+      "type": "string",
+      "enum": [
+        "Camel",
+        "Pascal",
+        "Snake",
+        "ScreamingSnake"
       ]
     },
     "Type": {

--- a/src/config/lint.rs
+++ b/src/config/lint.rs
@@ -1,0 +1,56 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, schemars::JsonSchema)]
+pub enum TextCase {
+    Camel,
+    Pascal,
+    Snake,
+    ScreamingSnake,
+}
+
+impl Display for TextCase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            TextCase::Camel => "camelCase",
+            TextCase::Pascal => "PascalCase",
+            TextCase::Snake => "snake_case",
+            TextCase::ScreamingSnake => "SCREAMING_SNAKE_CASE",
+        })
+    }
+}
+
+/// The @lint directive allows you to configure linting.
+#[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug, Clone, schemars::JsonSchema)]
+pub struct Lint {
+    ///
+    /// To autoFix the lint.
+    /// Example Usage lint:{autoFix:true}
+    #[serde(rename = "autoFix")]
+    pub auto_fix: Option<bool>,
+    ///
+    ///
+    /// This enum is provided with appropriate TextCase.
+    /// Example Usage: lint:{enum:Pascal}
+    #[serde(rename = "enum")]
+    pub enum_lint: Option<TextCase>,
+    ///
+    ///
+    /// This enumValue is provided with appropriate TextCase.
+    /// Example Usage: lint:{enumValue:ScreamingSnake}
+    #[serde(rename = "enumValue")]
+    pub enum_value_lint: Option<TextCase>,
+    ///
+    ///
+    /// This field is provided with appropriate TextCase.
+    /// Example Usage: lint:{field:Camel}
+    #[serde(rename = "field")]
+    pub field_lint: Option<TextCase>,
+    ///
+    ///
+    /// This type is provided with appropriate TextCase.
+    /// Example Usage: lint:{type:Pascal}
+    #[serde(rename = "type")]
+    pub type_lint: Option<TextCase>,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,7 @@ pub mod group_by;
 mod into_document;
 mod key_values;
 mod link;
+mod lint;
 mod n_plus_one;
 pub mod reader;
 pub mod reader_context;

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use super::lint::Lint;
 use crate::config::KeyValue;
 use crate::is_default;
 
@@ -97,6 +98,8 @@ pub struct Server {
     /// `workers` sets the number of worker threads. @default the number of
     /// system cores.
     pub workers: Option<usize>,
+
+    pub lint: Option<Lint>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._
Added TextCase enum
Which allows user to choose the case for each lint config variable.
This fix follows fix for #1322

**Issue Reference(s):**  
Fixes #1330 
/claim #1330

**Build & Testing:**

- [Yes ] I ran `cargo test` successfully.
- [Yes ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [No ] I have added relevant unit & integration tests.
- [No] I have updated the [documentation] accordingly.
- [Yes ] I have performed a self-review of my code.
- [Yes ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new linting configuration to improve code quality and consistency.
	- Added support for specifying text case styles through a new `TextCase` enum.
	- Enhanced server configuration with linting options.
- **Enhancements**
	- Expanded existing enums and directives with new values and arguments for greater flexibility in linting configurations.
- **Documentation**
	- Added comprehensive descriptions for the new linting features and their configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->