### PR TITLE
fix: add protected directive to autogen

### DIFF
--- a/autogen/src/gen_gql_schema.rs
+++ b/autogen/src/gen_gql_schema.rs
@@ -27,6 +27,7 @@ lazy_static! {
         ("omit", vec![Entity::FieldDefinition], false),
         ("groupBy", vec![Entity::FieldDefinition], false),
         ("const", vec![Entity::FieldDefinition], false),
+        ("protected", vec![Entity::FieldDefinition], false),
         ("graphQL", vec![Entity::FieldDefinition], false),
         (
             "cache",

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -222,6 +222,8 @@ Used to omit a field from public consumption.
 """
 directive @omit on FIELD_DEFINITION
 
+directive @protected on FIELD_DEFINITION
+
 """
 The `@server` directive, when applied at the schema level, offers a comprehensive 
 set of server configurations. It dictates how the server behaves and helps tune tailcall 


### PR DESCRIPTION

**Issue Reference(s):**  
Fixes #1605

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

/claim #1605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced a "protected" field definition in schema generation, allowing for enhanced data privacy.
	- Added a new `@protected` directive for marking fields as protected in GraphQL schemas.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->