### PR TITLE
refactor: move server.responseHeaders to server.headers.custom

### DIFF
--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -286,12 +286,6 @@ directive @server(
   """
   queryValidation: Boolean
   """
-  The `responseHeaders` are key-value pairs included in every server response. Useful 
-  for setting headers like `Access-Control-Allow-Origin` for cross-origin requests 
-  or additional headers for downstream services.
-  """
-  responseHeaders: [KeyValue]
-  """
   `responseValidation` Tailcall automatically validates responses from upstream services 
   using inferred schema. @default `false`.
   """
@@ -577,6 +571,12 @@ input Headers {
   value is the least of the values received from upstream services. @default `false`.
   """
   cacheControl: Boolean
+  """
+  The `headers` are key-value pairs included in every server response. Useful for setting 
+  headers like `Access-Control-Allow-Origin` for cross-origin requests or additional 
+  headers for downstream services.
+  """
+  custom: [KeyValue]
 }
 """
 The @http operator indicates that a field or node is backed by a REST API.For instance, 

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1215,6 +1215,16 @@
             "boolean",
             "null"
           ]
+        },
+        "custom": {
+          "description": "The `headers` are key-value pairs included in every server response. Useful for setting headers like `Access-Control-Allow-Origin` for cross-origin requests or additional headers for downstream services.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/KeyValue"
+          }
         }
       }
     },
@@ -1587,13 +1597,6 @@
             "boolean",
             "null"
           ]
-        },
-        "responseHeaders": {
-          "description": "The `responseHeaders` are key-value pairs included in every server response. Useful for setting headers like `Access-Control-Allow-Origin` for cross-origin requests or additional headers for downstream services.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/KeyValue"
-          }
         },
         "responseValidation": {
           "description": "`responseValidation` Tailcall automatically validates responses from upstream services using inferred schema. @default `false`.",

--- a/src/config/headers.rs
+++ b/src/config/headers.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::is_default;
 
+use super::KeyValue;
+
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Headers {
@@ -10,6 +12,10 @@ pub struct Headers {
     /// activated. The `max-age` value is the least of the values received from
     /// upstream services. @default `false`.
     pub cache_control: Option<bool>,
+    /// The `headers` are key-value pairs included in every server
+    /// response. Useful for setting headers like `Access-Control-Allow-Origin`
+    /// for cross-origin requests or additional headers for downstream services.
+    pub custom: Option<Vec<KeyValue>>,
 }
 
 impl Headers {

--- a/src/config/headers.rs
+++ b/src/config/headers.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::is_default;
-
 use super::KeyValue;
+use crate::is_default;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -164,7 +164,10 @@ impl Server {
             .as_ref()
             .and_then(|h| h.custom.as_ref())
             .map_or_else(BTreeMap::new, |custom| {
-                custom.iter().map(|kv| (kv.key.clone(), kv.value.clone())).collect()
+                custom
+                    .iter()
+                    .map(|kv| (kv.key.clone(), kv.value.clone()))
+                    .collect()
             })
     }
 

--- a/tests/execution/custom-headers.md
+++ b/tests/execution/custom-headers.md
@@ -3,7 +3,8 @@
 ```json @server
 {
   "server": {
-    "responseHeaders": [
+    "headers": {
+      "custom": [
       {
         "key": "x-id",
         "value": "1"
@@ -13,6 +14,7 @@
         "value": "John Doe"
       }
     ]
+    }
   },
   "upstream": {},
   "schema": {

--- a/tests/execution/custom-headers.md
+++ b/tests/execution/custom-headers.md
@@ -5,15 +5,15 @@
   "server": {
     "headers": {
       "custom": [
-      {
-        "key": "x-id",
-        "value": "1"
-      },
-      {
-        "key": "x-name",
-        "value": "John Doe"
-      }
-    ]
+        {
+          "key": "x-id",
+          "value": "1"
+        },
+        {
+          "key": "x-name",
+          "value": "John Doe"
+        }
+      ]
     }
   },
   "upstream": {},

--- a/tests/execution/test-response-header-value.md
+++ b/tests/execution/test-response-header-value.md
@@ -3,7 +3,7 @@
 ###### sdl error
 
 ```graphql @server
-schema @server(headers: { custom: [{key: "a", value: "a \n b"}]}) {
+schema @server(headers: {custom: [{key: "a", value: "a \n b"}]}) {
   query: Query
 }
 

--- a/tests/execution/test-response-header-value.md
+++ b/tests/execution/test-response-header-value.md
@@ -3,7 +3,7 @@
 ###### sdl error
 
 ```graphql @server
-schema @server(responseHeaders: [{key: "a", value: "a \n b"}]) {
+schema @server(headers: { custom: [{key: "a", value: "a \n b"}]}) {
   query: Query
 }
 

--- a/tests/execution/test-response-headers-multi.md
+++ b/tests/execution/test-response-headers-multi.md
@@ -3,7 +3,7 @@
 ###### sdl error
 
 ```graphql @server
-schema @server(responseHeaders: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]) {
+schema @server(headers: { custom: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]}) {
   query: Query
 }
 

--- a/tests/execution/test-response-headers-multi.md
+++ b/tests/execution/test-response-headers-multi.md
@@ -3,7 +3,7 @@
 ###### sdl error
 
 ```graphql @server
-schema @server(headers: { custom: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]}) {
+schema @server(headers: {custom: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]}) {
   query: Query
 }
 

--- a/tests/execution/test-response-headers-name.md
+++ b/tests/execution/test-response-headers-name.md
@@ -3,7 +3,7 @@
 ###### sdl error
 
 ```graphql @server
-schema @server(responseHeaders: [{key: "🤣", value: "a"}]) {
+schema @server(headers: { custom: [{key: "🤣", value: "a"}]}) {
   query: Query
 }
 

--- a/tests/execution/test-response-headers-name.md
+++ b/tests/execution/test-response-headers-name.md
@@ -3,7 +3,7 @@
 ###### sdl error
 
 ```graphql @server
-schema @server(headers: { custom: [{key: "🤣", value: "a"}]}) {
+schema @server(headers: {custom: [{key: "🤣", value: "a"}]}) {
   query: Query
 }
 

--- a/tests/snapshots/execution_spec__cache-control.md_merged.snap
+++ b/tests/snapshots/execution_spec__cache-control.md_merged.snap
@@ -2,7 +2,7 @@
 source: tests/execution_spec.rs
 expression: merged
 ---
-schema @server(headers: {cacheControl: true}) @upstream {
+schema @server(headers: {cacheControl: true, custom: null}) @upstream {
   query: Query
 }
 

--- a/tests/snapshots/execution_spec__custom-headers.md_merged.snap
+++ b/tests/snapshots/execution_spec__custom-headers.md_merged.snap
@@ -2,7 +2,7 @@
 source: tests/execution_spec.rs
 expression: merged
 ---
-schema @server(responseHeaders: [{key: "x-id", value: "1"}, {key: "x-name", value: "John Doe"}]) @upstream {
+schema @server(headers: {custom: [{key: "x-id", value: "1"}, {key: "x-name", value: "John Doe"}]}) @upstream {
   query: Query
 }
 


### PR DESCRIPTION
This PR moves server.responseHeaders to server.headers.custom

**Issue Reference(s):**  
Fixes #1400

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs

/claim #1400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `custom` directive for specifying key-value pairs in server responses, enhancing customization.
- **Refactor**
	- Refined the handling of response headers to utilize a new nested structure for storing custom headers, improving flexibility and organization.
- **Documentation**
	- Updated descriptions and structures in documentation to reflect changes in handling key-value pairs and response headers.
- **Tests**
	- Adapted tests to align with the new structure for custom headers, ensuring reliability and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->