### PR TITLE
fix: handle non-experimental headers

### DIFF
--- a/src/blueprint/server.rs
+++ b/src/blueprint/server.rs
@@ -113,27 +113,32 @@ impl TryFrom<crate::config::ConfigModule> for Server {
                 (config_server).get_response_headers(),
             ))
             .fuse(to_script(&config_module))
-            .map(|(hostname, http, response_headers, script)| Server {
-                enable_apollo_tracing: (config_server).enable_apollo_tracing(),
-                enable_cache_control_header: (config_server).enable_cache_control(),
-                enable_set_cookie_header: (config_server).enable_set_cookies(),
-                enable_graphiql: (config_server).enable_graphiql(),
-                enable_introspection: (config_server).enable_introspection(),
-                enable_query_validation: (config_server).enable_query_validation(),
-                enable_response_validation: (config_server).enable_http_validation(),
-                enable_batch_requests: (config_server).enable_batch_requests(),
-                enable_showcase: (config_server).enable_showcase(),
-                experimental_headers: (config_server).get_experimental_headers(),
-                global_response_timeout: (config_server).get_global_response_timeout(),
-                http,
-                worker: (config_server).get_workers(),
-                port: (config_server).get_port(),
-                hostname,
-                vars: (config_server).get_vars(),
-                pipeline_flush: (config_server).get_pipeline_flush(),
-                response_headers,
-                script,
-            })
+            .fuse(handle_experimental_headers(
+                (config_server).get_experimental_headers(),
+            ))
+            .map(
+                |(hostname, http, response_headers, script, experimental_headers)| Server {
+                    enable_apollo_tracing: (config_server).enable_apollo_tracing(),
+                    enable_cache_control_header: (config_server).enable_cache_control(),
+                    enable_set_cookie_header: (config_server).enable_set_cookies(),
+                    enable_graphiql: (config_server).enable_graphiql(),
+                    enable_introspection: (config_server).enable_introspection(),
+                    enable_query_validation: (config_server).enable_query_validation(),
+                    enable_response_validation: (config_server).enable_http_validation(),
+                    enable_batch_requests: (config_server).enable_batch_requests(),
+                    enable_showcase: (config_server).enable_showcase(),
+                    experimental_headers,
+                    global_response_timeout: (config_server).get_global_response_timeout(),
+                    http,
+                    worker: (config_server).get_workers(),
+                    port: (config_server).get_port(),
+                    hostname,
+                    vars: (config_server).get_vars(),
+                    pipeline_flush: (config_server).get_pipeline_flush(),
+                    response_headers,
+                    script,
+                },
+            )
             .to_result()
     }
 }
@@ -182,6 +187,27 @@ fn handle_response_headers(resp_headers: Vec<(String, String)>) -> Valid<HeaderM
     })
     .map(|headers| headers.into_iter().collect::<HeaderMap>())
     .trace("custom")
+    .trace("headers")
+    .trace("@server")
+    .trace("schema")
+}
+
+fn handle_experimental_headers(headers: BTreeSet<String>) -> Valid<BTreeSet<String>, String> {
+    Valid::from_iter(headers.iter(), |h| {
+        if !h.to_lowercase().starts_with("x-") {
+            Valid::fail(
+                format!(
+                    "Experimental headers must start with 'x-' or 'X-'. Got: '{}'",
+                    h
+                )
+                .to_string(),
+            )
+        } else {
+            Valid::succeed(h.clone())
+        }
+    })
+    .map_to(headers)
+    .trace("experimental")
     .trace("headers")
     .trace("@server")
     .trace("schema")

--- a/tests/execution/experimental-headers-error.md
+++ b/tests/execution/experimental-headers-error.md
@@ -1,0 +1,13 @@
+# test-experimental-headers-error
+
+###### sdl error
+
+```graphql @server
+schema @server(headers: {experimental: ["non-experimental", "foo", "bar", "tailcall"]}) {
+  query: Query
+}
+
+type Query {
+  hello: String @const(data: "World!")
+}
+```

--- a/tests/execution/experimental-headers.md
+++ b/tests/execution/experimental-headers.md
@@ -1,7 +1,7 @@
 # Experimental headers
 
 ```graphql @server
-schema @server(headers: {experimental: ["x-tailcall", "x-experimental"]}) {
+schema @server(headers: {experimental: ["x-tailcall", "X-experimental"]}) {
   query: Query
 }
 
@@ -20,7 +20,7 @@ type User {
     method: GET
     url: http://jsonplaceholder.typicode.com/users
     headers:
-      x-tailcall: "tailcall-header"
+      X-tailcall: "tailcall-header"
       x-experimental: "experimental-header"
       x-not-allowed: "not-allowed-header"
     body: null
@@ -35,7 +35,7 @@ type User {
 - method: POST
   url: http://localhost:8080/graphql
   headers:
-    x-tailcall: "tailcall-header"
+    X-tailcall: "tailcall-header"
     x-experimental: "experimental-header"
   body:
     query: query { users { id name } }

--- a/tests/snapshots/execution_spec__experimental-headers-error.md_errors.snap
+++ b/tests/snapshots/execution_spec__experimental-headers-error.md_errors.snap
@@ -1,0 +1,46 @@
+---
+source: tests/execution_spec.rs
+expression: errors
+---
+[
+  {
+    "message": "Experimental headers must start with 'x-' or 'X-'. Got: 'bar'",
+    "trace": [
+      "schema",
+      "@server",
+      "headers",
+      "experimental"
+    ],
+    "description": null
+  },
+  {
+    "message": "Experimental headers must start with 'x-' or 'X-'. Got: 'foo'",
+    "trace": [
+      "schema",
+      "@server",
+      "headers",
+      "experimental"
+    ],
+    "description": null
+  },
+  {
+    "message": "Experimental headers must start with 'x-' or 'X-'. Got: 'non-experimental'",
+    "trace": [
+      "schema",
+      "@server",
+      "headers",
+      "experimental"
+    ],
+    "description": null
+  },
+  {
+    "message": "Experimental headers must start with 'x-' or 'X-'. Got: 'tailcall'",
+    "trace": [
+      "schema",
+      "@server",
+      "headers",
+      "experimental"
+    ],
+    "description": null
+  }
+]

--- a/tests/snapshots/execution_spec__experimental-headers.md_merged.snap
+++ b/tests/snapshots/execution_spec__experimental-headers.md_merged.snap
@@ -2,7 +2,7 @@
 source: tests/execution_spec.rs
 expression: merged
 ---
-schema @server(headers: {experimental: ["x-experimental", "x-tailcall"]}) @upstream {
+schema @server(headers: {experimental: ["X-experimental", "x-tailcall"]}) @upstream {
   query: Query
 }
 


### PR DESCRIPTION
- **test(experimental-headers): ensure case insensitivity on experimental headers**
- **fix: ensure error throwing when a non-experimental header is used**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of experimental headers in server operations, including case sensitivity adjustments.
- **Tests**
	- Added test cases for handling errors related to experimental headers in GraphQL schemas.
	- Introduced tests for case sensitivity in experimental headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->