### PR TITLE
fix(grpc): schema validation for fields in snake_case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4941,6 +4950,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "convert_case",
  "criterion",
  "deno_core",
  "derive_setters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ async-graphql = { version = "7.0.3", features = [
     "apollo_tracing",
     "opentelemetry",
 ]}
+convert_case = "0.6.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/grpc/protobuf.rs
+++ b/src/grpc/protobuf.rs
@@ -201,7 +201,7 @@ impl ProtobufOperation {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     // TODO: Rewrite protobuf tests
     use std::path::PathBuf;
 
@@ -232,7 +232,7 @@ mod tests {
         test_file
     }
 
-    async fn get_proto_file(name: &str) -> Result<FileDescriptorSet> {
+    pub async fn get_proto_file(name: &str) -> Result<FileDescriptorSet> {
         let runtime = crate::runtime::test::init(None);
         let reader = ConfigReader::init(runtime);
 

--- a/src/grpc/tests/proto/news.proto
+++ b/src/grpc/tests/proto/news.proto
@@ -8,7 +8,7 @@ message News {
     int32 id = 1;
     string title = 2;
     string body = 3;
-    string postImage = 4;
+    string post_image = 4;
 }
 
 service NewsService {

--- a/src/grpc/tests/proto/news_no_pkg.proto
+++ b/src/grpc/tests/proto/news_no_pkg.proto
@@ -6,7 +6,7 @@ message News {
   int32 id = 1;
   string title = 2;
   string body = 3;
-  string postImage = 4;
+  string post_image = 4;
 }
 
 service NewsService {


### PR DESCRIPTION
**Summary:**  
Following by [grpc style guide](https://protobuf.dev/programming-guides/style/#message_and_field_names) fields should be named in snake_case. prost also automatically converts snake_case naming to camelCase and other way around on serde serialization/deserialization for protobuf message. But the schema validation in tailcall was only checking raw name fields without considering that conversion happening. 

This pr changes proto naming style to follow grpc guide and updates schema validation to execute the comparison between camelCase field names

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code visibility and external testing capabilities.
- **Style**
	- Standardized field naming conventions across protobuf definitions.
- **New Features**
	- Enhanced JSON schema support with automatic snake_case to camelCase conversion for field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->