### PR TITLE
fix: use `args` instead of `value` to compose expressions

### DIFF
--- a/src/lambda/expression.rs
+++ b/src/lambda/expression.rs
@@ -107,7 +107,7 @@ impl Expression {
     }
 
     pub fn and_then(self, next: Self) -> Self {
-        Expression::Context(Context::PushValue { expr: Box::new(self), and_then: Box::new(next) })
+        Expression::Context(Context::PushArgs { expr: Box::new(self), and_then: Box::new(next) })
     }
 }
 

--- a/tests/expression_spec.rs
+++ b/tests/expression_spec.rs
@@ -19,16 +19,16 @@ async fn test_no_key() {
     let abcde = DynamicValue::try_from(&json!({"a": {"b": {"c": {"d": "e"}}}})).unwrap();
     let expr = Expression::Literal(abcde)
         .and_then(Expression::Literal(DynamicValue::Mustache(
-            Mustache::parse("{{value.a}}").unwrap(),
+            Mustache::parse("{{args.a}}").unwrap(),
         )))
         .and_then(Expression::Literal(DynamicValue::Mustache(
-            Mustache::parse("{{value.b}}").unwrap(),
+            Mustache::parse("{{args.b}}").unwrap(),
         )))
         .and_then(Expression::Literal(DynamicValue::Mustache(
-            Mustache::parse("{{value.c}}").unwrap(),
+            Mustache::parse("{{args.c}}").unwrap(),
         )))
         .and_then(Expression::Literal(DynamicValue::Mustache(
-            Mustache::parse("{{value.d}}").unwrap(),
+            Mustache::parse("{{args.d}}").unwrap(),
         )));
 
     let actual = eval(&expr).await.unwrap();


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1481
/claim 1481

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated argument pushing behavior in expressions.
- **Tests**
	- Adjusted Mustache template keys in expression evaluations tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->