### PR TITLE
fix: tailcall panics on SchemaError

### DIFF
--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -122,13 +122,13 @@ impl TryFrom<&ConfigModule> for Blueprint {
     type Error = ValidationError<String>;
 
     fn try_from(config_module: &ConfigModule) -> Result<Self, Self::Error> {
-        let blueprint = config_blueprint()
-            .try_fold(config_module, Blueprint::default())
-            .to_result()?;
-        let schema_builder = SchemaBuilder::from(&blueprint);
-        let _ = schema_builder
-            .finish()
-            .map_err(|e| ValidationError::new(e.to_string()))?;
-        Ok(blueprint)
+        config_blueprint()
+            .try_fold(config_module, Blueprint::default()).and_then(|blueprint| {
+            let schema_builder = SchemaBuilder::from(&blueprint);
+            match schema_builder.finish() {
+                Ok(_) => Valid::succeed(blueprint),
+                Err(e) => Valid::fail(e.to_string()),
+            }
+        }).to_result()
     }
 }

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+
 use async_graphql::dynamic::SchemaBuilder;
 
 use self::telemetry::to_opentelemetry;
@@ -123,12 +124,14 @@ impl TryFrom<&ConfigModule> for Blueprint {
 
     fn try_from(config_module: &ConfigModule) -> Result<Self, Self::Error> {
         config_blueprint()
-            .try_fold(config_module, Blueprint::default()).and_then(|blueprint| {
-            let schema_builder = SchemaBuilder::from(&blueprint);
-            match schema_builder.finish() {
-                Ok(_) => Valid::succeed(blueprint),
-                Err(e) => Valid::fail(e.to_string()),
-            }
-        }).to_result()
+            .try_fold(config_module, Blueprint::default())
+            .and_then(|blueprint| {
+                let schema_builder = SchemaBuilder::from(&blueprint);
+                match schema_builder.finish() {
+                    Ok(_) => Valid::succeed(blueprint),
+                    Err(e) => Valid::fail(e.to_string()),
+                }
+            })
+            .to_result()
     }
 }


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1478
/claim 1478

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved error handling across various components, including AWS Lambda Rust code, application context initialization, schema creation, server configuration, and schema validation in operations.
	- Enhanced error reporting in schema validation and operations, ensuring more robust application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->