### PR TITLE
refactor: add `Expression::with_args`

### DIFF
--- a/src/lambda/expression.rs
+++ b/src/lambda/expression.rs
@@ -109,6 +109,10 @@ impl Expression {
     pub fn and_then(self, next: Self) -> Self {
         Expression::Context(Context::PushArgs { expr: Box::new(self), and_then: Box::new(next) })
     }
+
+    pub fn with_args(self, args: Expression) -> Self {
+        Expression::Context(Context::PushArgs { expr: Box::new(args), and_then: Box::new(self) })
+    }
 }
 
 impl Eval for Expression {

--- a/tests/expression_spec.rs
+++ b/tests/expression_spec.rs
@@ -15,7 +15,7 @@ async fn eval(expr: &Expression) -> anyhow::Result<Value> {
 }
 
 #[tokio::test]
-async fn test_no_key() {
+async fn test_and_then() {
     let abcde = DynamicValue::try_from(&json!({"a": {"b": {"c": {"d": "e"}}}})).unwrap();
     let expr = Expression::Literal(abcde)
         .and_then(Expression::Literal(DynamicValue::Mustache(
@@ -30,6 +30,23 @@ async fn test_no_key() {
         .and_then(Expression::Literal(DynamicValue::Mustache(
             Mustache::parse("{{args.d}}").unwrap(),
         )));
+
+    let actual = eval(&expr).await.unwrap();
+    let expected = Value::from_json(json!("e")).unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn test_with_args() {
+    let args = Expression::Literal(
+        DynamicValue::try_from(&json!({"a": {"b": {"c": {"d": "e"}}}})).unwrap(),
+    );
+
+    let expr = Expression::Literal(DynamicValue::Mustache(
+        Mustache::parse("{{args.a.b.c.d}}").unwrap(),
+    ))
+    .with_args(args);
 
     let actual = eval(&expr).await.unwrap();
     let expected = Value::from_json(json!("e")).unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to modify expressions with arguments, enhancing expression evaluation capabilities.
- **Tests**
	- Renamed and added test functions for improved coverage and clarity in expression evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->