### PR TITLE
chore: added CLI Error downcasting testcases

### DIFF
--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -380,39 +380,38 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_error_downcasting() {
+    fn test_cli_error_identity() {
         let cli_error = CLIError::new("Server could not be started")
             .description("The port is already in use".to_string())
             .trace(vec!["@server".into(), "port".into()]);
-
         let anyhow_error: anyhow::Error = cli_error.clone().into();
-        let error = CLIError::from(anyhow_error);
+
+        let actual = CLIError::from(anyhow_error);
         let expected = cli_error;
 
-        assert_eq!(error, expected);
+        assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_validation_error_downcasting() {
-        let cause = Cause::new("Test Error".to_string()).trace(vec!["Query".to_string()]);
-        let validation_error: ValidationError<String> = ValidationError::from(cause);
-        let anyhow_error: anyhow::Error = validation_error.into();
-        let error = CLIError::from(anyhow_error);
+    fn test_validation_error_identity() {
+        let validation_error = ValidationError::from(
+            Cause::new("Test Error".to_string()).trace(vec!["Query".to_string()]),
+        );
+        let anyhow_error: anyhow::Error = validation_error.clone().into();
 
-        let expected = CLIError::new("Invalid Configuration")
-            .caused_by(vec![
-                CLIError::new("Test Error").trace(vec!["Query".to_string()])
-            ]);
+        let actual = CLIError::from(anyhow_error);
+        let expected = CLIError::from(validation_error);
 
-        assert_eq!(error, expected);
+        assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_generic_error_downcasting() {
+    fn test_generic_error() {
         let anyhow_error = anyhow::anyhow!("Some error msg");
-        let error: CLIError = CLIError::from(anyhow_error);
+
+        let actual: CLIError = CLIError::from(anyhow_error);
         let expected = CLIError::new("Some error msg");
 
-        assert_eq!(error, expected);
+        assert_eq!(actual, expected);
     }
 }

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -385,8 +385,7 @@ mod tests {
             .description("The port is already in use".to_string())
             .trace(vec!["@server".into(), "port".into()]);
 
-        let cli_error_copy = cli_error.clone();
-        let anyhow_error: anyhow::Error = cli_error_copy.into();
+        let anyhow_error: anyhow::Error = cli_error.clone().into();
         let error = CLIError::from(anyhow_error);
         let expected = cli_error;
 
@@ -412,8 +411,8 @@ mod tests {
     fn test_generic_error_downcasting() {
         let anyhow_error = anyhow::anyhow!("Some error msg");
         let error: CLIError = CLIError::from(anyhow_error);
-        let expected = r"|Some error msg".strip_margin();
+        let expected = CLIError::new("Some error msg");
 
-        assert_eq!(error.to_string(), expected);
+        assert_eq!(error, expected);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use std::cell::Cell;
 use mimalloc::MiMalloc;
 use tailcall::cli::CLIError;
 use tailcall::tracing::default_tailcall_tracing;
-use tailcall::valid::ValidationError;
 use tracing::subscriber::DefaultGuard;
 
 #[global_allocator]
@@ -47,24 +46,7 @@ fn main() -> anyhow::Result<()> {
         Ok(_) => {}
         Err(error) => {
             // Ensure all errors are converted to CLIErrors before being printed.
-            let cli_error = match error.downcast::<CLIError>() {
-                Ok(cli_error) => cli_error,
-                Err(error) => {
-                    // Convert other errors to CLIError
-                    let cli_error = match error.downcast::<ValidationError<String>>() {
-                        Ok(validation_error) => CLIError::from(validation_error),
-                        Err(error) => {
-                            let sources = error
-                                .source()
-                                .map(|error| vec![CLIError::new(error.to_string().as_str())])
-                                .unwrap_or_default();
-
-                            CLIError::new(&error.to_string()).caused_by(sources)
-                        }
-                    };
-                    cli_error
-                }
-            };
+            let cli_error: CLIError = error.into();
             tracing::error!("{}", cli_error.color(true));
             std::process::exit(exitcode::CONFIG);
         }


### PR DESCRIPTION
**Summary:**  
Moved the entire downcasting logic to cli/error.rs from main.rs. Wrote downcasting test cases.

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified error handling in the CLI for improved readability and efficiency.
- **Tests**
	- Added tests for downcasting errors to `CLIError`, including `ValidationError`.
- **New Features**
	- Streamlined error conversion by adding an implementation to convert `anyhow::Error` to `CLIError`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->