### PR TITLE
chore: make `ValidationError` wrap `IndexSet`

### DIFF
--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -363,8 +363,8 @@ mod test_proto_config {
         proto_no_pkg.pop();
         proto_no_pkg.push("proto");
         proto_no_pkg.push("news_no_pkg.proto");
-        let err = &validation.as_vec().first().unwrap().message;
-        let trace = &validation.as_vec().first().unwrap().trace;
+        let err = &validation.as_vec().iter().next().unwrap().message;
+        let trace = &validation.as_vec().iter().next().unwrap().trace;
         assert!(err.starts_with("Package name is not defined for proto file"));
 
         let expected_trace = ["schema", "link[0]"]

--- a/src/try_fold.rs
+++ b/src/try_fold.rs
@@ -6,7 +6,9 @@ use crate::valid::{Valid, Validator};
 /// fail. It can optionally consume an input to transform the provided value.
 type TryFoldFn<'a, I, O, E> = Box<dyn Fn(&I, O) -> Valid<O, E> + 'a>;
 
-pub struct TryFold<'a, I: 'a, O: 'a, E: 'a + std::cmp::Eq + std::hash::Hash>(TryFoldFn<'a, I, O, E>);
+pub struct TryFold<'a, I: 'a, O: 'a, E: 'a + std::cmp::Eq + std::hash::Hash>(
+    TryFoldFn<'a, I, O, E>,
+);
 
 impl<'a, I, O: Clone + 'a, E: std::cmp::Eq + std::hash::Hash> TryFold<'a, I, O, E> {
     /// Try to fold the value with the input.
@@ -148,7 +150,9 @@ impl<'a, I, O: Clone + 'a, E: std::cmp::Eq + std::hash::Hash> TryFold<'a, I, O, 
     }
 }
 
-impl<'a, I, O: Clone, E: std::cmp::Eq + std::hash::Hash> FromIterator<TryFold<'a, I, O, E>> for TryFold<'a, I, O, E> {
+impl<'a, I, O: Clone, E: std::cmp::Eq + std::hash::Hash> FromIterator<TryFold<'a, I, O, E>>
+    for TryFold<'a, I, O, E>
+{
     fn from_iter<T: IntoIterator<Item = TryFold<'a, I, O, E>>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
         let head = iter.next();

--- a/src/try_fold.rs
+++ b/src/try_fold.rs
@@ -6,9 +6,9 @@ use crate::valid::{Valid, Validator};
 /// fail. It can optionally consume an input to transform the provided value.
 type TryFoldFn<'a, I, O, E> = Box<dyn Fn(&I, O) -> Valid<O, E> + 'a>;
 
-pub struct TryFold<'a, I: 'a, O: 'a, E: 'a>(TryFoldFn<'a, I, O, E>);
+pub struct TryFold<'a, I: 'a, O: 'a, E: 'a + std::cmp::Eq + std::hash::Hash>(TryFoldFn<'a, I, O, E>);
 
-impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
+impl<'a, I, O: Clone + 'a, E: std::cmp::Eq + std::hash::Hash> TryFold<'a, I, O, E> {
     /// Try to fold the value with the input.
     ///
     /// # Parameters
@@ -148,7 +148,7 @@ impl<'a, I, O: Clone + 'a, E> TryFold<'a, I, O, E> {
     }
 }
 
-impl<'a, I, O: Clone, E> FromIterator<TryFold<'a, I, O, E>> for TryFold<'a, I, O, E> {
+impl<'a, I, O: Clone, E: std::cmp::Eq + std::hash::Hash> FromIterator<TryFold<'a, I, O, E>> for TryFold<'a, I, O, E> {
     fn from_iter<T: IntoIterator<Item = TryFold<'a, I, O, E>>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
         let head = iter.next();

--- a/src/valid/cause.rs
+++ b/src/valid/cause.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use derive_setters::Setters;
 use thiserror::Error;
 
-#[derive(Clone, PartialEq, Debug, Setters, Error)]
+#[derive(Clone, PartialEq, Debug, Setters, Error, Eq, Hash)]
 pub struct Cause<E> {
     pub message: E,
     #[setters(strip_option)]

--- a/src/valid/error.rs
+++ b/src/valid/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
-use indexmap::IndexSet;
 
+use indexmap::IndexSet;
 use regex::Regex;
 
 use super::Cause;
@@ -74,7 +74,10 @@ impl<E: std::cmp::Eq + std::hash::Hash> ValidationError<E> {
         Self(errors)
     }
 
-    pub fn transform<E1: std::cmp::Eq + std::hash::Hash>(self, f: &impl Fn(E) -> E1) -> ValidationError<E1> {
+    pub fn transform<E1: std::cmp::Eq + std::hash::Hash>(
+        self,
+        f: &impl Fn(E) -> E1,
+    ) -> ValidationError<E1> {
         ValidationError(self.0.into_iter().map(|cause| cause.transform(f)).collect())
     }
 }
@@ -91,7 +94,7 @@ impl<E: std::cmp::Eq + std::hash::Hash> From<Cause<E>> for ValidationError<E> {
 
 impl<E: std::cmp::Eq + std::hash::Hash> From<Vec<Cause<E>>> for ValidationError<E> {
     fn from(value: Vec<Cause<E>>) -> Self {
-        let set = IndexSet::from_iter(value.into_iter());
+        let set = IndexSet::from_iter(value);
         ValidationError(set)
     }
 }

--- a/src/valid/valid.rs
+++ b/src/valid/valid.rs
@@ -3,9 +3,9 @@ use super::ValidationError;
 use crate::valid::Cause;
 
 #[derive(Debug, PartialEq)]
-pub struct Valid<A, E>(Result<A, ValidationError<E>>);
+pub struct Valid<A, E: std::cmp::Eq + std::hash::Hash>(Result<A, ValidationError<E>>);
 
-pub trait Validator<A, E>: Sized {
+pub trait Validator<A, E: std::cmp::Eq + std::hash::Hash>: Sized {
     fn map<A1>(self, f: impl FnOnce(A) -> A1) -> Valid<A1, E> {
         Valid(self.to_result().map(f))
     }
@@ -95,7 +95,7 @@ pub trait Validator<A, E>: Sized {
     }
 }
 
-impl<A, E> Valid<A, E> {
+impl<A, E: std::cmp::Eq + std::hash::Hash> Valid<A, E> {
     pub fn fail(e: E) -> Valid<A, E> {
         Valid(Err((vec![Cause::new(e)]).into()))
     }
@@ -157,7 +157,7 @@ impl<A, E> Valid<A, E> {
     }
 }
 
-impl<A, E> Validator<A, E> for Valid<A, E> {
+impl<A, E: std::cmp::Eq + std::hash::Hash> Validator<A, E> for Valid<A, E> {
     fn to_result(self) -> Result<A, ValidationError<E>> {
         self.0
     }
@@ -167,8 +167,8 @@ impl<A, E> Validator<A, E> for Valid<A, E> {
     }
 }
 
-pub struct Fusion<A, E>(Valid<A, E>);
-impl<A, E> Fusion<A, E> {
+pub struct Fusion<A, E: std::cmp::Eq + std::hash::Hash>(Valid<A, E>);
+impl<A, E: std::cmp::Eq + std::hash::Hash> Fusion<A, E> {
     pub fn fuse<A1>(self, other: Valid<A1, E>) -> Fusion<A::Out, E>
     where
         A: Append<A1>,
@@ -177,7 +177,7 @@ impl<A, E> Fusion<A, E> {
     }
 }
 
-impl<A, E> Validator<A, E> for Fusion<A, E> {
+impl<A, E: std::cmp::Eq + std::hash::Hash> Validator<A, E> for Fusion<A, E> {
     fn to_result(self) -> Result<A, ValidationError<E>> {
         self.0.to_result()
     }
@@ -186,7 +186,7 @@ impl<A, E> Validator<A, E> for Fusion<A, E> {
     }
 }
 
-impl<A, E> From<Result<A, ValidationError<E>>> for Valid<A, E> {
+impl<A, E: std::cmp::Eq + std::hash::Hash> From<Result<A, ValidationError<E>>> for Valid<A, E> {
     fn from(value: Result<A, ValidationError<E>>) -> Self {
         match value {
             Ok(a) => Valid::succeed(a),
@@ -195,7 +195,7 @@ impl<A, E> From<Result<A, ValidationError<E>>> for Valid<A, E> {
     }
 }
 
-impl<A, E> From<Fusion<A, E>> for Valid<A, E> {
+impl<A, E: std::cmp::Eq + std::hash::Hash> From<Fusion<A, E>> for Valid<A, E> {
     fn from(value: Fusion<A, E>) -> Self {
         Valid(value.to_result())
     }
@@ -204,7 +204,7 @@ impl<A, E> From<Fusion<A, E>> for Valid<A, E> {
 impl<A, E> Clone for Valid<A, E>
 where
     A: Clone,
-    E: Clone,
+    E: Clone + std::cmp::Eq + std::hash::Hash,
 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/tests/snapshots/execution_spec__test-response-headers-multi.md_errors.snap
+++ b/tests/snapshots/execution_spec__test-response-headers-multi.md_errors.snap
@@ -22,25 +22,5 @@ expression: errors
       "custom"
     ],
     "description": null
-  },
-  {
-    "message": "Parsing failed because of invalid HTTP header name",
-    "trace": [
-      "schema",
-      "@server",
-      "headers",
-      "custom"
-    ],
-    "description": null
-  },
-  {
-    "message": "Parsing failed because of failed to parse header value",
-    "trace": [
-      "schema",
-      "@server",
-      "headers",
-      "custom"
-    ],
-    "description": null
   }
 ]


### PR DESCRIPTION
related to https://github.com/tailcallhq/tailcall/issues/1546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved data access patterns in configuration reading for enhanced efficiency.
	- Enhanced type constraints for error handling components to ensure better data integrity and uniqueness.
	- Adopted more efficient data structures for error causes, improving error management and deduplication.
	- Updated trait bounds and implementations for better type handling in error validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->