### PR TITLE
fix: `JsRequest` body as string

### DIFF
--- a/src/cli/javascript/js_request.rs
+++ b/src/cli/javascript/js_request.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Display;
 
-use hyper::body::Bytes;
 use serde::{Deserialize, Serialize};
 
 use super::create_header_map;
@@ -14,7 +13,7 @@ pub struct JsRequest {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     headers: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "is_default")]
-    body: Option<Bytes>,
+    body: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq)]
@@ -138,7 +137,7 @@ mod tests {
             uri: Uri::parse("http://example.com/").unwrap(),
             method: "GET".to_string(),
             headers,
-            body: Some(Bytes::from(body)),
+            body: Some(body.to_string()),
         };
         let reqwest_request: reqwest::Request = js_request.try_into().unwrap();
         assert_eq!(reqwest_request.method(), reqwest::Method::GET);


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1493


**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Updated the request body handling in JavaScript requests to improve performance and compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->