### PR TITLE
feat(cache): add support for IO caching in RequestContext

### DIFF
--- a/benches/impl_path_string_for_evaluation_context.rs
+++ b/benches/impl_path_string_for_evaluation_context.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use async_graphql::context::SelectionField;
@@ -258,6 +258,7 @@ fn request_context() -> RequestContext {
         min_max_age: Arc::new(Mutex::new(None)),
         cache_public: Arc::new(Mutex::new(None)),
         runtime,
+        cache: Arc::new(RwLock::new(HashMap::new())),
     }
 }
 

--- a/src/async_cache.rs
+++ b/src/async_cache.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use futures_util::Future;
-use tokio::sync::oneshot::{Receiver};
+use tokio::sync::oneshot::Receiver;
 
 /// A simple async cache that uses a `HashMap` to store the values.
 pub struct AsyncCache<Key, Value> {

--- a/src/async_cache.rs
+++ b/src/async_cache.rs
@@ -5,9 +5,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use futures_util::Future;
-
-type Sender<A> = tokio::sync::oneshot::Sender<A>;
-type Receiver<A> = tokio::sync::oneshot::Receiver<A>;
+use tokio::sync::oneshot::{Receiver};
 
 /// A simple async cache that uses a `HashMap` to store the values.
 pub struct AsyncCache<Key, Value> {
@@ -81,7 +79,7 @@ mod tests {
 
         for i in 0..100 {
             cache
-                .get_or_else(1, || Box::pin(async move { Ok(i.clone()) }))
+                .get_or_else(1, || Box::pin(async move { Ok(i) }))
                 .await
                 .unwrap();
         }

--- a/src/async_cache.rs
+++ b/src/async_cache.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use futures_util::Future;
+
+type Sender<A> = tokio::sync::oneshot::Sender<A>;
+type Receiver<A> = tokio::sync::oneshot::Receiver<A>;
+
+/// A simple async cache that uses a `HashMap` to store the values.
+pub struct AsyncCache<Key, Value> {
+    cache: Arc<Mutex<HashMap<Key, (Arc<Mutex<Option<Value>>>, Receiver<Value>)>>>,
+}
+
+impl<Key: Eq + Hash, Value: Debug + Clone> AsyncCache<Key, Value> {
+    pub fn new() -> Self {
+        Self { cache: Arc::new(Mutex::new(HashMap::new())) }
+    }
+
+    pub async fn get_or_else(
+        &self,
+        key: Key,
+        or_else: impl FnOnce() -> Pin<Box<dyn Future<Output = anyhow::Result<Value>>>>,
+    ) -> anyhow::Result<Value> {
+        let mut cache = self.cache.lock().unwrap();
+        if let Some((value, rx)) = cache.get_mut(&key) {
+            if let Some(value) = value.lock().unwrap().as_ref() {
+                Ok(value.clone())
+            } else {
+                let value = rx.await?;
+                Ok(value.clone())
+            }
+        } else {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let last_value = Arc::new(Mutex::new(None));
+            cache.insert(key, (last_value.clone(), rx));
+            let value = or_else().await?;
+            last_value.lock().unwrap().replace(value.clone());
+            tx.send(value.clone()).unwrap();
+            Ok(value)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_no_key() {
+        let cache = AsyncCache::new();
+        let actual = cache
+            .get_or_else(1, || Box::pin(async { Ok(1) }))
+            .await
+            .unwrap();
+        assert_eq!(actual, 1);
+    }
+
+    #[tokio::test]
+    async fn test_with_key() {
+        let cache = AsyncCache::new();
+        cache
+            .get_or_else(1, || Box::pin(async { Ok(1) }))
+            .await
+            .unwrap();
+
+        let actual = cache
+            .get_or_else(1, || Box::pin(async { Ok(2) }))
+            .await
+            .unwrap();
+        assert_eq!(actual, 1);
+    }
+
+    #[tokio::test]
+    async fn test_with_multi_get() {
+        let cache = AsyncCache::new();
+
+        for i in 0..100 {
+            cache
+                .get_or_else(1, || Box::pin(async move { Ok(i.clone()) }))
+                .await
+                .unwrap();
+        }
+
+        let actual = cache
+            .get_or_else(1, || Box::pin(async { Ok(2) }))
+            .await
+            .unwrap();
+        assert_eq!(actual, 0);
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -13,7 +13,7 @@ pub use cache::*;
 pub use data_loader::*;
 pub use data_loader_request::*;
 pub use method::Method;
-pub use request_context::RequestContext;
+pub use request_context::{CacheValue, RequestContext};
 pub use request_handler::{graphiql, handle_request};
 pub use request_template::RequestTemplate;
 pub use response::*;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -13,7 +13,7 @@ pub use cache::*;
 pub use data_loader::*;
 pub use data_loader_request::*;
 pub use method::Method;
-pub use request_context::{CacheValue, RequestContext};
+pub use request_context::RequestContext;
 pub use request_handler::{graphiql, handle_request};
 pub use request_template::RequestTemplate;
 pub use response::*;

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -7,7 +7,7 @@ use async_graphql_value::ConstValue;
 use cache_control::{Cachability, CacheControl};
 use derive_setters::Setters;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use tokio::sync::broadcast;
+use tokio::sync::watch;
 
 use crate::blueprint::{Server, Upstream};
 use crate::data_loader::DataLoader;
@@ -30,13 +30,7 @@ pub struct RequestContext {
     pub min_max_age: Arc<Mutex<Option<i32>>>,
     pub cache_public: Arc<Mutex<Option<bool>>>,
     pub runtime: TargetRuntime,
-    pub cache: Arc<RwLock<HashMap<u64, CacheValue>>>,
-}
-
-#[derive(Clone)]
-pub enum CacheValue {
-    Pending(broadcast::Sender<ConstValue>),
-    Ready(ConstValue),
+    pub cache: Arc<RwLock<HashMap<u64, watch::Receiver<Option<ConstValue>>>>>,
 }
 
 impl RequestContext {

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -7,7 +7,7 @@ use async_graphql_value::ConstValue;
 use cache_control::{Cachability, CacheControl};
 use derive_setters::Setters;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use tokio::sync::watch;
+use tokio::sync::broadcast;
 
 use crate::blueprint::{Server, Upstream};
 use crate::data_loader::DataLoader;
@@ -30,7 +30,13 @@ pub struct RequestContext {
     pub min_max_age: Arc<Mutex<Option<i32>>>,
     pub cache_public: Arc<Mutex<Option<bool>>>,
     pub runtime: TargetRuntime,
-    pub cache: Arc<RwLock<HashMap<u64, watch::Receiver<Option<ConstValue>>>>>,
+    pub cache: Arc<RwLock<HashMap<u64, CacheValue>>>,
+}
+
+#[derive(Clone)]
+pub enum CacheValue {
+    Pending(broadcast::Sender<ConstValue>),
+    Ready(ConstValue),
 }
 
 impl RequestContext {

--- a/src/lambda/io.rs
+++ b/src/lambda/io.rs
@@ -73,73 +73,83 @@ impl Eval for IO {
             .insert(cache_key, CacheValue::Pending(snd.clone()));
 
         Box::pin(async move {
-            let result = match self {
-                IO::Http { req_template, dl_id, .. } => {
-                    let req = req_template.to_request(ctx)?;
-                    let is_get = req.method() == reqwest::Method::GET;
+            let result = eval_io(self, ctx, _conc).await?;
 
-                    let res = if is_get && ctx.req_ctx.is_batching_enabled() {
-                        let data_loader: Option<&DataLoader<DataLoaderRequest, HttpDataLoader>> =
-                            dl_id.and_then(|index| ctx.req_ctx.http_data_loaders.get(index.0));
-                        execute_request_with_dl(ctx, req, data_loader).await?
-                    } else {
-                        execute_raw_request(ctx, req).await?
-                    };
-
-                    if ctx.req_ctx.server.get_enable_http_validation() {
-                        req_template
-                            .endpoint
-                            .output
-                            .validate(&res.body)
-                            .to_result()
-                            .map_err(EvaluationError::from)?;
-                    }
-
-                    set_headers(ctx, &res);
-
-                    Ok(res.body)
-                }
-                IO::GraphQL { req_template, field_name, dl_id, .. } => {
-                    let req = req_template.to_request(ctx)?;
-
-                    let res = if ctx.req_ctx.upstream.batch.is_some()
-                        && matches!(req_template.operation_type, GraphQLOperationType::Query)
-                    {
-                        let data_loader: Option<&DataLoader<DataLoaderRequest, GraphqlDataLoader>> =
-                            dl_id.and_then(|index| ctx.req_ctx.gql_data_loaders.get(index.0));
-                        execute_request_with_dl(ctx, req, data_loader).await?
-                    } else {
-                        execute_raw_request(ctx, req).await?
-                    };
-
-                    set_headers(ctx, &res);
-                    parse_graphql_response(ctx, res, field_name)
-                }
-                IO::Grpc { req_template, dl_id, .. } => {
-                    let rendered = req_template.render(ctx)?;
-
-                    let res = if ctx.req_ctx.upstream.batch.is_some() &&
-                        // TODO: share check for operation_type for resolvers
-                        matches!(req_template.operation_type, GraphQLOperationType::Query)
-                    {
-                        let data_loader: Option<
-                            &DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>,
-                        > = dl_id.and_then(|index| ctx.req_ctx.grpc_data_loaders.get(index.0));
-                        execute_grpc_request_with_dl(ctx, rendered, data_loader).await?
-                    } else {
-                        let req = rendered.to_request()?;
-                        execute_raw_grpc_request(ctx, req, &req_template.operation).await?
-                    };
-
-                    set_headers(ctx, &res);
-
-                    Ok(res.body)
-                }
-            }?;
-
+            if let Some(cache_value) = ctx.req_ctx.cache.write().unwrap().get_mut(&cache_key) {
+                *cache_value = CacheValue::Ready(result.clone());
+            }
             snd.send(result.clone()).ok();
             Ok(result)
         })
+    }
+}
+
+async fn eval_io<'a, Ctx: super::ResolverContextLike<'a> + Sync + Send>(
+    io: &'a IO,
+    ctx: &'a super::EvaluationContext<'a, Ctx>,
+    _conc: &'a super::Concurrent,
+) -> Result<ConstValue> {
+    match io {
+        IO::Http { req_template, dl_id, .. } => {
+            let req = req_template.to_request(ctx)?;
+            let is_get = req.method() == reqwest::Method::GET;
+
+            let res = if is_get && ctx.req_ctx.is_batching_enabled() {
+                let data_loader: Option<&DataLoader<DataLoaderRequest, HttpDataLoader>> =
+                    dl_id.and_then(|index| ctx.req_ctx.http_data_loaders.get(index.0));
+                execute_request_with_dl(ctx, req, data_loader).await?
+            } else {
+                execute_raw_request(ctx, req).await?
+            };
+
+            if ctx.req_ctx.server.get_enable_http_validation() {
+                req_template
+                    .endpoint
+                    .output
+                    .validate(&res.body)
+                    .to_result()
+                    .map_err(EvaluationError::from)?;
+            }
+
+            set_headers(ctx, &res);
+
+            Ok(res.body)
+        }
+        IO::GraphQL { req_template, field_name, dl_id, .. } => {
+            let req = req_template.to_request(ctx)?;
+
+            let res = if ctx.req_ctx.upstream.batch.is_some()
+                && matches!(req_template.operation_type, GraphQLOperationType::Query)
+            {
+                let data_loader: Option<&DataLoader<DataLoaderRequest, GraphqlDataLoader>> =
+                    dl_id.and_then(|index| ctx.req_ctx.gql_data_loaders.get(index.0));
+                execute_request_with_dl(ctx, req, data_loader).await?
+            } else {
+                execute_raw_request(ctx, req).await?
+            };
+
+            set_headers(ctx, &res);
+            parse_graphql_response(ctx, res, field_name)
+        }
+        IO::Grpc { req_template, dl_id, .. } => {
+            let rendered = req_template.render(ctx)?;
+
+            let res = if ctx.req_ctx.upstream.batch.is_some() &&
+                // TODO: share check for operation_type for resolvers
+                matches!(req_template.operation_type, GraphQLOperationType::Query)
+            {
+                let data_loader: Option<&DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>> =
+                    dl_id.and_then(|index| ctx.req_ctx.grpc_data_loaders.get(index.0));
+                execute_grpc_request_with_dl(ctx, rendered, data_loader).await?
+            } else {
+                let req = rendered.to_request()?;
+                execute_raw_grpc_request(ctx, req, &req_template.operation).await?
+            };
+
+            set_headers(ctx, &res);
+
+            Ok(res.body)
+        }
     }
 }
 

--- a/src/lambda/io.rs
+++ b/src/lambda/io.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_graphql_value::ConstValue;
 use reqwest::Request;
-use tokio::sync::watch;
+use tokio::sync::broadcast;
 
 use super::{CacheKey, Eval, EvaluationContext, ResolverContextLike};
 use crate::config::group_by::GroupBy;
@@ -16,7 +16,7 @@ use crate::grpc::data_loader::GrpcDataLoader;
 use crate::grpc::protobuf::ProtobufOperation;
 use crate::grpc::request::execute_grpc_request;
 use crate::grpc::request_template::RenderedRequestTemplate;
-use crate::http::{cache_policy, DataLoaderRequest, HttpDataLoader, Response};
+use crate::http::{cache_policy, CacheValue, DataLoaderRequest, HttpDataLoader, Response};
 use crate::json::JsonLike;
 use crate::lambda::EvaluationError;
 use crate::valid::Validator;
@@ -52,89 +52,94 @@ impl Eval for IO {
         _conc: &'a super::Concurrent,
     ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
         let cache_key = self.cache_key(ctx);
-        if let Some(mut rcv) = ctx.req_ctx.cache.read().unwrap().get(&cache_key).cloned() {
-            return Box::pin(
-                async move { Ok(rcv.wait_for(Option::is_some).await?.clone().unwrap()) },
-            );
+        if let Some(cache_value) = ctx.req_ctx.cache.read().unwrap().get(&cache_key).cloned() {
+            return match cache_value {
+                CacheValue::Pending(rcv) => Box::pin(async move {
+                    let result = rcv.subscribe().recv().await?;
+                    if let Some(val) = ctx.req_ctx.cache.write().unwrap().get_mut(&cache_key) {
+                        *val = CacheValue::Ready(result.clone())
+                    }
+                    Ok(result)
+                }),
+                CacheValue::Ready(val) => Box::pin(async move { Ok(val) }),
+            };
         }
 
-        let (snd, rcv) = watch::channel(None);
-        ctx.req_ctx.cache.write().unwrap().insert(cache_key, rcv);
+        let (snd, _) = broadcast::channel(100);
+        ctx.req_ctx
+            .cache
+            .write()
+            .unwrap()
+            .insert(cache_key, CacheValue::Pending(snd.clone()));
 
         Box::pin(async move {
-            let result = eval_io(self, ctx, _conc).await?;
-            snd.send(Some(result.clone()))?;
+            let result = match self {
+                IO::Http { req_template, dl_id, .. } => {
+                    let req = req_template.to_request(ctx)?;
+                    let is_get = req.method() == reqwest::Method::GET;
+
+                    let res = if is_get && ctx.req_ctx.is_batching_enabled() {
+                        let data_loader: Option<&DataLoader<DataLoaderRequest, HttpDataLoader>> =
+                            dl_id.and_then(|index| ctx.req_ctx.http_data_loaders.get(index.0));
+                        execute_request_with_dl(ctx, req, data_loader).await?
+                    } else {
+                        execute_raw_request(ctx, req).await?
+                    };
+
+                    if ctx.req_ctx.server.get_enable_http_validation() {
+                        req_template
+                            .endpoint
+                            .output
+                            .validate(&res.body)
+                            .to_result()
+                            .map_err(EvaluationError::from)?;
+                    }
+
+                    set_headers(ctx, &res);
+
+                    Ok(res.body)
+                }
+                IO::GraphQL { req_template, field_name, dl_id, .. } => {
+                    let req = req_template.to_request(ctx)?;
+
+                    let res = if ctx.req_ctx.upstream.batch.is_some()
+                        && matches!(req_template.operation_type, GraphQLOperationType::Query)
+                    {
+                        let data_loader: Option<&DataLoader<DataLoaderRequest, GraphqlDataLoader>> =
+                            dl_id.and_then(|index| ctx.req_ctx.gql_data_loaders.get(index.0));
+                        execute_request_with_dl(ctx, req, data_loader).await?
+                    } else {
+                        execute_raw_request(ctx, req).await?
+                    };
+
+                    set_headers(ctx, &res);
+                    parse_graphql_response(ctx, res, field_name)
+                }
+                IO::Grpc { req_template, dl_id, .. } => {
+                    let rendered = req_template.render(ctx)?;
+
+                    let res = if ctx.req_ctx.upstream.batch.is_some() &&
+                        // TODO: share check for operation_type for resolvers
+                        matches!(req_template.operation_type, GraphQLOperationType::Query)
+                    {
+                        let data_loader: Option<
+                            &DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>,
+                        > = dl_id.and_then(|index| ctx.req_ctx.grpc_data_loaders.get(index.0));
+                        execute_grpc_request_with_dl(ctx, rendered, data_loader).await?
+                    } else {
+                        let req = rendered.to_request()?;
+                        execute_raw_grpc_request(ctx, req, &req_template.operation).await?
+                    };
+
+                    set_headers(ctx, &res);
+
+                    Ok(res.body)
+                }
+            }?;
+
+            snd.send(result.clone()).ok();
             Ok(result)
         })
-    }
-}
-
-async fn eval_io<'a, Ctx: super::ResolverContextLike<'a> + Sync + Send>(
-    io: &'a IO,
-    ctx: &'a super::EvaluationContext<'a, Ctx>,
-    _conc: &'a super::Concurrent,
-) -> Result<ConstValue> {
-    match io {
-        IO::Http { req_template, dl_id, .. } => {
-            let req = req_template.to_request(ctx)?;
-            let is_get = req.method() == reqwest::Method::GET;
-
-            let res = if is_get && ctx.req_ctx.is_batching_enabled() {
-                let data_loader: Option<&DataLoader<DataLoaderRequest, HttpDataLoader>> =
-                    dl_id.and_then(|index| ctx.req_ctx.http_data_loaders.get(index.0));
-                execute_request_with_dl(ctx, req, data_loader).await?
-            } else {
-                execute_raw_request(ctx, req).await?
-            };
-
-            if ctx.req_ctx.server.get_enable_http_validation() {
-                req_template
-                    .endpoint
-                    .output
-                    .validate(&res.body)
-                    .to_result()
-                    .map_err(EvaluationError::from)?;
-            }
-
-            set_headers(ctx, &res);
-
-            Ok(res.body)
-        }
-        IO::GraphQL { req_template, field_name, dl_id, .. } => {
-            let req = req_template.to_request(ctx)?;
-
-            let res = if ctx.req_ctx.upstream.batch.is_some()
-                && matches!(req_template.operation_type, GraphQLOperationType::Query)
-            {
-                let data_loader: Option<&DataLoader<DataLoaderRequest, GraphqlDataLoader>> =
-                    dl_id.and_then(|index| ctx.req_ctx.gql_data_loaders.get(index.0));
-                execute_request_with_dl(ctx, req, data_loader).await?
-            } else {
-                execute_raw_request(ctx, req).await?
-            };
-
-            set_headers(ctx, &res);
-            parse_graphql_response(ctx, res, field_name)
-        }
-        IO::Grpc { req_template, dl_id, .. } => {
-            let rendered = req_template.render(ctx)?;
-
-            let res = if ctx.req_ctx.upstream.batch.is_some() &&
-                // TODO: share check for operation_type for resolvers
-                matches!(req_template.operation_type, GraphQLOperationType::Query)
-            {
-                let data_loader: Option<&DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>> =
-                    dl_id.and_then(|index| ctx.req_ctx.grpc_data_loaders.get(index.0));
-                execute_grpc_request_with_dl(ctx, rendered, data_loader).await?
-            } else {
-                let req = rendered.to_request()?;
-                execute_raw_grpc_request(ctx, req, &req_template.operation).await?
-            };
-
-            set_headers(ctx, &res);
-
-            Ok(res.body)
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::mutable_key_type)]
 
 mod app_context;
+mod async_cache;
 pub mod async_graphql_hyper;
 pub mod blueprint;
 pub mod cache;


### PR DESCRIPTION
**Summary:**  
Eliminates duplicate IO calls made in the same request by saving the results in `RequestContext`

**Issue Reference(s):**  
Fixes #1445 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new caching mechanism across the application to improve performance.
	- Added an `AsyncCache` structure for asynchronous value retrieval and caching.

- **Enhancements**
	- Expanded `RequestContext` to include caching capabilities using a combination of `HashMap` and `broadcast` channels.
	- Enhanced `IO` operations to support caching, improving efficiency in data handling.

- **Refactor**
	- Reorganized module imports for better code structure and readability.

- **Documentation**
	- Updated public exports to include `CacheValue`, making it accessible for further development and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->