### PR TITLE
feat: GRPC status details + scoped references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
  "async-graphql-value",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "fast_chemail",
@@ -578,7 +578,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598e2ade8447dce8d3a15b6159b73354db34257851344b232fb1920c272acc61"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -653,6 +653,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64-simd"
@@ -2226,7 +2232,7 @@ dependencies = [
  "async-object-pool",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -2592,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8fafd7a4ce0bc6093cf1bed3dcdfc1239c27df1e79e3f2154f4d3299d4f60e"
 dependencies = [
  "aws_lambda_events",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures",
@@ -2619,7 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2904c10fbeaf07aa317fc96a0e28e89c80ed12f7949ed06afd7869b21fef32"
 dependencies = [
  "async-stream",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "futures",
  "http 1.1.0",
@@ -3784,7 +3790,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9372e3227f3685376a0836e5c248611eafc95a0be900d44bc6cdf225b700f"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "logos",
  "miette",
  "once_cell",
@@ -4089,7 +4095,7 @@ version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4276,7 +4282,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4285,7 +4291,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "rustls-pki-types",
 ]
 
@@ -4924,6 +4930,7 @@ dependencies = [
  "async-recursion",
  "async-std",
  "async-trait",
+ "base64 0.22.0",
  "cache_control",
  "chrono",
  "clap",
@@ -5248,7 +5255,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "h2",
  "http 0.2.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ opentelemetry-prometheus = "0.15.0"
 phonenumber = "0.3.3"
 chrono = "0.4.35"
 async-graphql-extension-apollo-tracing = { git = "https://github.com/tailcallhq/async_graphql_apollo_studio_extension/" }
+base64 = "0.22.0"
 
 [patch.crates-io]
 async-graphql-value = {git ="https://github.com/tailcallhq/async-graphql.git", branch = "add-setter"}

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -122,6 +122,11 @@ directive @grpc(
   """
   body: String
   """
+  This refers to the gRPC message you're going to use for decoding grpc-status-details-bin. 
+  For instance `google.rpc.Status`.
+  """
+  errorMessage: String
+  """
   The `headers` parameter allows you to customize the headers of the HTTP request made 
   by the `@grpc` operator. It is used by specifying a key-value map of header names 
   and their values. Note: content-type is automatically set to application/grpc
@@ -582,6 +587,11 @@ input Grpc {
   the body in `protobuf` format.
   """
   body: String
+  """
+  This refers to the gRPC message you're going to use for decoding grpc-status-details-bin. 
+  For instance `google.rpc.Status`.
+  """
+  errorMessage: String
   """
   The `headers` parameter allows you to customize the headers of the HTTP request made 
   by the `@grpc` operator. It is used by specifying a key-value map of header names 

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1225,6 +1225,13 @@
             "null"
           ]
         },
+        "errorMessage": {
+          "description": "This refers to the gRPC message you're going to use for decoding grpc-status-details-bin. For instance `google.rpc.Status`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "headers": {
           "description": "The `headers` parameter allows you to customize the headers of the HTTP request made by the `@grpc` operator. It is used by specifying a key-value map of header names and their values. Note: content-type is automatically set to application/grpc",
           "type": "array",

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -84,6 +84,7 @@ impl AppContext {
                                     let data_loader = GrpcDataLoader {
                                         runtime: runtime.clone(),
                                         operation: req_template.operation.clone(),
+                                        status_details: req_template.status_details.clone(),
                                         group_by: group_by.clone(),
                                     };
                                     let data_loader = data_loader

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -650,6 +650,10 @@ pub struct Grpc {
     /// This refers to the gRPC method you're going to call. For instance
     /// `GetAllNews`.
     pub method: String,
+    #[serde(default, skip_serializing_if = "is_default")]
+    /// This refers to the gRPC message you're going to use for decoding
+    /// grpc-status-details-bin. For instance `google.rpc.Status`.
+    pub error_message: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, schemars::JsonSchema)]

--- a/src/grpc/data_loader_request.rs
+++ b/src/grpc/data_loader_request.rs
@@ -61,7 +61,7 @@ mod tests {
     use url::Url;
 
     use super::DataLoaderRequest;
-    use crate::blueprint::GrpcMethod;
+    use crate::blueprint::{GrpcMethod, Scope};
     use crate::config::reader::ConfigReader;
     use crate::config::{Config, Field, Grpc, Link, LinkType, Type};
     use crate::grpc::protobuf::{ProtobufOperation, ProtobufSet};
@@ -81,6 +81,7 @@ mod tests {
             type_of: LinkType::Protobuf,
         }]);
         let method = GrpcMethod {
+            scope: Scope::Default,
             package: "greetings".to_string(),
             service: "Greeter".to_string(),
             name: "SayHello".to_string(),
@@ -98,7 +99,7 @@ mod tests {
         let protobuf_set = ProtobufSet::from_proto_file(
             config_module
                 .extensions
-                .get_file_descriptor_set(&method)
+                .get_file_descriptor_set(&method.scope)
                 .unwrap(),
         )
         .unwrap();

--- a/src/grpc/request_template.rs
+++ b/src/grpc/request_template.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::request::create_grpc_request;
 use crate::config::GraphQLOperationType;
-use crate::grpc::protobuf::ProtobufOperation;
+use crate::grpc::protobuf::{ProtobufMessage, ProtobufOperation};
 use crate::has_headers::HasHeaders;
 use crate::helpers::headers::MustacheHeaders;
 use crate::lambda::CacheKey;
@@ -26,6 +26,7 @@ pub struct RequestTemplate {
     pub body: Option<Mustache>,
     pub operation: ProtobufOperation,
     pub operation_type: GraphQLOperationType,
+    pub status_details: Option<ProtobufMessage>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -127,7 +128,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::RequestTemplate;
-    use crate::blueprint::GrpcMethod;
+    use crate::blueprint::{GrpcMethod, Scope};
     use crate::config::reader::ConfigReader;
     use crate::config::{Config, Field, GraphQLOperationType, Grpc, Link, LinkType, Type};
     use crate::grpc::protobuf::{ProtobufOperation, ProtobufSet};
@@ -153,6 +154,7 @@ mod tests {
             type_of: LinkType::Protobuf,
         }]);
         let method = GrpcMethod {
+            scope: Scope::Default,
             package: id.to_string(),
             service: "a".to_string(),
             name: "b".to_string(),
@@ -169,7 +171,7 @@ mod tests {
                 .await
                 .unwrap()
                 .extensions
-                .get_file_descriptor_set(&method)
+                .get_file_descriptor_set(&method.scope)
                 .unwrap(),
         )
         .unwrap();
@@ -213,6 +215,7 @@ mod tests {
                 Mustache::parse("value").unwrap(),
             )],
             operation: get_protobuf_op().await,
+            status_details: None,
             body: None,
             operation_type: GraphQLOperationType::Query,
         };
@@ -249,6 +252,7 @@ mod tests {
             operation: get_protobuf_op().await,
             body: Some(Mustache::parse(r#"{ "name": "test" }"#).unwrap()),
             operation_type: GraphQLOperationType::Query,
+            status_details: None,
         };
         let ctx = Context::default();
         let rendered = tmpl.render(&ctx).unwrap();
@@ -266,6 +270,7 @@ mod tests {
             operation: get_protobuf_op().await,
             body: Some(Mustache::parse(body_str).unwrap()),
             operation_type: GraphQLOperationType::Query,
+            status_details: None,
         }
     }
 

--- a/src/lambda/expression.rs
+++ b/src/lambda/expression.rs
@@ -63,7 +63,7 @@ pub enum Context {
 
 #[derive(Debug, Error)]
 pub enum EvaluationError {
-    #[error("IOException: {0}")]
+    #[error("{0}")]
     IOException(String),
 
     #[error("APIValidationError: {0:?}")]


### PR DESCRIPTION
I'd like to share the draft of a pull request to understand what improvements can be made.
**Summary:**  

1. Error handling for gRPC upstream has been added. Now GraphQL will return `grpc-status`, `grpc-message`, and `grpc-status-details`.
2. An `errorMessage` option has been added to `@grpc`, necessary to specify the type returned by the upstream in `grpc-status-details-bin`.
3. The error is duplicated in `errors.message` and `errors.extensions`, but only if it can be represented as JSON. Here, a problem arose because errors are propagated through anyhow, and I couldn't immediately figure out how to gracefully add an extension to the error through `async_graphql`. Thus, this led to some amount of not-so-pretty code.
4. I've reworked the search for protofile descriptors. Now, they are collected within a scope defined by `@link.id` and used through `scope:package.Service.Name`. This was necessary because BFS through dependencies didn't work when the field type is `Any`, hence the need to fill the scope with the required types.

Currently, several tests are failing, but I'll figure out the issue and fix it.

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gRPC error handling with the addition of `errorMessage` field for detailed error messages.
	- Improved organization and retrieval of gRPC file descriptors using a `BTreeMap` based on `Scope`.
	- Added support for decoding gRPC status details, enhancing error diagnostics.
- **Bug Fixes**
	- Refined error message formatting in lambda expressions, removing specific error type prefixes for clearer communication.
- **Refactor**
	- Upgraded data loading structures to include status details for better error handling.
	- Modified request execution to handle new `status_details` parameter, improving error detail capture during gRPC requests.
- **Documentation**
	- Updated schema and configuration documentation to reflect new error handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->