### PR TITLE
refactor: drop  json like

### DIFF
--- a/src/scalar/date.rs
+++ b/src/scalar/date.rs
@@ -3,8 +3,6 @@ use chrono::DateTime;
 use schemars::schema::Schema;
 use schemars::{schema_for, JsonSchema};
 
-use crate::json::JsonLike;
-
 #[derive(JsonSchema, Default)]
 pub struct Date {
     #[serde(rename = "Date")]
@@ -16,7 +14,7 @@ impl super::Scalar for Date {
     /// Function used to validate the date
     fn validate(&self) -> fn(&ConstValue) -> bool {
         |value| {
-            if let Ok(date_str) = value.clone().as_str_ok() {
+            if let ConstValue::String(date_str) = value {
                 return DateTime::parse_from_rfc3339(date_str).is_ok();
             }
             false

--- a/src/scalar/email.rs
+++ b/src/scalar/email.rs
@@ -3,8 +3,6 @@ use async_graphql_value::ConstValue;
 use schemars::schema::Schema;
 use schemars::{schema_for, JsonSchema};
 
-use crate::json::JsonLike;
-
 #[derive(JsonSchema, Default)]
 pub struct Email {
     #[serde(rename = "Email")]
@@ -26,7 +24,7 @@ impl super::Scalar for Email {
     /// Function used to validate the email address
     fn validate(&self) -> fn(&ConstValue) -> bool {
         |value| {
-            if let Ok(email_str) = value.clone().as_str_ok() {
+            if let ConstValue::String(email_str) = value {
                 let email_str = email_str.to_string();
                 return email(&email_str).is_ok();
             }

--- a/src/scalar/phone.rs
+++ b/src/scalar/phone.rs
@@ -2,8 +2,6 @@ use async_graphql_value::ConstValue;
 use schemars::schema::Schema;
 use schemars::{schema_for, JsonSchema};
 
-use crate::json::JsonLike;
-
 #[derive(JsonSchema, Default)]
 pub struct PhoneNumber {
     #[serde(rename = "PhoneNumber")]
@@ -14,7 +12,7 @@ impl super::Scalar for PhoneNumber {
     /// Function used to validate the phone number
     fn validate(&self) -> fn(&ConstValue) -> bool {
         |value| {
-            if let Ok(phone_str) = value.clone().as_str_ok() {
+            if let ConstValue::String(phone_str) = value {
                 return phonenumber::parse(None, phone_str).is_ok();
             }
             false

--- a/src/scalar/url.rs
+++ b/src/scalar/url.rs
@@ -2,8 +2,6 @@ use async_graphql_value::ConstValue;
 use schemars::schema::Schema;
 use schemars::{schema_for, JsonSchema};
 
-use crate::json::JsonLike;
-
 #[derive(JsonSchema, Default)]
 pub struct Url {
     #[serde(rename = "Url")]
@@ -15,7 +13,7 @@ impl super::Scalar for Url {
     /// Function used to validate the date
     fn validate(&self) -> fn(&ConstValue) -> bool {
         |value| {
-            if let Ok(date_str) = value.clone().as_str_ok() {
+            if let ConstValue::String(date_str) = value {
                 return url::Url::parse(date_str).is_ok();
             }
             false


### PR DESCRIPTION
**Summary:**  
- Drop functions in json like
- I can't drop Json Like because some references still use it: ex
https://github.com/tailcallhq/tailcall/blob/44746de4afe3fbf73ad92cdfd24c52148ea027eb/src/grpc/data_loader.rs#L82
- If we drop json_like file, test case will break
**Issue Reference(s):**  
Fixes https://github.com/tailcallhq/tailcall/issues/1551

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved and streamlined the handling of JSON-like data structures.
	- Enhanced validation processes for date, email, phone, and URL scalar values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->