### PR TITLE
feat: support for set cookie

### DIFF
--- a/benches/impl_path_string_for_evaluation_context.rs
+++ b/benches/impl_path_string_for_evaluation_context.rs
@@ -247,7 +247,7 @@ fn request_context() -> RequestContext {
     };
     RequestContext {
         req_headers: HeaderMap::new(),
-        cookie_headers: HeaderMap::new(),
+        cookie_headers: None,
         server,
         upstream,
         http_data_loaders: Arc::new(vec![]),

--- a/benches/impl_path_string_for_evaluation_context.rs
+++ b/benches/impl_path_string_for_evaluation_context.rs
@@ -247,6 +247,7 @@ fn request_context() -> RequestContext {
     };
     RequestContext {
         req_headers: HeaderMap::new(),
+        set_cookie_headers: HeaderMap::new(),
         server,
         upstream,
         http_data_loaders: Arc::new(vec![]),

--- a/benches/impl_path_string_for_evaluation_context.rs
+++ b/benches/impl_path_string_for_evaluation_context.rs
@@ -247,7 +247,7 @@ fn request_context() -> RequestContext {
     };
     RequestContext {
         req_headers: HeaderMap::new(),
-        set_cookie_headers: HeaderMap::new(),
+        cookie_headers: HeaderMap::new(),
         server,
         upstream,
         http_data_loaders: Arc::new(vec![]),

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -577,6 +577,10 @@ input Headers {
   value is the least of the values received from upstream services. @default `false`.
   """
   cacheControl: Boolean
+  """
+  `setCookies` when enabled stores `set-cookie` headers and all the response will be 
+  sent with the headers.
+  """
   setCookies: Boolean
 }
 """

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -577,6 +577,11 @@ input Headers {
   headers for downstream services.
   """
   custom: [KeyValue]
+  """
+  `setCookies` when enabled stores `set-cookie` headers and all the response will be 
+  sent with the headers.
+  """
+  setCookies: Boolean
 }
 """
 The @http operator indicates that a field or node is backed by a REST API.For instance, 

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -577,6 +577,7 @@ input Headers {
   value is the least of the values received from upstream services. @default `false`.
   """
   cacheControl: Boolean
+  setCookies: Boolean
 }
 """
 The @http operator indicates that a field or node is backed by a REST API.For instance, 

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1222,6 +1222,13 @@
           "items": {
             "$ref": "#/definitions/KeyValue"
           }
+        },
+        "setCookies": {
+          "description": "`setCookies` when enabled stores `set-cookie` headers and all the response will be sent with the headers.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1217,6 +1217,7 @@
           ]
         },
         "setCookies": {
+          "description": "`setCookies` when enabled stores `set-cookie` headers and all the response will be sent with the headers.",
           "type": [
             "boolean",
             "null"

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1215,6 +1215,12 @@
             "boolean",
             "null"
           ]
+        },
+        "setCookies": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },

--- a/src/blueprint/server.rs
+++ b/src/blueprint/server.rs
@@ -15,6 +15,7 @@ use crate::valid::{Valid, ValidationError, Validator};
 pub struct Server {
     pub enable_apollo_tracing: bool,
     pub enable_cache_control_header: bool,
+    pub enable_set_cookie_header: bool,
     pub enable_graphiql: bool,
     pub enable_introspection: bool,
     pub enable_query_validation: bool,
@@ -110,6 +111,7 @@ impl TryFrom<crate::config::ConfigModule> for Server {
             .map(|(hostname, http, response_headers, script)| Server {
                 enable_apollo_tracing: (config_server).enable_apollo_tracing(),
                 enable_cache_control_header: (config_server).enable_cache_control(),
+                enable_set_cookie_header: (config_server).enable_set_cookies(),
                 enable_graphiql: (config_server).enable_graphiql(),
                 enable_introspection: (config_server).enable_introspection(),
                 enable_query_validation: (config_server).enable_query_validation(),

--- a/src/config/headers.rs
+++ b/src/config/headers.rs
@@ -11,6 +11,8 @@ pub struct Headers {
     /// upstream services. @default `false`.
     pub cache_control: Option<bool>,
 
+    /// `setCookies` when enabled stores `set-cookie` headers
+    /// and all the response will be sent with the headers.
     #[serde(default, skip_serializing_if = "is_default")]
     pub set_cookies: Option<bool>,
 }

--- a/src/config/headers.rs
+++ b/src/config/headers.rs
@@ -10,10 +10,16 @@ pub struct Headers {
     /// activated. The `max-age` value is the least of the values received from
     /// upstream services. @default `false`.
     pub cache_control: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub set_cookies: Option<bool>,
 }
 
 impl Headers {
     pub fn enable_cache_control(&self) -> bool {
         self.cache_control.unwrap_or(false)
+    }
+    pub fn set_cookies(&self) -> bool {
+        self.set_cookies.unwrap_or_default()
     }
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -140,6 +140,12 @@ impl Server {
             .map(|h| h.enable_cache_control())
             .unwrap_or(false)
     }
+    pub fn enable_set_cookies(&self) -> bool {
+        self.headers
+            .as_ref()
+            .map(|h| h.set_cookies())
+            .unwrap_or(false)
+    }
     pub fn enable_introspection(&self) -> bool {
         self.introspection.unwrap_or(true)
     }

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -19,6 +19,7 @@ pub struct RequestContext {
     pub server: Server,
     pub upstream: Upstream,
     pub req_headers: HeaderMap,
+    pub set_cookie_headers: HeaderMap,
     pub http_data_loaders: Arc<Vec<DataLoader<DataLoaderRequest, HttpDataLoader>>>,
     pub gql_data_loaders: Arc<Vec<DataLoader<DataLoaderRequest, GraphqlDataLoader>>>,
     pub grpc_data_loaders: Arc<Vec<DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>>>,
@@ -97,6 +98,7 @@ impl From<&AppContext> for RequestContext {
             server: app_ctx.blueprint.server.clone(),
             upstream: app_ctx.blueprint.upstream.clone(),
             req_headers: HeaderMap::new(),
+            set_cookie_headers: HeaderMap::new(),
             http_data_loaders: app_ctx.http_data_loaders.clone(),
             gql_data_loaders: app_ctx.gql_data_loaders.clone(),
             grpc_data_loaders: app_ctx.grpc_data_loaders.clone(),
@@ -127,6 +129,7 @@ mod test {
             let upstream = Upstream::try_from(upstream).unwrap();
             RequestContext {
                 req_headers: HeaderMap::new(),
+                set_cookie_headers: HeaderMap::new(),
                 server,
                 runtime: crate::runtime::test::init(None),
                 upstream,

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -44,16 +44,6 @@ impl RequestContext {
         *self.cache_public.lock().unwrap()
     }
 
-    /*    pub fn set_cookie_headers(&self, headers: &HeaderMap) {
-        if let Some(cookie_headers) = &self.cookie_headers {
-            for (k, v) in headers {
-                if k.as_str().to_lowercase().contains("set-cookie") {
-                    cookie_headers.lock().unwrap().insert(k.clone(), v.clone());
-                }
-            }
-        }
-    }*/
-
     pub fn set_min_max_age(&self, max_age: i32) {
         let min_max_age_lock = self.get_min_max_age();
         match min_max_age_lock {
@@ -104,12 +94,6 @@ impl RequestContext {
 
 impl From<&AppContext> for RequestContext {
     fn from(app_ctx: &AppContext) -> Self {
-        /*let set_cookie_headers = if app_ctx.blueprint.server.enable_set_cookie_header {
-                    Some(Arc::new(Mutex::new(HeaderMap::new())))
-                } else {
-                    None
-                };
-        */
         Self {
             server: app_ctx.blueprint.server.clone(),
             upstream: app_ctx.blueprint.upstream.clone(),

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -19,7 +19,7 @@ pub struct RequestContext {
     pub server: Server,
     pub upstream: Upstream,
     pub req_headers: HeaderMap,
-    pub set_cookie_headers: HeaderMap,
+    pub cookie_headers: HeaderMap,
     pub http_data_loaders: Arc<Vec<DataLoader<DataLoaderRequest, HttpDataLoader>>>,
     pub gql_data_loaders: Arc<Vec<DataLoader<DataLoaderRequest, GraphqlDataLoader>>>,
     pub grpc_data_loaders: Arc<Vec<DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>>>,
@@ -43,6 +43,16 @@ impl RequestContext {
     pub fn is_cache_public(&self) -> Option<bool> {
         *self.cache_public.lock().unwrap()
     }
+
+    /*    pub fn set_cookie_headers(&self, headers: &HeaderMap) {
+        if let Some(cookie_headers) = &self.cookie_headers {
+            for (k, v) in headers {
+                if k.as_str().to_lowercase().contains("set-cookie") {
+                    cookie_headers.lock().unwrap().insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }*/
 
     pub fn set_min_max_age(&self, max_age: i32) {
         let min_max_age_lock = self.get_min_max_age();
@@ -94,11 +104,17 @@ impl RequestContext {
 
 impl From<&AppContext> for RequestContext {
     fn from(app_ctx: &AppContext) -> Self {
+        /*let set_cookie_headers = if app_ctx.blueprint.server.enable_set_cookie_header {
+                    Some(Arc::new(Mutex::new(HeaderMap::new())))
+                } else {
+                    None
+                };
+        */
         Self {
             server: app_ctx.blueprint.server.clone(),
             upstream: app_ctx.blueprint.upstream.clone(),
             req_headers: HeaderMap::new(),
-            set_cookie_headers: HeaderMap::new(),
+            cookie_headers: HeaderMap::new(),
             http_data_loaders: app_ctx.http_data_loaders.clone(),
             gql_data_loaders: app_ctx.gql_data_loaders.clone(),
             grpc_data_loaders: app_ctx.grpc_data_loaders.clone(),
@@ -129,7 +145,7 @@ mod test {
             let upstream = Upstream::try_from(upstream).unwrap();
             RequestContext {
                 req_headers: HeaderMap::new(),
-                set_cookie_headers: HeaderMap::new(),
+                cookie_headers: HeaderMap::new(),
                 server,
                 runtime: crate::runtime::test::init(None),
                 upstream,

--- a/src/lambda/io.rs
+++ b/src/lambda/io.rs
@@ -73,7 +73,7 @@ impl Eval for IO {
                             .map_err(EvaluationError::from)?;
                     }
 
-                    set_cache_control(ctx, &res);
+                    set_headers(ctx, &res);
 
                     Ok(res.body)
                 }
@@ -90,7 +90,7 @@ impl Eval for IO {
                         execute_raw_request(ctx, req).await?
                     };
 
-                    set_cache_control(ctx, &res);
+                    set_headers(ctx, &res);
                     parse_graphql_response(ctx, res, field_name)
                 }
                 IO::Grpc { req_template, dl_id, .. } => {
@@ -109,7 +109,7 @@ impl Eval for IO {
                         execute_raw_grpc_request(ctx, req, &req_template.operation).await?
                     };
 
-                    set_cache_control(ctx, &res);
+                    set_headers(ctx, &res);
 
                     Ok(res.body)
                 }
@@ -128,6 +128,14 @@ impl<'a, Ctx: ResolverContextLike<'a> + Sync + Send> CacheKey<EvaluationContext<
     }
 }
 
+fn set_headers<'ctx, Ctx: ResolverContextLike<'ctx>>(
+    ctx: &EvaluationContext<'ctx, Ctx>,
+    res: &Response<async_graphql::Value>,
+) {
+    set_cache_control(ctx, res);
+    set_cookie_headers(ctx, res);
+}
+
 fn set_cache_control<'ctx, Ctx: ResolverContextLike<'ctx>>(
     ctx: &EvaluationContext<'ctx, Ctx>,
     res: &Response<async_graphql::Value>,
@@ -136,6 +144,15 @@ fn set_cache_control<'ctx, Ctx: ResolverContextLike<'ctx>>(
         if let Some(policy) = cache_policy(res) {
             ctx.req_ctx.set_cache_control(policy);
         }
+    }
+}
+
+fn set_cookie_headers<'ctx, Ctx: ResolverContextLike<'ctx>>(
+    ctx: &EvaluationContext<'ctx, Ctx>,
+    res: &Response<async_graphql::Value>,
+) {
+    if res.status.is_success() {
+        ctx.req_ctx.set_cookie_headers(&res.headers);
     }
 }
 

--- a/tests/execution/test-set-cookie-headers.md
+++ b/tests/execution/test-set-cookie-headers.md
@@ -27,16 +27,28 @@ type User {
 
   response:
     status: 200
+    headers:
+      set-cookie: user=1
     body:
       id: 1
       name: foo
+
+- request:
+    method: GET
+    url: http://jsonplaceholder.typicode.com/users/2
+
+  response:
+    status: 200
+    headers:
+      set-cookie: user=2
+    body:
+      id: 2
+      name: bar
 ```
 
 ```yaml @assert
 - method: POST
   url: http://localhost:8080/graphql
-  headers:
-    set-cookie: foo2=bar2
   body:
-    query: "query { user(id: 1) { name } }"
+    query: "query { u1:user(id: 1) { name } u2:user(id: 2) { name } }"
 ```

--- a/tests/execution/test-set-cookie-headers.md
+++ b/tests/execution/test-set-cookie-headers.md
@@ -1,0 +1,42 @@
+# Set Cookie Header
+
+```graphql @server
+schema
+  @server(port: 8080, graphiql: true, hostname: "0.0.0.0", headers: {setCookies: true})
+  @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  user(id: Int!): User @http(path: "/users/{{args.id}}")
+}
+type User {
+  id: Int!
+  name: String!
+  username: String!
+  email: String!
+  phone: String
+  website: String
+}
+```
+
+```yaml @mock
+- request:
+    method: GET
+    url: http://jsonplaceholder.typicode.com/users/1
+
+  response:
+    status: 200
+    body:
+      id: 1
+      name: foo
+```
+
+```yaml @assert
+- method: POST
+  url: http://localhost:8080/graphql
+  headers:
+    set-cookie: foo2=bar2
+  body:
+    query: "query { user(id: 1) { name } }"
+```

--- a/tests/execution_spec.rs
+++ b/tests/execution_spec.rs
@@ -16,7 +16,7 @@ use hyper::body::Bytes;
 use hyper::{Body, Request};
 use markdown::mdast::Node;
 use markdown::ParseOptions;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::header::{HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tailcall::async_graphql_hyper::{GraphQLBatchRequest, GraphQLRequest};
@@ -218,7 +218,7 @@ struct APIResponse {
     #[serde(default = "default_status")]
     status: u16,
     #[serde(default)]
-    headers: Vec<(String, String)>,
+    headers: BTreeMap<String, String>,
     #[serde(default)]
     body: serde_json::Value,
     #[serde(default)]
@@ -1015,10 +1015,10 @@ async fn assert_spec(spec: ExecutionSpec, opentelemetry: &InMemoryTelemetry) {
                 .context(spec.path.to_str().unwrap().to_string())
                 .unwrap();
 
-            let mut headers= vec![];
+            let mut headers: BTreeMap<String, String> = BTreeMap::new();
 
             for (key, value) in response.headers() {
-                headers.insert((key.to_string(), value.to_str().unwrap().to_string()));
+                headers.insert(key.to_string(), value.to_str().unwrap().to_string());
             }
 
             let response: APIResponse = APIResponse {

--- a/tests/execution_spec.rs
+++ b/tests/execution_spec.rs
@@ -16,7 +16,7 @@ use hyper::body::Bytes;
 use hyper::{Body, Request};
 use markdown::mdast::Node;
 use markdown::ParseOptions;
-use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tailcall::async_graphql_hyper::{GraphQLBatchRequest, GraphQLRequest};
@@ -218,7 +218,7 @@ struct APIResponse {
     #[serde(default = "default_status")]
     status: u16,
     #[serde(default)]
-    headers: BTreeMap<String, String>,
+    headers: Vec<(String, String)>,
     #[serde(default)]
     body: serde_json::Value,
     #[serde(default)]
@@ -1015,10 +1015,10 @@ async fn assert_spec(spec: ExecutionSpec, opentelemetry: &InMemoryTelemetry) {
                 .context(spec.path.to_str().unwrap().to_string())
                 .unwrap();
 
-            let mut headers: BTreeMap<String, String> = BTreeMap::new();
+            let mut headers= vec![];
 
             for (key, value) in response.headers() {
-                headers.insert(key.to_string(), value.to_str().unwrap().to_string());
+                headers.insert((key.to_string(), value.to_str().unwrap().to_string()));
             }
 
             let response: APIResponse = APIResponse {

--- a/tests/snapshots/execution_spec__test-set-cookie-headers.md_assert_0.snap
+++ b/tests/snapshots/execution_spec__test-set-cookie-headers.md_assert_0.snap
@@ -6,12 +6,15 @@ expression: response
   "status": 200,
   "headers": {
     "content-type": "application/json",
-    "set-cookie": "foo2=bar2"
+    "set-cookie": "user=1; user=2"
   },
   "body": {
     "data": {
-      "user": {
+      "u1": {
         "name": "foo"
+      },
+      "u2": {
+        "name": "bar"
       }
     }
   }

--- a/tests/snapshots/execution_spec__test-set-cookie-headers.md_assert_0.snap
+++ b/tests/snapshots/execution_spec__test-set-cookie-headers.md_assert_0.snap
@@ -1,0 +1,18 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json",
+    "set-cookie": "foo2=bar2"
+  },
+  "body": {
+    "data": {
+      "user": {
+        "name": "foo"
+      }
+    }
+  }
+}

--- a/tests/snapshots/execution_spec__test-set-cookie-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__test-set-cookie-headers.md_client.snap
@@ -1,0 +1,20 @@
+---
+source: tests/execution_spec.rs
+expression: client
+---
+type Query {
+  user(id: Int!): User
+}
+
+type User {
+  email: String!
+  id: Int!
+  name: String!
+  phone: String
+  username: String!
+  website: String
+}
+
+schema {
+  query: Query
+}

--- a/tests/snapshots/execution_spec__test-set-cookie-headers.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-set-cookie-headers.md_merged.snap
@@ -2,7 +2,7 @@
 source: tests/execution_spec.rs
 expression: merged
 ---
-schema @server(headers: {setCookies: false}, graphiql: true, hostname: "0.0.0.0", port: 8080) @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server(headers: {setCookies: true}, graphiql: true, hostname: "0.0.0.0", port: 8080) @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
   query: Query
 }
 

--- a/tests/snapshots/execution_spec__test-set-cookie-headers.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-set-cookie-headers.md_merged.snap
@@ -1,0 +1,20 @@
+---
+source: tests/execution_spec.rs
+expression: merged
+---
+schema @server(headers: {setCookies: false}, graphiql: true, hostname: "0.0.0.0", port: 8080) @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  user(id: Int!): User @http(path: "/users/{{args.id}}")
+}
+
+type User {
+  email: String!
+  id: Int!
+  name: String!
+  phone: String
+  username: String!
+  website: String
+}


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1397
/claim 1397

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for handling cookie headers in server requests, including the ability to set cookies via GraphQL schema and server configuration.
	- Introduced a new field `setCookies` in the GraphQL schema and corresponding logic in server components.
- **Enhancements**
	- Enhanced request context creation with conditional cookie headers addition based on server configuration.
- **Refactor**
	- Refactored logic in the `IO` module to separate setting cache control and cookie headers into distinct functions for improved organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->