### PR TITLE
feat: add empty scalar

### DIFF
--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -784,6 +784,9 @@ scalar Date
 field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
 """
 scalar Email
+"""
+Empty scalar type represents an empty value.
+"""
 scalar Empty
 """
 The JSON scalar type represents JSON values as specified by [ECMA-404](www.ecma-international.org/publications/files/ECMA-ST/ ECMA-404.pdf).

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -784,6 +784,7 @@ scalar Date
 field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address.
 """
 scalar Email
+scalar Empty
 """
 The JSON scalar type represents JSON values as specified by [ECMA-404](www.ecma-international.org/publications/files/ECMA-ST/ ECMA-404.pdf).
 """

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -310,6 +310,19 @@
         }
       }
     },
+    "Empty": {
+      "title": "Empty",
+      "type": "object",
+      "required": [
+        "JSON"
+      ],
+      "properties": {
+        "JSON": {
+          "description": "Empty scalar type represents an empty value.",
+          "type": "null"
+        }
+      }
+    },
     "Encoding": {
       "type": "string",
       "enum": [

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -314,10 +314,10 @@
       "title": "Empty",
       "type": "object",
       "required": [
-        "JSON"
+        "Empty"
       ],
       "properties": {
-        "JSON": {
+        "Empty": {
           "description": "Empty scalar type represents an empty value.",
           "type": "null"
         }

--- a/src/scalar/empty.rs
+++ b/src/scalar/empty.rs
@@ -1,0 +1,20 @@
+use async_graphql_value::ConstValue;
+use schemars::schema::Schema;
+use schemars::{schema_for, JsonSchema};
+
+#[derive(JsonSchema, Default)]
+pub struct Empty {
+    #[serde(rename = "JSON")]
+    /// Empty scalar type represents an empty value.
+    pub empty: (), // we don't care about the type, this is just for documentation
+}
+
+impl super::Scalar for Empty {
+    fn validate(&self) -> fn(&ConstValue) -> bool {
+        |_| true
+    }
+
+    fn scalar(&self) -> Schema {
+        Schema::Object(schema_for!(Self).schema)
+    }
+}

--- a/src/scalar/empty.rs
+++ b/src/scalar/empty.rs
@@ -4,7 +4,7 @@ use schemars::{schema_for, JsonSchema};
 
 #[derive(JsonSchema, Default)]
 pub struct Empty {
-    #[serde(rename = "JSON")]
+    #[serde(rename = "Empty")]
     /// Empty scalar type represents an empty value.
     pub empty: (), // we don't care about the type, this is just for documentation
 }

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -1,11 +1,13 @@
 pub use date::*;
 pub use email::*;
+pub use empty::*;
 pub use json::*;
 pub use phone::*;
 pub use url::*;
 
 mod date;
 mod email;
+mod empty;
 mod json;
 mod phone;
 mod url;
@@ -25,6 +27,7 @@ lazy_static! {
             Arc::new(Date::default()),
             Arc::new(Url::default()),
             Arc::new(JSON::default()),
+            Arc::new(Empty::default()),
         ];
         let mut hm = HashMap::new();
 

--- a/tests/snapshots/execution_spec__add-field-index-list.md_client.snap
+++ b/tests/snapshots/execution_spec__add-field-index-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__add-field-many-list.md_client.snap
+++ b/tests/snapshots/execution_spec__add-field-many-list.md_client.snap
@@ -12,6 +12,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__add-field-many.md_client.snap
+++ b/tests/snapshots/execution_spec__add-field-many.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Foo {
   a: String
   b: String

--- a/tests/snapshots/execution_spec__add-field-modify.md_client.snap
+++ b/tests/snapshots/execution_spec__add-field-modify.md_client.snap
@@ -12,6 +12,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__add-field-with-composition.md_client.snap
+++ b/tests/snapshots/execution_spec__add-field-with-composition.md_client.snap
@@ -11,6 +11,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Geo {
   lat: String
   lng: String

--- a/tests/snapshots/execution_spec__add-field-with-modify.md_client.snap
+++ b/tests/snapshots/execution_spec__add-field-with-modify.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__add-field.md_client.snap
+++ b/tests/snapshots/execution_spec__add-field.md_client.snap
@@ -10,6 +10,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Geo {
   lat: String
 }

--- a/tests/snapshots/execution_spec__apollo-tracing.md_client.snap
+++ b/tests/snapshots/execution_spec__apollo-tracing.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__auth-basic.md_client.snap
+++ b/tests/snapshots/execution_spec__auth-basic.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type Nested {

--- a/tests/snapshots/execution_spec__auth-jwt.md_client.snap
+++ b/tests/snapshots/execution_spec__auth-jwt.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type Nested {

--- a/tests/snapshots/execution_spec__auth.md_client.snap
+++ b/tests/snapshots/execution_spec__auth.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__batching-default.md_client.snap
+++ b/tests/snapshots/execution_spec__batching-default.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__batching-disabled.md_client.snap
+++ b/tests/snapshots/execution_spec__batching-disabled.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__batching-group-by-default.md_client.snap
+++ b/tests/snapshots/execution_spec__batching-group-by-default.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__batching-group-by.md_client.snap
+++ b/tests/snapshots/execution_spec__batching-group-by.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__batching-post.md_client.snap
+++ b/tests/snapshots/execution_spec__batching-post.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__batching.md_client.snap
+++ b/tests/snapshots/execution_spec__batching.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__cache-control.md_client.snap
+++ b/tests/snapshots/execution_spec__cache-control.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__caching-collision.md_client.snap
+++ b/tests/snapshots/execution_spec__caching-collision.md_client.snap
@@ -11,6 +11,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Foo {
   id: Int!
 }

--- a/tests/snapshots/execution_spec__caching.md_client.snap
+++ b/tests/snapshots/execution_spec__caching.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__call-graphql-datasource.md_client.snap
+++ b/tests/snapshots/execution_spec__call-graphql-datasource.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__call-multiple-steps-piping.md_client.snap
+++ b/tests/snapshots/execution_spec__call-multiple-steps-piping.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__call-mutation.md_client.snap
+++ b/tests/snapshots/execution_spec__call-mutation.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type Mutation {

--- a/tests/snapshots/execution_spec__call-operator.md_client.snap
+++ b/tests/snapshots/execution_spec__call-operator.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type News {

--- a/tests/snapshots/execution_spec__cors-allow-cred-false.md_client.snap
+++ b/tests/snapshots/execution_spec__cors-allow-cred-false.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__cors-allow-cred-true.md_client.snap
+++ b/tests/snapshots/execution_spec__cors-allow-cred-true.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__cors-allow-cred-vary.md_client.snap
+++ b/tests/snapshots/execution_spec__cors-allow-cred-vary.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__custom-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__custom-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__env-value.md_client.snap
+++ b/tests/snapshots/execution_spec__env-value.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__experimental-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__experimental-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__graphql-dataloader-batch-request.md_client.snap
+++ b/tests/snapshots/execution_spec__graphql-dataloader-batch-request.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__graphql-dataloader-no-batch-request.md_client.snap
+++ b/tests/snapshots/execution_spec__graphql-dataloader-no-batch-request.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__graphql-datasource-errors.md_client.snap
+++ b/tests/snapshots/execution_spec__graphql-datasource-errors.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__graphql-datasource-mutation.md_client.snap
+++ b/tests/snapshots/execution_spec__graphql-datasource-mutation.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type Mutation {

--- a/tests/snapshots/execution_spec__graphql-datasource-no-args.md_client.snap
+++ b/tests/snapshots/execution_spec__graphql-datasource-no-args.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__graphql-datasource-with-args.md_client.snap
+++ b/tests/snapshots/execution_spec__graphql-datasource-with-args.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__grpc-batch.md_client.snap
+++ b/tests/snapshots/execution_spec__grpc-batch.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type News {

--- a/tests/snapshots/execution_spec__grpc-override-url-from-upstream.md_client.snap
+++ b/tests/snapshots/execution_spec__grpc-override-url-from-upstream.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type News {

--- a/tests/snapshots/execution_spec__grpc-simple.md_client.snap
+++ b/tests/snapshots/execution_spec__grpc-simple.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type News {

--- a/tests/snapshots/execution_spec__grpc-url-from-upstream.md_client.snap
+++ b/tests/snapshots/execution_spec__grpc-url-from-upstream.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type News {

--- a/tests/snapshots/execution_spec__https.md_client.snap
+++ b/tests/snapshots/execution_spec__https.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__inline-field.md_client.snap
+++ b/tests/snapshots/execution_spec__inline-field.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__inline-index-list.md_client.snap
+++ b/tests/snapshots/execution_spec__inline-index-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__inline-many-list.md_client.snap
+++ b/tests/snapshots/execution_spec__inline-many-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__inline-many.md_client.snap
+++ b/tests/snapshots/execution_spec__inline-many.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__io-cache.md_client.snap
+++ b/tests/snapshots/execution_spec__io-cache.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__modified-field.md_client.snap
+++ b/tests/snapshots/execution_spec__modified-field.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__mutation-put.md_client.snap
+++ b/tests/snapshots/execution_spec__mutation-put.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type Mutation {

--- a/tests/snapshots/execution_spec__mutation.md_client.snap
+++ b/tests/snapshots/execution_spec__mutation.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type Mutation {

--- a/tests/snapshots/execution_spec__n-plus-one-list.md_client.snap
+++ b/tests/snapshots/execution_spec__n-plus-one-list.md_client.snap
@@ -12,6 +12,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Foo {
   bar: Bar
   id: Int!

--- a/tests/snapshots/execution_spec__n-plus-one.md_client.snap
+++ b/tests/snapshots/execution_spec__n-plus-one.md_client.snap
@@ -12,6 +12,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Foo {
   bar: Bar
   id: Int!

--- a/tests/snapshots/execution_spec__nested-objects.md_client.snap
+++ b/tests/snapshots/execution_spec__nested-objects.md_client.snap
@@ -11,6 +11,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Geo {
   lat: String
   lng: String

--- a/tests/snapshots/execution_spec__nesting-level3.md_client.snap
+++ b/tests/snapshots/execution_spec__nesting-level3.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__nullable-arg-query.md_client.snap
+++ b/tests/snapshots/execution_spec__nullable-arg-query.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__omit-index-list.md_client.snap
+++ b/tests/snapshots/execution_spec__omit-index-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__omit-many.md_client.snap
+++ b/tests/snapshots/execution_spec__omit-many.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__omit-resolved-by-parent.md_client.snap
+++ b/tests/snapshots/execution_spec__omit-resolved-by-parent.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__ref-other-nested.md_client.snap
+++ b/tests/snapshots/execution_spec__ref-other-nested.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__ref-other.md_client.snap
+++ b/tests/snapshots/execution_spec__ref-other.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__rename-field.md_client.snap
+++ b/tests/snapshots/execution_spec__rename-field.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__request-to-upstream-batching.md_client.snap
+++ b/tests/snapshots/execution_spec__request-to-upstream-batching.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__resolve-with-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__resolve-with-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__resolve-with-vars.md_client.snap
+++ b/tests/snapshots/execution_spec__resolve-with-vars.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__resolved-by-parent.md_client.snap
+++ b/tests/snapshots/execution_spec__resolved-by-parent.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__rest-api-error.md_client.snap
+++ b/tests/snapshots/execution_spec__rest-api-error.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__rest-api-post.md_client.snap
+++ b/tests/snapshots/execution_spec__rest-api-post.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__rest-api.md_client.snap
+++ b/tests/snapshots/execution_spec__rest-api.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__showcase.md_client.snap
+++ b/tests/snapshots/execution_spec__showcase.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__simple-graphql.md_client.snap
+++ b/tests/snapshots/execution_spec__simple-graphql.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__simple-query.md_client.snap
+++ b/tests/snapshots/execution_spec__simple-query.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-add-field-list.md_client.snap
+++ b/tests/snapshots/execution_spec__test-add-field-list.md_client.snap
@@ -14,6 +14,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Foo {
   a: A
 }

--- a/tests/snapshots/execution_spec__test-add-field.md_client.snap
+++ b/tests/snapshots/execution_spec__test-add-field.md_client.snap
@@ -14,6 +14,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Foo {
   a: A
 }

--- a/tests/snapshots/execution_spec__test-add-link-to-empty-config.md_client.snap
+++ b/tests/snapshots/execution_spec__test-add-link-to-empty-config.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 enum Foo {
   BAR
   BAZ

--- a/tests/snapshots/execution_spec__test-batching-group-by.md_client.snap
+++ b/tests/snapshots/execution_spec__test-batching-group-by.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-cache.md_client.snap
+++ b/tests/snapshots/execution_spec__test-cache.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-const-with-mustache.md_client.snap
+++ b/tests/snapshots/execution_spec__test-const-with-mustache.md_client.snap
@@ -23,6 +23,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-const.md_client.snap
+++ b/tests/snapshots/execution_spec__test-const.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-custom-scalar.md_client.snap
+++ b/tests/snapshots/execution_spec__test-custom-scalar.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar Json

--- a/tests/snapshots/execution_spec__test-custom-types.md_client.snap
+++ b/tests/snapshots/execution_spec__test-custom-types.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type Mut {

--- a/tests/snapshots/execution_spec__test-description-many.md_client.snap
+++ b/tests/snapshots/execution_spec__test-description-many.md_client.snap
@@ -13,6 +13,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-enum-default.md_client.snap
+++ b/tests/snapshots/execution_spec__test-enum-default.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type News {

--- a/tests/snapshots/execution_spec__test-enum.md_client.snap
+++ b/tests/snapshots/execution_spec__test-enum.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 enum Foo {
   BAR
   BAZ

--- a/tests/snapshots/execution_spec__test-graphqlsource.md_client.snap
+++ b/tests/snapshots/execution_spec__test-graphqlsource.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-grpc.md_client.snap
+++ b/tests/snapshots/execution_spec__test-grpc.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type News {

--- a/tests/snapshots/execution_spec__test-http-baseurl.md_client.snap
+++ b/tests/snapshots/execution_spec__test-http-baseurl.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-http-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__test-http-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-http-tmpl.md_client.snap
+++ b/tests/snapshots/execution_spec__test-http-tmpl.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-http-with-mustache-const.md_client.snap
+++ b/tests/snapshots/execution_spec__test-http-with-mustache-const.md_client.snap
@@ -20,6 +20,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-http.md_client.snap
+++ b/tests/snapshots/execution_spec__test-http.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-inline-list.md_client.snap
+++ b/tests/snapshots/execution_spec__test-inline-list.md_client.snap
@@ -10,6 +10,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-inline.md_client.snap
+++ b/tests/snapshots/execution_spec__test-inline.md_client.snap
@@ -10,6 +10,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-interface-result.md_client.snap
+++ b/tests/snapshots/execution_spec__test-interface-result.md_client.snap
@@ -11,6 +11,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 interface IA {
   a: String
 }

--- a/tests/snapshots/execution_spec__test-interface.md_client.snap
+++ b/tests/snapshots/execution_spec__test-interface.md_client.snap
@@ -11,6 +11,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 interface IA {
   a: String
 }

--- a/tests/snapshots/execution_spec__test-js-request-reponse.md_client.snap
+++ b/tests/snapshots/execution_spec__test-js-request-reponse.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-merge-server-sdl.md_client.snap
+++ b/tests/snapshots/execution_spec__test-merge-server-sdl.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-modify.md_client.snap
+++ b/tests/snapshots/execution_spec__test-modify.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 input Foo {
   bar: String
 }

--- a/tests/snapshots/execution_spec__test-multi-interface.md_client.snap
+++ b/tests/snapshots/execution_spec__test-multi-interface.md_client.snap
@@ -11,6 +11,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 interface IA {
   a: String
 }

--- a/tests/snapshots/execution_spec__test-nested-input.md_client.snap
+++ b/tests/snapshots/execution_spec__test-nested-input.md_client.snap
@@ -22,6 +22,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-nested-link.md_client.snap
+++ b/tests/snapshots/execution_spec__test-nested-link.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 enum Foo {
   BAR
   BAZ

--- a/tests/snapshots/execution_spec__test-nested-value.md_client.snap
+++ b/tests/snapshots/execution_spec__test-nested-value.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-omit-list.md_client.snap
+++ b/tests/snapshots/execution_spec__test-omit-list.md_client.snap
@@ -10,6 +10,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-omit.md_client.snap
+++ b/tests/snapshots/execution_spec__test-omit.md_client.snap
@@ -10,6 +10,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-params-as-body.md_client.snap
+++ b/tests/snapshots/execution_spec__test-params-as-body.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-query-documentation.md_client.snap
+++ b/tests/snapshots/execution_spec__test-query-documentation.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-query.md_client.snap
+++ b/tests/snapshots/execution_spec__test-query.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-ref-other.md_client.snap
+++ b/tests/snapshots/execution_spec__test-ref-other.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type InPost {
   get: [Post]
 }

--- a/tests/snapshots/execution_spec__test-scalars.md_client.snap
+++ b/tests/snapshots/execution_spec__test-scalars.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-server-vars.md_client.snap
+++ b/tests/snapshots/execution_spec__test-server-vars.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-set-cookie-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__test-set-cookie-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-static-value.md_client.snap
+++ b/tests/snapshots/execution_spec__test-static-value.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-tag.md_client.snap
+++ b/tests/snapshots/execution_spec__test-tag.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 type NEWS {

--- a/tests/snapshots/execution_spec__test-union.md_client.snap
+++ b/tests/snapshots/execution_spec__test-union.md_client.snap
@@ -10,6 +10,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 type Foo {
   foo: String
 }

--- a/tests/snapshots/execution_spec__test-upstream-headers.md_client.snap
+++ b/tests/snapshots/execution_spec__test-upstream-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__test-upstream.md_client.snap
+++ b/tests/snapshots/execution_spec__test-upstream.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__upstream-batching.md_client.snap
+++ b/tests/snapshots/execution_spec__upstream-batching.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__upstream-fail-request.md_client.snap
+++ b/tests/snapshots/execution_spec__upstream-fail-request.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__with-args-url.md_client.snap
+++ b/tests/snapshots/execution_spec__with-args-url.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__with-args.md_client.snap
+++ b/tests/snapshots/execution_spec__with-args.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber

--- a/tests/snapshots/execution_spec__with-nesting.md_client.snap
+++ b/tests/snapshots/execution_spec__with-nesting.md_client.snap
@@ -6,6 +6,8 @@ scalar Date
 
 scalar Email
 
+scalar Empty
+
 scalar JSON
 
 scalar PhoneNumber


### PR DESCRIPTION
#1576 keeps an nullable String as return type if the output is empty type in proto file. So we need to introduce an `Empty` scalar to fix the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced a new scalar type `Empty` to represent empty values, enhancing data handling capabilities.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->