### PR TITLE
test: add tests for `and_then`

### DIFF
--- a/src/blueprint/dynamic_value.rs
+++ b/src/blueprint/dynamic_value.rs
@@ -19,7 +19,7 @@ impl TryFrom<&DynamicValue> for ConstValue {
         match value {
             DynamicValue::Value(v) => Ok(v.to_owned()),
             DynamicValue::Mustache(_) => Err(anyhow::anyhow!(
-                "mustache cannot be converted to const value at compiletime"
+                "mustache cannot be converted to const value"
             )),
             DynamicValue::Object(obj) => {
                 let out: Result<IndexMap<Name, ConstValue>, anyhow::Error> = obj

--- a/src/lambda/mod.rs
+++ b/src/lambda/mod.rs
@@ -16,7 +16,7 @@ pub use cache::*;
 pub use concurrent::*;
 pub use eval::*;
 pub use evaluation_context::EvaluationContext;
-pub(crate) use expression::*;
+pub use expression::*;
 pub use graphql_operation_context::GraphQLOperationContext;
 pub use io::*;
 pub use list::*;

--- a/tests/expression_spec.rs
+++ b/tests/expression_spec.rs
@@ -1,13 +1,10 @@
 use async_graphql::Value;
 use pretty_assertions::assert_eq;
 use serde_json::json;
-
-use tailcall::{
-    blueprint::{DynamicValue, Upstream},
-    http::RequestContext,
-    lambda::{Concurrent, EmptyResolverContext, Eval, EvaluationContext, Expression},
-    mustache::Mustache,
-};
+use tailcall::blueprint::{DynamicValue, Upstream};
+use tailcall::http::RequestContext;
+use tailcall::lambda::{Concurrent, EmptyResolverContext, Eval, EvaluationContext, Expression};
+use tailcall::mustache::Mustache;
 
 async fn eval(expr: &Expression) -> anyhow::Result<Value> {
     let runtime = tailcall::cli::runtime::init(&Upstream::default(), None);

--- a/tests/expression_spec.rs
+++ b/tests/expression_spec.rs
@@ -1,0 +1,41 @@
+use async_graphql::Value;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use tailcall::{
+    blueprint::{DynamicValue, Upstream},
+    http::RequestContext,
+    lambda::{Concurrent, EmptyResolverContext, Eval, EvaluationContext, Expression},
+    mustache::Mustache,
+};
+
+async fn eval(expr: &Expression) -> anyhow::Result<Value> {
+    let runtime = tailcall::cli::runtime::init(&Upstream::default(), None);
+    let req_ctx = RequestContext::new(runtime);
+    let res_ctx = EmptyResolverContext {};
+    let eval_ctx = EvaluationContext::new(&req_ctx, &res_ctx);
+    expr.eval(eval_ctx, &Concurrent::Parallel).await
+}
+
+#[tokio::test]
+async fn test_no_key() {
+    let abcde = DynamicValue::try_from(&json!({"a": {"b": {"c": {"d": "e"}}}})).unwrap();
+    let expr = Expression::Literal(abcde)
+        .and_then(Expression::Literal(DynamicValue::Mustache(
+            Mustache::parse("{{value.a}}").unwrap(),
+        )))
+        .and_then(Expression::Literal(DynamicValue::Mustache(
+            Mustache::parse("{{value.b}}").unwrap(),
+        )))
+        .and_then(Expression::Literal(DynamicValue::Mustache(
+            Mustache::parse("{{value.c}}").unwrap(),
+        )))
+        .and_then(Expression::Literal(DynamicValue::Mustache(
+            Mustache::parse("{{value.d}}").unwrap(),
+        )));
+
+    let actual = eval(&expr).await.unwrap();
+    let expected = Value::from_json(json!("e")).unwrap();
+
+    assert_eq!(actual, expected);
+}

--- a/tests/server_spec.rs
+++ b/tests/server_spec.rs
@@ -1,3 +1,5 @@
+mod expression_spec;
+
 use tailcall::{blueprint, EnvIO, FileIO, HttpIO};
 
 #[cfg(test)]

--- a/tests/server_spec.rs
+++ b/tests/server_spec.rs
@@ -1,5 +1,3 @@
-mod expression_spec;
-
 use tailcall::{blueprint, EnvIO, FileIO, HttpIO};
 
 #[cfg(test)]


### PR DESCRIPTION
fixes #1473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved clarity of error messages related to type conversion.
	- Enhanced the accessibility of the `expression` module for external use.
- **Tests**
	- Added a test case for evaluating expressions and extracting nested values from JSON objects.
	- Integrated `expression_spec` tests into the server testing suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->