### PR TITLE
feat: add `enum` support

### DIFF
--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -823,6 +823,7 @@ input Schema {
   Obj: JSON
   Arr: Schema
   Opt: Schema
+  Enum: [String!]
 }
 """
 A date string, such as 2007-12-03, is compliant with the full-date format outlined in section 5.6 of the RFC 3339 (https://datatracker.ietf.org/doc/html/rfc3339) profile of the ISO 8601 standard for the representation of dates and times using the Gregorian calendar.

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -2172,6 +2172,22 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Enum"
+          ],
+          "properties": {
+            "Enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": false
         }
       ]
     }

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -333,7 +333,8 @@ pub fn update_nested_resolvers<'a>(
                     .types
                     .get(&field.type_of)
                     .map(|v| v.variants.is_some())
-                    .unwrap_or_default() // Enum should not have a resolver.
+                    .unwrap_or_default()
+            // Enum should not have a resolver.
             {
                 b_field = b_field.resolver(Some(Expression::Literal(DynamicValue::Value(
                     ConstValue::Object(Default::default()),

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -330,11 +330,6 @@ pub fn fix_dangling_resolvers<'a>(
         move |(config, field, _, name), mut b_field| {
             if !field.has_resolver()
                 && validate_field_has_resolver(name, field, &config.types).is_succeed()
-                && !config
-                    .types
-                    .get(&field.type_of)
-                    .map_or(false, |v| v.variants.is_some())
-            // Enum should not have a resolver.
             {
                 b_field = b_field.resolver(Some(Expression::Literal(DynamicValue::Value(
                     ConstValue::Object(Default::default()),

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -329,11 +329,11 @@ pub fn update_nested_resolvers<'a>(
         move |(config, field, _, name), mut b_field| {
             if !field.has_resolver()
                 && validate_field_has_resolver(name, field, &config.types).is_succeed()
-                && config
+                && !config
                     .types
                     .get(&field.type_of)
-                    .map(|v| v.variants.is_none())
-                    .unwrap_or_default()
+                    .map(|v| v.variants.is_some())
+                    .unwrap_or_default() // Enum should not have a resolver.
             {
                 b_field = b_field.resolver(Some(Expression::Literal(DynamicValue::Value(
                     ConstValue::Object(Default::default()),

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -329,7 +329,11 @@ pub fn update_nested_resolvers<'a>(
         move |(config, field, _, name), mut b_field| {
             if !field.has_resolver()
                 && validate_field_has_resolver(name, field, &config.types).is_succeed()
-                && config.types.get(&field.type_of).map(|v|v.variants.is_none()).unwrap_or_default()
+                && config
+                    .types
+                    .get(&field.type_of)
+                    .map(|v| v.variants.is_none())
+                    .unwrap_or_default()
             {
                 b_field = b_field.resolver(Some(Expression::Literal(DynamicValue::Value(
                     ConstValue::Object(Default::default()),

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -332,8 +332,7 @@ pub fn update_nested_resolvers<'a>(
                 && !config
                     .types
                     .get(&field.type_of)
-                    .map(|v| v.variants.is_some())
-                    .unwrap_or_default()
+                    .map_or(false, |v| v.variants.is_some())
             // Enum should not have a resolver.
             {
                 b_field = b_field.resolver(Some(Expression::Literal(DynamicValue::Value(

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -329,6 +329,7 @@ pub fn update_nested_resolvers<'a>(
         move |(config, field, _, name), mut b_field| {
             if !field.has_resolver()
                 && validate_field_has_resolver(name, field, &config.types).is_succeed()
+                && config.types.get(&field.type_of).map(|v|v.variants.is_none()).unwrap_or_default()
             {
                 b_field = b_field.resolver(Some(Expression::Literal(DynamicValue::Value(
                     ConstValue::Object(Default::default()),

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -318,11 +318,12 @@ fn update_resolver_from_path(
     })
 }
 
-/// Sets empty resolver to fields that has
-/// nested resolvers for its fields.
-/// To solve the problem that by default such fields will be resolved to null
-/// value and nested resolvers won't be called
-pub fn update_nested_resolvers<'a>(
+/// This function iterates over all types and their fields identifying paths to
+/// fields with dangling resolvers and fixes them. Dangling resolvers are those
+/// resolvers that cannot be resolved from the root of the schema. This function
+/// finds such dangling resolvers and creates a resolvable path from the root
+/// schema.
+pub fn fix_dangling_resolvers<'a>(
 ) -> TryFold<'a, (&'a ConfigModule, &'a Field, &'a config::Type, &'a str), FieldDefinition, String>
 {
     TryFold::<(&ConfigModule, &Field, &config::Type, &str), FieldDefinition, String>::new(
@@ -404,7 +405,7 @@ fn to_fields(
             .and(update_expr(&operation_type).trace(config::Expr::trace_name().as_str()))
             .and(update_modify().trace(config::Modify::trace_name().as_str()))
             .and(update_call(&operation_type).trace(config::Call::trace_name().as_str()))
-            .and(update_nested_resolvers())
+            .and(fix_dangling_resolvers())
             .and(update_cache_resolvers())
             .try_fold(
                 &(config_module, field, type_of, name),

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -89,13 +89,17 @@ where
     let type_ = config.find_type(type_of);
     let schema = match type_ {
         Some(type_) => {
-            let mut schema_fields = HashMap::new();
-            for (name, field) in type_.fields.iter() {
-                if field.script.is_none() && field.http.is_none() {
-                    schema_fields.insert(name.clone(), to_json_schema_for_field(field, config));
+            if let Some(variants) = type_.variants.clone() {
+                JsonSchema::Enum(variants)
+            }else {
+                let mut schema_fields = HashMap::new();
+                for (name, field) in type_.fields.iter() {
+                    if field.script.is_none() && field.http.is_none() {
+                        schema_fields.insert(name.clone(), to_json_schema_for_field(field, config));
+                    }
                 }
+                JsonSchema::Obj(schema_fields)
             }
-            JsonSchema::Obj(schema_fields)
         }
         None => match type_of {
             "String" => JsonSchema::Str {},

--- a/src/blueprint/from_config.rs
+++ b/src/blueprint/from_config.rs
@@ -91,7 +91,7 @@ where
         Some(type_) => {
             if let Some(variants) = type_.variants.clone() {
                 JsonSchema::Enum(variants)
-            }else {
+            } else {
                 let mut schema_fields = HashMap::new();
                 for (name, field) in type_.fields.iter() {
                     if field.script.is_none() && field.http.is_none() {

--- a/src/blueprint/schema.rs
+++ b/src/blueprint/schema.rs
@@ -44,11 +44,16 @@ pub fn validate_field_has_resolver(
     Valid::<(), String>::fail("No resolver has been found in the schema".to_owned())
         .when(|| {
             if !field.has_resolver() {
-                let f_type = &field.type_of;
-                if let Some(ty) = types.get(f_type) {
-                    let res = validate_type_has_resolvers(f_type, ty, types);
+                let type_name = &field.type_of;
+                if let Some(ty) = types.get(type_name) {
+                    // It's an enum
+                    if ty.variants.is_some() {
+                        return true;
+                    }
+                    let res = validate_type_has_resolvers(type_name, ty, types);
                     return !res.is_succeed();
                 } else {
+                    // It's a Scalar
                     return true;
                 }
             }

--- a/src/grpc/protobuf.rs
+++ b/src/grpc/protobuf.rs
@@ -112,19 +112,42 @@ impl ProtobufService {
         let input_type = method.input();
         let output_type = method.output();
 
-        Ok(ProtobufOperation { method, input_type, output_type })
+        Ok(ProtobufOperation::new(method, input_type, output_type))
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct ProtobufOperation {
     method: MethodDescriptor,
     pub input_type: MessageDescriptor,
     pub output_type: MessageDescriptor,
+    serialize_options: SerializeOptions,
+}
+
+impl Eq for ProtobufOperation {}
+
+impl PartialEq for ProtobufOperation {
+    fn eq(&self, other: &Self) -> bool {
+        self.method.eq(&other.method)
+            && self.input_type.eq(&other.input_type)
+            && self.output_type.eq(&other.output_type)
+    }
 }
 
 // TODO: support compression
 impl ProtobufOperation {
+    pub fn new(
+        method: MethodDescriptor,
+        input_type: MessageDescriptor,
+        output_type: MessageDescriptor,
+    ) -> Self {
+        Self {
+            method,
+            input_type,
+            output_type,
+            serialize_options: SerializeOptions::default().skip_default_fields(false),
+        }
+    }
     pub fn name(&self) -> &str {
         self.method.name()
     }
@@ -196,10 +219,7 @@ impl ProtobufOperation {
             })?;
 
         let mut ser = serde_json::Serializer::new(vec![]);
-        message.serialize_with_options(
-            &mut ser,
-            &SerializeOptions::new().skip_default_fields(false),
-        )?;
+        message.serialize_with_options(&mut ser, &self.serialize_options)?;
         let json = serde_json::from_slice::<Value>(ser.into_inner().as_ref())?;
 
         Ok(json)

--- a/src/grpc/protobuf.rs
+++ b/src/grpc/protobuf.rs
@@ -221,7 +221,6 @@ impl ProtobufOperation {
         let mut ser = serde_json::Serializer::new(vec![]);
         message.serialize_with_options(&mut ser, &self.serialize_options)?;
         let json = serde_json::from_slice::<Value>(ser.into_inner().as_ref())?;
-
         Ok(json)
     }
 }

--- a/src/json/json_schema.rs
+++ b/src/json/json_schema.rs
@@ -211,7 +211,7 @@ impl TryFrom<&FieldDescriptor> for JsonSchema {
             Kind::String => JsonSchema::Str,
             Kind::Bytes => JsonSchema::Str,
             Kind::Message(msg) => JsonSchema::try_from(&msg)?,
-            Kind::Enum(enm) =>  JsonSchema::try_from(&enm)?,
+            Kind::Enum(enm) => JsonSchema::try_from(&enm)?,
         };
         let field_schema = if value
             .cardinality()

--- a/src/json/json_schema.rs
+++ b/src/json/json_schema.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use convert_case::{Case, Casing};
-use prost_reflect::{FieldDescriptor, Kind, MessageDescriptor};
+use prost_reflect::{EnumDescriptor, FieldDescriptor, Kind, MessageDescriptor};
 use serde::{Deserialize, Serialize};
 
 use crate::valid::{Valid, Validator};
@@ -12,6 +12,7 @@ pub enum JsonSchema {
     Obj(HashMap<String, JsonSchema>),
     Arr(Box<JsonSchema>),
     Opt(Box<JsonSchema>),
+    Enum(BTreeSet<String>),
     Str,
     Num,
     Bool,
@@ -85,6 +86,7 @@ impl JsonSchema {
                 async_graphql::Value::Null => Valid::succeed(()),
                 _ => schema.validate(value),
             },
+            JsonSchema::Enum(_) => Valid::succeed(()),
         }
     }
 
@@ -132,6 +134,13 @@ impl JsonSchema {
                     return Valid::fail(format!("expected Boolean, got {:?}", other)).trace(name);
                 }
             }
+            JsonSchema::Enum(a) => {
+                if let JsonSchema::Enum(b) = other {
+                    if a.ne(b) {
+                        return Valid::fail("expected Enum type".to_string()).trace(name);
+                    }
+                }
+            }
         }
         Valid::succeed(())
     }
@@ -169,6 +178,18 @@ impl TryFrom<&MessageDescriptor> for JsonSchema {
     }
 }
 
+impl TryFrom<&EnumDescriptor> for JsonSchema {
+    type Error = crate::valid::ValidationError<String>;
+
+    fn try_from(value: &EnumDescriptor) -> Result<Self, Self::Error> {
+        let mut set = BTreeSet::new();
+        for value in value.values() {
+            set.insert(value.name().to_string());
+        }
+        Ok(JsonSchema::Enum(set))
+    }
+}
+
 impl TryFrom<&FieldDescriptor> for JsonSchema {
     type Error = crate::valid::ValidationError<String>;
 
@@ -190,9 +211,7 @@ impl TryFrom<&FieldDescriptor> for JsonSchema {
             Kind::String => JsonSchema::Str,
             Kind::Bytes => JsonSchema::Str,
             Kind::Message(msg) => JsonSchema::try_from(&msg)?,
-            Kind::Enum(_) => {
-                todo!("Enum")
-            }
+            Kind::Enum(enm) =>  JsonSchema::try_from(&enm)?,
         };
         let field_schema = if value
             .cardinality()

--- a/tests/execution/test-enum-default.md
+++ b/tests/execution/test-enum-default.md
@@ -1,0 +1,79 @@
+# test-enum-grpc-default
+
+```protobuf @file:service.proto
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package news;
+
+enum Status {
+  PUBLISHED = 0;
+  DRAFT = 1;
+  ND = 2;
+}
+
+
+message News {
+  int32 id = 1;
+  Status foo = 5;
+}
+
+service NewsService {
+  rpc GetAllNews (google.protobuf.Empty) returns (NewsList) {}
+}
+
+message NewsList {
+  repeated News news = 1;
+}
+```
+
+```graphql @server
+# for test upstream server see [repo](https://github.com/tailcallhq/rust-grpc)
+schema
+  @server(port: 8080, graphiql: true)
+  @upstream(baseURL: "http://localhost:50051", httpCache: true, batch: {delay: 10})
+  @link(id: "news", src: "./service.proto", type: Protobuf) {
+  query: Query
+}
+
+type Query {
+  news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
+}
+
+enum Status {
+  PUBLISHED
+  DRAFT
+  ND
+}
+
+type News {
+  id: Int
+  foo: Status
+}
+
+input NewsInput {
+  id: Int
+}
+
+type NewsData {
+  news: [News]!
+}
+```
+
+```yml @mock
+- request:
+    method: POST
+    url: http://localhost:50051/news.NewsService/GetAllNews
+    body: '\0\0\0\0\0'
+  response:
+    status: 200
+    body: '\0\0\0\0s\n#\x08\x01\x12\x06Note 1\x1a\tContent 1\"\x0cPost image 1\n%\x08\x02\x12\x06Note 2\x1a\tContent 2\"\x0cPost image 2(\x01\n%\x08\x03\x12\x06Note 3\x1a\tContent 3\"\x0cPost image 3(\x02'
+```
+
+```yml @assert
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: "query { news { news { id foo } } }"
+```

--- a/tests/execution/test-enum.md
+++ b/tests/execution/test-enum.md
@@ -5,7 +5,7 @@ check_identity: true
 # test-enum
 
 ```graphql @server
-schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server @upstream(baseURL: "http://localhost:8080") {
   query: Query
 }
 
@@ -15,6 +15,23 @@ enum Foo {
 }
 
 type Query {
-  foo: Foo @http(path: "/foo")
+  foo(val: String!): Foo @const(data: "{{args.val}}")
 }
+```
+
+```yml @assert
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: 'query { foo(val: "BAR") }'
+
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: 'query { foo(val: "BAZ") }'
+
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: 'query { foo(val: "INVALID") }'
 ```

--- a/tests/snapshots/execution_spec__test-enum-default.md_assert_0.snap
+++ b/tests/snapshots/execution_spec__test-enum-default.md_assert_0.snap
@@ -1,0 +1,30 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "news": {
+        "news": [
+          {
+            "id": 1,
+            "foo": "PUBLISHED"
+          },
+          {
+            "id": 2,
+            "foo": "DRAFT"
+          },
+          {
+            "id": 3,
+            "foo": "ND"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/snapshots/execution_spec__test-enum-default.md_client.snap
+++ b/tests/snapshots/execution_spec__test-enum-default.md_client.snap
@@ -1,0 +1,36 @@
+---
+source: tests/execution_spec.rs
+expression: client
+---
+scalar Date
+
+scalar Email
+
+scalar JSON
+
+type News {
+  foo: Status
+  id: Int
+}
+
+type NewsData {
+  news: [News]!
+}
+
+scalar PhoneNumber
+
+type Query {
+  news: NewsData!
+}
+
+enum Status {
+  DRAFT
+  ND
+  PUBLISHED
+}
+
+scalar Url
+
+schema {
+  query: Query
+}

--- a/tests/snapshots/execution_spec__test-enum-default.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-enum-default.md_merged.snap
@@ -1,0 +1,30 @@
+---
+source: tests/execution_spec.rs
+expression: merged
+---
+schema @server(graphiql: true, port: 8080) @upstream(baseURL: "http://localhost:50051", batch: {delay: 10, headers: [], maxSize: 100}, httpCache: true) @link(id: "news", src: "./service.proto", type: Protobuf) {
+  query: Query
+}
+
+enum Status {
+  DRAFT
+  ND
+  PUBLISHED
+}
+
+type News {
+  foo: Status
+  id: Int
+}
+
+type NewsData {
+  news: [News]!
+}
+
+type NewsInput {
+  id: Int
+}
+
+type Query {
+  news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
+}

--- a/tests/snapshots/execution_spec__test-enum.md_assert_0.snap
+++ b/tests/snapshots/execution_spec__test-enum.md_assert_0.snap
@@ -1,0 +1,15 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "foo": "BAR"
+    }
+  }
+}

--- a/tests/snapshots/execution_spec__test-enum.md_assert_1.snap
+++ b/tests/snapshots/execution_spec__test-enum.md_assert_1.snap
@@ -1,0 +1,15 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "foo": "BAZ"
+    }
+  }
+}

--- a/tests/snapshots/execution_spec__test-enum.md_assert_2.snap
+++ b/tests/snapshots/execution_spec__test-enum.md_assert_2.snap
@@ -1,0 +1,27 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": null,
+    "errors": [
+      {
+        "message": "internal: invalid item for enum \"Foo\"",
+        "locations": [
+          {
+            "line": 1,
+            "column": 9
+          }
+        ],
+        "path": [
+          "foo"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/snapshots/execution_spec__test-enum.md_client.snap
+++ b/tests/snapshots/execution_spec__test-enum.md_client.snap
@@ -16,7 +16,7 @@ scalar JSON
 scalar PhoneNumber
 
 type Query {
-  foo: Foo
+  foo(val: String!): Foo
 }
 
 scalar Url

--- a/tests/snapshots/execution_spec__test-enum.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-enum.md_merged.snap
@@ -2,7 +2,7 @@
 source: tests/execution_spec.rs
 expression: merged
 ---
-schema @server @upstream(baseURL: "http://jsonplaceholder.typicode.com") {
+schema @server @upstream(baseURL: "http://localhost:8080") {
   query: Query
 }
 
@@ -12,5 +12,5 @@ enum Foo {
 }
 
 type Query {
-  foo: Foo @http(path: "/foo")
+  foo(val: String!): Foo @const(data: "{{args.val}}")
 }


### PR DESCRIPTION
**Issue Reference(s):**  
Fixes #1407
/claim 1407

WIP:

- [x] Add support for enum
- [x] set default value of enum if there is no enum value in response (for proto3, https://github.com/hyperium/tonic/issues/1028)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for Enum types in schemas, including validation and serialization enhancements.
	- Updated the schema generation logic to handle enums more effectively.
	- Enhanced test scenarios to include Enum types and improved the testing framework for gRPC services.
- **Bug Fixes**
	- Fixed an issue with updating nested resolvers under specific conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->