### PR TITLE
chore: add bench for `JsonLike::group_by`

### DIFF
--- a/benches/json_like_bench.rs
+++ b/benches/json_like_bench.rs
@@ -45,9 +45,7 @@ fn benchmark_group_by(c: &mut Criterion) {
             let binding = ["data".into(), "type".into()];
             let gathered = tailcall::json::gather_path_matches(&input, &binding, vec![]);
 
-            let grouped = black_box(tailcall::json::group_by_key(gathered));
-
-            serde_json::to_value(grouped).unwrap();
+            black_box(serde_json::to_value(tailcall::json::group_by_key(gathered)).unwrap());
         })
     });
 }

--- a/benches/json_like_bench.rs
+++ b/benches/json_like_bench.rs
@@ -29,5 +29,28 @@ fn benchmark_batched_body(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, benchmark_batched_body);
+fn benchmark_group_by(c: &mut Criterion) {
+    c.bench_function("group_by", |b| {
+        b.iter(|| {
+            let input = json!({
+                "data": [
+                    {"type": "A", "value": {"id": "1"}},
+                    {"type": "B", "value": {"id": "2"}},
+                    {"type": "A", "value": {"id": "3"}},
+                    {"type": "A", "value": {"id": "4"}},
+                    {"type": "B", "value": {"id": "5"}}
+                ]
+            });
+
+            let binding = ["data".into(), "type".into()];
+            let gathered = tailcall::json::gather_path_matches(&input, &binding, vec![]);
+
+            let grouped = black_box(tailcall::json::group_by_key(gathered));
+
+            serde_json::to_value(grouped).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, benchmark_batched_body, benchmark_group_by);
 criterion_main!(benches);

--- a/benches/json_like_bench.rs
+++ b/benches/json_like_bench.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use serde_json::json;
+use tailcall::json::JsonLike;
 
 fn benchmark_batched_body(c: &mut Criterion) {
     c.bench_function("test_batched_body", |b| {
@@ -30,22 +31,19 @@ fn benchmark_batched_body(c: &mut Criterion) {
 }
 
 fn benchmark_group_by(c: &mut Criterion) {
+    let input = json!({
+        "data": [
+            {"type": "A", "value": {"id": "1"}},
+            {"type": "B", "value": {"id": "2"}},
+            {"type": "A", "value": {"id": "3"}},
+            {"type": "A", "value": {"id": "4"}},
+            {"type": "B", "value": {"id": "5"}}
+        ]
+    });
     c.bench_function("group_by", |b| {
         b.iter(|| {
-            let input = json!({
-                "data": [
-                    {"type": "A", "value": {"id": "1"}},
-                    {"type": "B", "value": {"id": "2"}},
-                    {"type": "A", "value": {"id": "3"}},
-                    {"type": "A", "value": {"id": "4"}},
-                    {"type": "B", "value": {"id": "5"}}
-                ]
-            });
-
             let binding = ["data".into(), "type".into()];
-            let gathered = tailcall::json::gather_path_matches(&input, &binding, vec![]);
-
-            black_box(serde_json::to_value(tailcall::json::group_by_key(gathered)).unwrap());
+            black_box(input.group_by(&binding));
         })
     });
 }


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #1560
/claim 1560

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced benchmarking with a new function for testing grouping operations on JSON-like data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->