### PR TITLE
chore: run code coverage only in on darwin 64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
 
       - name: Upload Coverage to Codecov
-        if: matrix.build == 'darwin-x64' || matrix.build == 'darwin-arm64'
+        if: matrix.build == 'darwin-arm64'
         uses: Wandalen/wretry.action@v2
         with:
           action: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
 
       - name: Upload Coverage to Codecov
+        if: matrix.build == 'darwin-x64' || matrix.build == 'darwin-arm64'
         uses: Wandalen/wretry.action@v2
         with:
           action: codecov/codecov-action@v4


### PR DESCRIPTION
/claim #1529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved CI workflow efficiency by conditionally uploading coverage data for specific builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->