### PR TITLE
fix: Upstream URL to error propagation

### DIFF
--- a/aws-lambda/src/http.rs
+++ b/aws-lambda/src/http.rs
@@ -28,7 +28,12 @@ impl LambdaHttp {
 impl HttpIO for LambdaHttp {
     async fn execute(&self, request: reqwest::Request) -> Result<Response<Bytes>> {
         let req_str = format!("{} {}", request.method(), request.url());
-        let response = self.client.execute(request).await?.error_for_status()?;
+        let response = self
+            .client
+            .execute(request)
+            .await?
+            .error_for_status()
+            .map_err(|err| err.without_url())?;
         let res = Response::from_reqwest(response).await?;
         tracing::info!("{} {}", req_str, res.status.as_u16());
         Ok(res)

--- a/cloudflare/src/http.rs
+++ b/cloudflare/src/http.rs
@@ -35,7 +35,11 @@ impl HttpIO for CloudflareHttp {
         let url = request.url().clone();
         // TODO: remove spawn local
         let res = spawn_local(async move {
-            let response = client.execute(request).await?.error_for_status()?;
+            let response = client
+                .execute(request)
+                .await?
+                .error_for_status()
+                .map_err(|err| err.without_url())?;
             Response::from_reqwest(response).await
         })
         .await?;

--- a/src/cli/runtime/http.rs
+++ b/src/cli/runtime/http.rs
@@ -79,7 +79,12 @@ impl HttpIO for NativeHttp {
         tracing::debug!("request: {:?}", request);
         let response = self.client.execute(request).await;
         tracing::debug!("response: {:?}", response);
-        Ok(Response::from_reqwest(response?.error_for_status()?).await?)
+        Ok(Response::from_reqwest(
+            response?
+                .error_for_status()
+                .map_err(|err| err.without_url())?,
+        )
+        .await?)
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -108,7 +108,12 @@ pub mod test {
     impl HttpIO for TestHttp {
         async fn execute(&self, request: reqwest::Request) -> Result<Response<Bytes>> {
             let response = self.client.execute(request).await;
-            Response::from_reqwest(response?.error_for_status()?).await
+            Response::from_reqwest(
+                response?
+                    .error_for_status()
+                    .map_err(|err| err.without_url())?,
+            )
+            .await
         }
     }
 

--- a/tests/execution_spec.rs
+++ b/tests/execution_spec.rs
@@ -110,7 +110,12 @@ pub mod test {
     impl HttpIO for TestHttp {
         async fn execute(&self, request: reqwest::Request) -> Result<Response<Bytes>> {
             let response = self.client.execute(request).await;
-            Response::from_reqwest(response?.error_for_status()?).await
+            Response::from_reqwest(
+                response?
+                    .error_for_status()
+                    .map_err(|err| err.without_url())?,
+            )
+            .await
         }
     }
 

--- a/tests/server_spec.rs
+++ b/tests/server_spec.rs
@@ -74,7 +74,12 @@ pub mod test {
     impl HttpIO for TestHttp {
         async fn execute(&self, request: reqwest::Request) -> Result<Response<Bytes>> {
             let response = self.client.execute(request).await;
-            Response::from_reqwest(response?.error_for_status()?).await
+            Response::from_reqwest(
+                response?
+                    .error_for_status()
+                    .map_err(|err| err.without_url())?,
+            )
+            .await
         }
     }
 


### PR DESCRIPTION
**Summary:**  
There is a problem: when a request to upstream fails, `reqwest` raises an error that contains the upstream URL.
It is not secure behavior, because graphql end-user shouldn't know details about upstream URLs/methods and these URLs can also contain tokens/private intranet service information

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced error handling across various HTTP implementations to improve privacy by removing URLs from error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->