### PR TITLE
chore: move `async-graphql*` dependency link to tailcallhq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,11 +244,11 @@ dependencies = [
 [[package]]
 name = "async-graphql"
 version = "7.0.2"
-source = "git+https://github.com/tusharmath/async-graphql.git?branch=add-setter#bb4064a48aff9bf16c1641c67d8c7b8892d53f82"
+source = "git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter#b18d097ff3deb17d29e56376eb8e6081440624b0"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
- "async-graphql-value",
+ "async-graphql-value 7.0.2 (git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter)",
  "async-stream",
  "async-trait",
  "base64",
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-derive"
 version = "7.0.2"
-source = "git+https://github.com/tusharmath/async-graphql.git?branch=add-setter#bb4064a48aff9bf16c1641c67d8c7b8892d53f82"
+source = "git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter#b18d097ff3deb17d29e56376eb8e6081440624b0"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -329,10 +329,21 @@ dependencies = [
 [[package]]
 name = "async-graphql-parser"
 version = "7.0.2"
-source = "git+https://github.com/tusharmath/async-graphql.git?branch=add-setter#bb4064a48aff9bf16c1641c67d8c7b8892d53f82"
+source = "git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter#b18d097ff3deb17d29e56376eb8e6081440624b0"
 dependencies = [
- "async-graphql-value",
+ "async-graphql-value 7.0.2 (git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter)",
  "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.0.2"
+source = "git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter#b18d097ff3deb17d29e56376eb8e6081440624b0"
+dependencies = [
+ "bytes",
+ "indexmap 2.2.5",
  "serde",
  "serde_json",
 ]
@@ -937,7 +948,7 @@ name = "cloudflare"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-graphql-value",
+ "async-graphql-value 7.0.2 (git+https://github.com/tusharmath/async-graphql.git?branch=add-setter)",
  "async-std",
  "async-trait",
  "console_error_panic_hook",
@@ -4922,7 +4933,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-extension-apollo-tracing",
- "async-graphql-value",
+ "async-graphql-value 7.0.2 (git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter)",
  "async-recursion",
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ source = "git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter#
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
- "async-graphql-value 7.0.2 (git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter)",
+ "async-graphql-value",
  "async-stream",
  "async-trait",
  "base64",
@@ -331,7 +331,7 @@ name = "async-graphql-parser"
 version = "7.0.2"
 source = "git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter#b18d097ff3deb17d29e56376eb8e6081440624b0"
 dependencies = [
- "async-graphql-value 7.0.2 (git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter)",
+ "async-graphql-value",
  "pest",
  "serde",
  "serde_json",
@@ -341,17 +341,6 @@ dependencies = [
 name = "async-graphql-value"
 version = "7.0.2"
 source = "git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter#b18d097ff3deb17d29e56376eb8e6081440624b0"
-dependencies = [
- "bytes",
- "indexmap 2.2.5",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "7.0.2"
-source = "git+https://github.com/tusharmath/async-graphql.git?branch=add-setter#bb4064a48aff9bf16c1641c67d8c7b8892d53f82"
 dependencies = [
  "bytes",
  "indexmap 2.2.5",
@@ -948,7 +937,7 @@ name = "cloudflare"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-graphql-value 7.0.2 (git+https://github.com/tusharmath/async-graphql.git?branch=add-setter)",
+ "async-graphql-value",
  "async-std",
  "async-trait",
  "console_error_panic_hook",
@@ -4933,7 +4922,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-extension-apollo-tracing",
- "async-graphql-value 7.0.2 (git+https://github.com/tailcallhq/async-graphql.git?branch=add-setter)",
+ "async-graphql-value",
  "async-recursion",
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ reqwest = { version = "0.11", features = [
 ], default-features = false }
 # TODO: Modification with the ability to set a parsed GraphQL operation.
 # Remove this once https://github.com/async-graphql/async-graphql/pull/1483/files is merged
-async-graphql = { git = "https://github.com/tusharmath/async-graphql.git", branch = "add-setter", features = [
+async-graphql = { git = "https://github.com/tailcallhq/async-graphql.git", branch = "add-setter", features = [
     "dynamic-schema",
     "dataloader",
     "apollo_tracing",
@@ -60,7 +60,7 @@ async-graphql = { git = "https://github.com/tusharmath/async-graphql.git", branc
 ] }
 # TODO: Modification with the ability to set a parsed GraphQL operation.
 # Remove this once https://github.com/async-graphql/async-graphql/pull/1483/files is merged
-async-graphql-value = { git = "https://github.com/tusharmath/async-graphql.git", branch = "add-setter" }
+async-graphql-value = { git = "https://github.com/tailcallhq/async-graphql.git", branch = "add-setter" }
 indexmap = "2.2"
 once_cell = "1.19.0"
 clap = { version = "4.5.2", features = ["derive"] }
@@ -127,8 +127,8 @@ async-graphql-extension-apollo-tracing = { git = "https://github.com/tailcallhq/
 
 [patch.crates-io]
 # TODO: update this once https://github.com/haixuanTao/opentelemetry-system-metrics/pull/2 gets merged
-async-graphql-value = {git ="https://github.com/tusharmath/async-graphql.git", branch = "add-setter"}
-async-graphql = {git ="https://github.com/tusharmath/async-graphql.git", branch = "add-setter"}
+async-graphql-value = {git ="https://github.com/tailcallhq/async-graphql.git", branch = "add-setter"}
+async-graphql = {git ="https://github.com/tailcallhq/async-graphql.git", branch = "add-setter"}
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -20,7 +20,7 @@ async-std = "1.12.0"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 tracing-subscriber-wasm = "0.1.0"
-async-graphql-value = {git ="https://github.com/tusharmath/async-graphql.git", branch = "add-setter"}
+async-graphql-value = {git ="https://github.com/tailcallhq/async-graphql.git", branch = "add-setter"}
 serde_json = "1.0.114"
 serde_qs = "0.12.0"
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
