### PR TITLE
refactor: `EvaluationContext` pass by value

### DIFF
--- a/benches/impl_path_string_for_evaluation_context.rs
+++ b/benches/impl_path_string_for_evaluation_context.rs
@@ -170,6 +170,7 @@ fn to_bench_id(input: &[&str]) -> BenchmarkId {
     BenchmarkId::new("input", input.join("."))
 }
 
+#[derive(Clone)]
 struct MockGraphqlContext;
 
 impl<'a> ResolverContextLike<'a> for MockGraphqlContext {

--- a/src/blueprint/into_schema.rs
+++ b/src/blueprint/into_schema.rs
@@ -8,7 +8,7 @@ use tracing::Instrument;
 
 use crate::blueprint::{Blueprint, Definition, Type};
 use crate::http::RequestContext;
-use crate::lambda::{Concurrent, Eval, EvaluationContext};
+use crate::lambda::{Concurrent, Eval, EvaluationContext, ResolverContext};
 
 fn to_type_ref(type_of: &Type) -> dynamic::TypeRef {
     match type_of {
@@ -49,9 +49,11 @@ fn to_type(def: &Definition) -> dynamic::Type {
 
                         match &field.resolver {
                             None => {
+                                let ctx: ResolverContext = ctx.into();
                                 let ctx = EvaluationContext::new(req_ctx, &ctx);
                                 FieldFuture::from_value(
-                                    ctx.path_value(&[field_name]).map(|a| a.to_owned()),
+                                    ctx.path_value(&[field_name])
+                                        .map(|a| a.into_owned().to_owned()),
                                 )
                             }
                             Some(expr) => {
@@ -62,10 +64,11 @@ fn to_type(def: &Definition) -> dynamic::Type {
                                 let expr = expr.to_owned();
                                 FieldFuture::new(
                                     async move {
+                                        let ctx: ResolverContext = ctx.into();
                                         let ctx = EvaluationContext::new(req_ctx, &ctx);
 
                                         let const_value =
-                                            expr.eval(&ctx, &Concurrent::Sequential).await?;
+                                            expr.eval(ctx, &Concurrent::Sequential).await?;
 
                                         let p = match const_value {
                                             ConstValue::List(a) => FieldValue::list(a),

--- a/src/blueprint/operators/expr.rs
+++ b/src/blueprint/operators/expr.rs
@@ -181,7 +181,7 @@ mod tests {
     use crate::lambda::{Concurrent, Eval, EvaluationContext, ResolverContextLike};
     use crate::valid::Validator;
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     struct Context<'a> {
         value: Option<&'a async_graphql_value::ConstValue>,
         args: Option<
@@ -228,7 +228,7 @@ mod tests {
             let req_ctx = RequestContext::default();
             let graphql_ctx = Context::default();
             let ctx = EvaluationContext::new(&req_ctx, &graphql_ctx);
-            let value = expression.eval(&ctx, &Concurrent::default()).await?;
+            let value = expression.eval(ctx, &Concurrent::default()).await?;
 
             Ok(serde_json::to_value(value)?)
         }

--- a/src/lambda/cache.rs
+++ b/src/lambda/cache.rs
@@ -37,17 +37,17 @@ impl Cache {
 impl Eval for Cache {
     fn eval<'a, Ctx: ResolverContextLike<'a> + Sync + Send>(
         &'a self,
-        ctx: &'a EvaluationContext<'a, Ctx>,
+        ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
     ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
         Box::pin(async move {
             if let Expression::IO(io) = self.expr.deref() {
-                let key = io.cache_key(ctx);
+                let key = io.cache_key(&ctx);
 
                 if let Some(val) = ctx.req_ctx.runtime.cache.get(&key).await? {
                     Ok(val)
                 } else {
-                    let val = self.expr.eval(ctx, conc).await?;
+                    let val = self.expr.eval(ctx.clone(), conc).await?;
                     ctx.req_ctx
                         .runtime
                         .cache

--- a/src/lambda/eval.rs
+++ b/src/lambda/eval.rs
@@ -11,7 +11,7 @@ where
 {
     fn eval<'a, Ctx: ResolverContextLike<'a> + Sync + Send>(
         &'a self,
-        ctx: &'a EvaluationContext<'a, Ctx>,
+        ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
     ) -> Pin<Box<dyn Future<Output = Result<Output>> + 'a + Send>>
     where

--- a/src/lambda/expression.rs
+++ b/src/lambda/expression.rs
@@ -33,6 +33,14 @@ pub enum Expression {
 pub enum Context {
     Value,
     Path(Vec<String>),
+    PushArgs {
+        expr: Box<Expression>,
+        and_then: Box<Expression>,
+    },
+    PushValue {
+        expr: Box<Expression>,
+        and_then: Box<Expression>,
+    },
 }
 
 #[derive(Debug, Error)]
@@ -79,13 +87,17 @@ impl Expression {
     pub fn in_sequence(self) -> Self {
         self.concurrency(Concurrent::Sequential)
     }
+
+    pub fn and_then(self, next: Self) -> Self {
+        Expression::Context(Context::PushValue { expr: Box::new(self), and_then: Box::new(next) })
+    }
 }
 
 impl Eval for Expression {
     #[tracing::instrument(skip_all, fields(name = %self), err)]
     fn eval<'a, Ctx: ResolverContextLike<'a> + Sync + Send>(
         &'a self,
-        ctx: &'a EvaluationContext<'a, Ctx>,
+        ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
     ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
         Box::pin(async move {
@@ -97,8 +109,18 @@ impl Eval for Expression {
                     }
                     Context::Path(path) => Ok(ctx
                         .path_value(path)
-                        .cloned()
+                        .map(|a| a.into_owned())
                         .unwrap_or(async_graphql::Value::Null)),
+                    Context::PushArgs { expr, and_then } => {
+                        let args = expr.eval(ctx.clone(), conc).await?;
+                        let ctx = ctx.with_args(args).clone();
+                        and_then.eval(ctx, conc).await
+                    }
+                    Context::PushValue { expr, and_then } => {
+                        let value = expr.eval(ctx.clone(), conc).await?;
+                        let ctx = ctx.with_value(value);
+                        and_then.eval(ctx, conc).await
+                    }
                 },
                 Expression::Input(input, path) => {
                     let inp = &input.eval(ctx, conc).await?;
@@ -107,9 +129,9 @@ impl Eval for Expression {
                         .unwrap_or(&async_graphql::Value::Null)
                         .clone())
                 }
-                Expression::Literal(value) => value.render_value(ctx),
+                Expression::Literal(value) => value.render_value(&ctx),
                 Expression::EqualTo(left, right) => Ok(async_graphql::Value::from(
-                    left.eval(ctx, conc).await? == right.eval(ctx, conc).await?,
+                    left.eval(ctx.clone(), conc).await? == right.eval(ctx, conc).await?,
                 )),
                 Expression::IO(operation) => operation.eval(ctx, conc).await,
                 Expression::Cache(cached) => cached.eval(ctx, conc).await,

--- a/src/lambda/io.rs
+++ b/src/lambda/io.rs
@@ -47,21 +47,21 @@ pub struct DataLoaderId(pub usize);
 impl Eval for IO {
     fn eval<'a, Ctx: super::ResolverContextLike<'a> + Sync + Send>(
         &'a self,
-        ctx: &'a super::EvaluationContext<'a, Ctx>,
+        ctx: super::EvaluationContext<'a, Ctx>,
         _conc: &'a super::Concurrent,
     ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
         Box::pin(async move {
             match self {
                 IO::Http { req_template, dl_id, .. } => {
-                    let req = req_template.to_request(ctx)?;
+                    let req = req_template.to_request(&ctx)?;
                     let is_get = req.method() == reqwest::Method::GET;
 
                     let res = if is_get && ctx.req_ctx.is_batching_enabled() {
                         let data_loader: Option<&DataLoader<DataLoaderRequest, HttpDataLoader>> =
                             dl_id.and_then(|index| ctx.req_ctx.http_data_loaders.get(index.0));
-                        execute_request_with_dl(ctx, req, data_loader).await?
+                        execute_request_with_dl(&ctx, req, data_loader).await?
                     } else {
-                        execute_raw_request(ctx, req).await?
+                        execute_raw_request(&ctx, req).await?
                     };
 
                     if ctx.req_ctx.server.get_enable_http_validation() {
@@ -73,28 +73,28 @@ impl Eval for IO {
                             .map_err(EvaluationError::from)?;
                     }
 
-                    set_headers(ctx, &res);
+                    set_headers(&ctx, &res);
 
                     Ok(res.body)
                 }
                 IO::GraphQL { req_template, field_name, dl_id, .. } => {
-                    let req = req_template.to_request(ctx)?;
+                    let req = req_template.to_request(&ctx)?;
 
                     let res = if ctx.req_ctx.upstream.batch.is_some()
                         && matches!(req_template.operation_type, GraphQLOperationType::Query)
                     {
                         let data_loader: Option<&DataLoader<DataLoaderRequest, GraphqlDataLoader>> =
                             dl_id.and_then(|index| ctx.req_ctx.gql_data_loaders.get(index.0));
-                        execute_request_with_dl(ctx, req, data_loader).await?
+                        execute_request_with_dl(&ctx, req, data_loader).await?
                     } else {
-                        execute_raw_request(ctx, req).await?
+                        execute_raw_request(&ctx, req).await?
                     };
 
-                    set_headers(ctx, &res);
-                    parse_graphql_response(ctx, res, field_name)
+                    set_headers(&ctx, &res);
+                    parse_graphql_response(&ctx, res, field_name)
                 }
                 IO::Grpc { req_template, dl_id, .. } => {
-                    let rendered = req_template.render(ctx)?;
+                    let rendered = req_template.render(&ctx)?;
 
                     let res = if ctx.req_ctx.upstream.batch.is_some() &&
                     // TODO: share check for operation_type for resolvers
@@ -103,13 +103,13 @@ impl Eval for IO {
                         let data_loader: Option<
                             &DataLoader<grpc::DataLoaderRequest, GrpcDataLoader>,
                         > = dl_id.and_then(|index| ctx.req_ctx.grpc_data_loaders.get(index.0));
-                        execute_grpc_request_with_dl(ctx, rendered, data_loader).await?
+                        execute_grpc_request_with_dl(&ctx, rendered, data_loader).await?
                     } else {
                         let req = rendered.to_request()?;
-                        execute_raw_grpc_request(ctx, req, &req_template.operation).await?
+                        execute_raw_grpc_request(&ctx, req, &req_template.operation).await?
                     };
 
-                    set_headers(ctx, &res);
+                    set_headers(&ctx, &res);
 
                     Ok(res.body)
                 }

--- a/src/lambda/math.rs
+++ b/src/lambda/math.rs
@@ -27,13 +27,13 @@ pub enum Math {
 impl Eval for Math {
     fn eval<'a, Ctx: ResolverContextLike<'a> + Sync + Send>(
         &'a self,
-        ctx: &'a EvaluationContext<'a, Ctx>,
+        ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
     ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
         Box::pin(async move {
             Ok(match self {
                 Math::Mod(lhs, rhs) => {
-                    let lhs = lhs.eval(ctx, conc).await?;
+                    let lhs = lhs.eval(ctx.clone(), conc).await?;
                     let rhs = rhs.eval(ctx, conc).await?;
 
                     try_i64_operation(&lhs, &rhs, ops::Rem::rem)
@@ -41,7 +41,7 @@ impl Eval for Math {
                         .ok_or(EvaluationError::ExprEvalError("mod".into()))?
                 }
                 Math::Add(lhs, rhs) => {
-                    let lhs = lhs.eval(ctx, conc).await?;
+                    let lhs = lhs.eval(ctx.clone(), conc).await?;
                     let rhs = rhs.eval(ctx, conc).await?;
 
                     try_f64_operation(&lhs, &rhs, ops::Add::add)
@@ -60,7 +60,7 @@ impl Eval for Math {
                         .ok_or(EvaluationError::ExprEvalError("dec".into()))?
                 }
                 Math::Divide(lhs, rhs) => {
-                    let lhs = lhs.eval(ctx, conc).await?;
+                    let lhs = lhs.eval(ctx.clone(), conc).await?;
                     let rhs = rhs.eval(ctx, conc).await?;
 
                     try_f64_operation(&lhs, &rhs, ops::Div::div)
@@ -79,7 +79,7 @@ impl Eval for Math {
                         .ok_or(EvaluationError::ExprEvalError("dec".into()))?
                 }
                 Math::Multiply(lhs, rhs) => {
-                    let lhs = lhs.eval(ctx, conc).await?;
+                    let lhs = lhs.eval(ctx.clone(), conc).await?;
                     let rhs = rhs.eval(ctx, conc).await?;
 
                     try_f64_operation(&lhs, &rhs, ops::Mul::mul)
@@ -107,7 +107,7 @@ impl Eval for Math {
                     })?
                 }
                 Math::Subtract(lhs, rhs) => {
-                    let lhs = lhs.eval(ctx, conc).await?;
+                    let lhs = lhs.eval(ctx.clone(), conc).await?;
                     let rhs = rhs.eval(ctx, conc).await?;
 
                     try_f64_operation(&lhs, &rhs, ops::Sub::sub)

--- a/src/lambda/mod.rs
+++ b/src/lambda/mod.rs
@@ -23,4 +23,4 @@ pub use list::*;
 pub use logic::*;
 pub use math::*;
 pub use relation::*;
-pub use resolver_context_like::{EmptyResolverContext, ResolverContextLike};
+pub use resolver_context_like::{EmptyResolverContext, ResolverContext, ResolverContextLike};

--- a/src/lambda/resolver_context_like.rs
+++ b/src/lambda/resolver_context_like.rs
@@ -1,15 +1,17 @@
+use std::sync::Arc;
+
 use async_graphql::context::SelectionField;
-use async_graphql::dynamic::ResolverContext;
 use async_graphql::{Name, ServerError, Value};
 use indexmap::IndexMap;
 
-pub trait ResolverContextLike<'a> {
+pub trait ResolverContextLike<'a>: Clone {
     fn value(&'a self) -> Option<&'a Value>;
     fn args(&'a self) -> Option<&'a IndexMap<Name, Value>>;
     fn field(&'a self) -> Option<SelectionField>;
     fn add_error(&'a self, error: ServerError);
 }
 
+#[derive(Clone)]
 pub struct EmptyResolverContext;
 
 impl<'a> ResolverContextLike<'a> for EmptyResolverContext {
@@ -28,20 +30,31 @@ impl<'a> ResolverContextLike<'a> for EmptyResolverContext {
     fn add_error(&'a self, _: ServerError) {}
 }
 
+#[derive(Clone)]
+pub struct ResolverContext<'a> {
+    inner: Arc<async_graphql::dynamic::ResolverContext<'a>>,
+}
+
+impl<'a> From<async_graphql::dynamic::ResolverContext<'a>> for ResolverContext<'a> {
+    fn from(value: async_graphql::dynamic::ResolverContext<'a>) -> Self {
+        ResolverContext { inner: Arc::new(value) }
+    }
+}
+
 impl<'a> ResolverContextLike<'a> for ResolverContext<'a> {
     fn value(&'a self) -> Option<&'a Value> {
-        self.parent_value.as_value()
+        self.inner.parent_value.as_value()
     }
 
     fn args(&'a self) -> Option<&'a IndexMap<Name, Value>> {
-        Some(self.args.as_index_map())
+        Some(self.inner.args.as_index_map())
     }
 
     fn field(&'a self) -> Option<SelectionField> {
-        Some(self.ctx.field())
+        Some(self.inner.ctx.field())
     }
 
     fn add_error(&'a self, error: ServerError) {
-        self.ctx.add_error(error)
+        self.inner.ctx.add_error(error)
     }
 }


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.
- [ ] add unit tests for `graphql_ctx_value` and `graphql_ctx_args`

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced a new `ResolverContext` for improved field resolution logic.
    - Added functionality to handle evaluation contexts more flexibly with new methods and fields.
    - Enhanced expression evaluation with new enum variants for argument and value manipulation.
- **Refactor**
    - Updated various modules (e.g., `lambda`, `math`, `logic`, `list`) to improve context handling by cloning and passing by value.
    - Modified function signatures and call patterns across several modules for consistency in context passing.
    - Simplified the `EvaluationContext` structure and improved its initialization process.
- **Bug Fixes**
    - Fixed potential issues with context ownership and borrowing in the evaluation process across numerous modules.
- **Documentation**
    - Added minor TODO comments for future improvements in handling evaluation contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->