### PR TITLE
chore: add `new` method to `RequestContext`

### DIFF
--- a/benches/impl_path_string_for_evaluation_context.rs
+++ b/benches/impl_path_string_for_evaluation_context.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_graphql::context::SelectionField;
@@ -247,19 +247,9 @@ fn request_context() -> RequestContext {
         cache: Arc::new(InMemoryCache::new()),
         extensions: Arc::new(vec![]),
     };
-    RequestContext {
-        req_headers: HeaderMap::new(),
-        experimental_headers: HeaderMap::new(),
-        cookie_headers: None,
-        server,
-        upstream,
-        http_data_loaders: Arc::new(vec![]),
-        gql_data_loaders: Arc::new(vec![]),
-        grpc_data_loaders: Arc::new(vec![]),
-        min_max_age: Arc::new(Mutex::new(None)),
-        cache_public: Arc::new(Mutex::new(None)),
-        runtime,
-    }
+    RequestContext::new(runtime)
+        .server(server)
+        .upstream(upstream)
 }
 
 fn bench_main(c: &mut Criterion) {

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -31,6 +31,17 @@ pub struct RequestContext {
 }
 
 impl RequestContext {
+    pub fn new(target_runtime: TargetRuntime) -> RequestContext {
+        RequestContext {
+            http_data_loaders: Arc::new(vec![]),
+            gql_data_loaders: Arc::new(vec![]),
+            grpc_data_loaders: Arc::new(vec![]),
+            min_max_age: Arc::new(Mutex::new(None)),
+            cache_public: Arc::new(Mutex::new(None)),
+            runtime: target_runtime,
+            ..Default::default()
+        }
+    }
     fn set_min_max_age_conc(&self, min_max_age: i32) {
         *self.min_max_age.lock().unwrap() = Some(min_max_age);
     }

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -33,13 +33,17 @@ pub struct RequestContext {
 impl RequestContext {
     pub fn new(target_runtime: TargetRuntime) -> RequestContext {
         RequestContext {
+            server: Default::default(),
+            upstream: Default::default(),
+            req_headers: HeaderMap::new(),
+            experimental_headers: HeaderMap::new(),
+            cookie_headers: None,
             http_data_loaders: Arc::new(vec![]),
             gql_data_loaders: Arc::new(vec![]),
             grpc_data_loaders: Arc::new(vec![]),
             min_max_age: Arc::new(Mutex::new(None)),
             cache_public: Arc::new(Mutex::new(None)),
             runtime: target_runtime,
-            ..Default::default()
         }
     }
     fn set_min_max_age_conc(&self, min_max_age: i32) {
@@ -165,10 +169,7 @@ impl From<&AppContext> for RequestContext {
 
 #[cfg(test)]
 mod test {
-    use std::sync::{Arc, Mutex};
-
     use cache_control::Cachability;
-    use hyper::HeaderMap;
 
     use crate::blueprint::{Server, Upstream};
     use crate::config::{self, Batch};
@@ -181,19 +182,9 @@ mod test {
             let crate::config::Config { upstream, .. } = config_module.config.clone();
             let server = Server::try_from(config_module).unwrap();
             let upstream = Upstream::try_from(upstream).unwrap();
-            RequestContext {
-                req_headers: HeaderMap::new(),
-                experimental_headers: HeaderMap::new(),
-                cookie_headers: None,
-                server,
-                runtime: crate::runtime::test::init(None),
-                upstream,
-                http_data_loaders: Arc::new(vec![]),
-                gql_data_loaders: Arc::new(vec![]),
-                grpc_data_loaders: Arc::new(vec![]),
-                min_max_age: Arc::new(Mutex::new(None)),
-                cache_public: Arc::new(Mutex::new(None)),
-            }
+            RequestContext::new(crate::runtime::test::init(None))
+                .upstream(upstream)
+                .server(server)
         }
     }
 

--- a/src/rest/endpoint_set.rs
+++ b/src/rest/endpoint_set.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use super::endpoint::Endpoint;
 use super::partial_request::PartialRequest;
@@ -58,19 +58,7 @@ impl EndpointSet<Unchecked> {
     ) -> anyhow::Result<EndpointSet<Checked>> {
         let mut operations = vec![];
 
-        let req_ctx = RequestContext {
-            server: Default::default(),
-            upstream: Default::default(),
-            req_headers: Default::default(),
-            experimental_headers: Default::default(),
-            cookie_headers: None,
-            http_data_loaders: Arc::new(vec![]),
-            gql_data_loaders: Arc::new(vec![]),
-            grpc_data_loaders: Arc::new(vec![]),
-            min_max_age: Arc::new(Mutex::new(None)),
-            cache_public: Arc::new(Mutex::new(None)),
-            runtime: target_runtime,
-        };
+        let req_ctx = RequestContext::new(target_runtime);
         let req_ctx = Arc::new(req_ctx);
 
         for endpoint in self.endpoints.iter() {


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1463
/claim 1463

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced request handling capabilities with the initialization of additional fields in the `RequestContext`.
    - Refactored `RequestContext` initialization in the `EndpointSet` implementation for a simplified process.
    - Modified `RequestContext` struct initialization to use a builder pattern for setting specific fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->