### PR TITLE
refactor: add `resource_reader` module

### DIFF
--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -271,8 +271,8 @@ impl ConfigReader {
 
         Ok(protox_parse::parse(path, &content)?)
     }
-    
-        /// Checks if path is absolute else it joins file path with relative dir
+
+    /// Checks if path is absolute else it joins file path with relative dir
     /// path
     fn resolve_path(src: &str, root_dir: Option<&Path>) -> String {
         if Path::new(&src).is_absolute() {
@@ -402,6 +402,7 @@ mod reader_tests {
     use std::path::{Path, PathBuf};
 
     use pretty_assertions::assert_eq;
+
     use crate::config::reader::ConfigReader;
     use crate::config::{Config, Type};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::mutable_key_type)]
 
+mod resource_reader;
 mod app_context;
 pub mod async_cache;
 pub mod async_graphql_hyper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::mutable_key_type)]
 
-mod resource_reader;
 mod app_context;
 pub mod async_cache;
 pub mod async_graphql_hyper;
@@ -27,6 +26,7 @@ pub mod merge_right;
 pub mod mustache;
 pub mod path;
 pub mod print_schema;
+mod resource_reader;
 mod rest;
 pub mod runtime;
 pub mod scalar;

--- a/src/resource_reader.rs
+++ b/src/resource_reader.rs
@@ -1,6 +1,4 @@
-
-use std::path::Path;
-use futures_util::{TryFutureExt, future::join_all};
+use futures_util::{future::join_all, TryFutureExt};
 use url::Url;
 
 use crate::runtime::TargetRuntime;
@@ -57,41 +55,5 @@ impl ResourceReader {
             .into_iter()
             .collect::<anyhow::Result<Vec<_>>>()?;
         Ok(content)
-    }
-
-    /// Checks if path is absolute else it joins file path with relative dir
-    /// path
-    pub fn resolve_path(src: &str, root_dir: Option<&Path>) -> String {
-        if Path::new(&src).is_absolute() {
-            src.to_string()
-        } else {
-            let path = root_dir.unwrap_or(Path::new(""));
-            path.join(src).to_string_lossy().to_string()
-        }
-    }
-
-}
-
-
-
-#[cfg(test)]
-mod resource_reader_tests {
-    use std::path::{Path, PathBuf};
-    use pretty_assertions::assert_eq;
-    use crate::resource_reader::ResourceReader;
-    
-    #[test]
-    fn test_relative_path() {
-        let path_dir = Path::new("abc/xyz");
-        let file_relative = "foo/bar/my.proto";
-        let file_absolute = "/foo/bar/my.proto";
-        assert_eq!(
-            path_dir.to_path_buf().join(file_relative),
-            PathBuf::from(ResourceReader::resolve_path(file_relative, Some(path_dir)))
-        );
-        assert_eq!(
-            "/foo/bar/my.proto",
-            ResourceReader::resolve_path(file_absolute, Some(path_dir))
-        );
     }
 }

--- a/src/resource_reader.rs
+++ b/src/resource_reader.rs
@@ -1,0 +1,97 @@
+
+use std::path::Path;
+use futures_util::{TryFutureExt, future::join_all};
+use url::Url;
+
+use crate::runtime::TargetRuntime;
+
+/// Response of a file read operation
+#[derive(Debug)]
+pub struct FileRead {
+    pub content: String,
+    pub path: String,
+}
+
+pub struct ResourceReader {
+    runtime: TargetRuntime,
+}
+
+impl ResourceReader {
+    pub fn init(runtime: TargetRuntime) -> Self {
+        Self { runtime }
+    }
+    /// Reads a file from the filesystem or from an HTTP URL
+    pub async fn read_file<T: ToString>(&self, file: T) -> anyhow::Result<FileRead> {
+        // Is an HTTP URL
+        let content = if let Ok(url) = Url::parse(&file.to_string()) {
+            if url.scheme().starts_with("http") {
+                let response = self
+                    .runtime
+                    .http
+                    .execute(reqwest::Request::new(reqwest::Method::GET, url))
+                    .await?;
+
+                String::from_utf8(response.body.to_vec())?
+            } else {
+                // Is a file path on Windows
+
+                self.runtime.file.read(&file.to_string()).await?
+            }
+        } else {
+            // Is a file path
+
+            self.runtime.file.read(&file.to_string()).await?
+        };
+
+        Ok(FileRead { content, path: file.to_string() })
+    }
+
+    /// Reads all the files in parallel
+    pub async fn read_files<T: ToString>(&self, files: &[T]) -> anyhow::Result<Vec<FileRead>> {
+        let files = files.iter().map(|x| {
+            self.read_file(x.to_string())
+                .map_err(|e| e.context(x.to_string()))
+        });
+        let content = join_all(files)
+            .await
+            .into_iter()
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(content)
+    }
+
+    /// Checks if path is absolute else it joins file path with relative dir
+    /// path
+    pub fn resolve_path(src: &str, root_dir: Option<&Path>) -> String {
+        if Path::new(&src).is_absolute() {
+            src.to_string()
+        } else {
+            let path = root_dir.unwrap_or(Path::new(""));
+            path.join(src).to_string_lossy().to_string()
+        }
+    }
+
+}
+
+
+
+#[cfg(test)]
+mod resource_reader_tests {
+    use std::path::{Path, PathBuf};
+    use pretty_assertions::assert_eq;
+    use crate::resource_reader::ResourceReader;
+    
+    #[test]
+    fn test_relative_path() {
+        let path_dir = Path::new("abc/xyz");
+        let file_relative = "foo/bar/my.proto";
+        let file_absolute = "/foo/bar/my.proto";
+        assert_eq!(
+            path_dir.to_path_buf().join(file_relative),
+            PathBuf::from(ResourceReader::resolve_path(file_relative, Some(path_dir)))
+        );
+        assert_eq!(
+            "/foo/bar/my.proto",
+            ResourceReader::resolve_path(file_absolute, Some(path_dir))
+        );
+    }
+}

--- a/src/resource_reader.rs
+++ b/src/resource_reader.rs
@@ -1,4 +1,5 @@
-use futures_util::{future::join_all, TryFutureExt};
+use futures_util::future::join_all;
+use futures_util::TryFutureExt;
 use url::Url;
 
 use crate::runtime::TargetRuntime;


### PR DESCRIPTION
**Summary:**  
moved resource read logic into a new module in root.

**Issue Reference(s):**  
Fixes #1618

/claim #1618

**Build & Testing:**

- [Yes] I ran `cargo test` successfully.
- [Yes] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [Yes ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved modularity and efficiency in configuration file reading operations by introducing a dedicated `ResourceReader`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->