### PR TITLE
refactor: introduce `proto_reader.rs`

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -289,7 +289,7 @@ fn merge_types(
     mut self_types: BTreeMap<String, Type>,
     other_types: BTreeMap<String, Type>,
 ) -> BTreeMap<String, Type> {
-    for (name, mut other_type) in other_types {x
+    for (name, mut other_type) in other_types {
         if let Some(self_type) = self_types.remove(&name) {
             other_type = self_type.merge_right(other_type);
         }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -289,7 +289,7 @@ fn merge_types(
     mut self_types: BTreeMap<String, Type>,
     other_types: BTreeMap<String, Type>,
 ) -> BTreeMap<String, Type> {
-    for (name, mut other_type) in other_types {
+    for (name, mut other_type) in other_types {x
         if let Some(self_type) = self_types.remove(&name) {
             other_type = self_type.merge_right(other_type);
         }

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -85,10 +85,7 @@ impl ConfigReader {
             }
         }
 
-        for i in 0..links.len() {
-            let config_link = links
-                .get(i)
-                .context(format!("Expected a link at index: {i} but found none"))?;
+        for config_link in links.iter() {
             let path = Self::resolve_path(&config_link.src, parent_dir);
 
             let source = self.resource_reader.read_file(&path).await?;

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context};
-
 use rustls_pemfile;
 use rustls_pki_types::{
     CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer, PrivateSec1KeyDer,

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -70,12 +70,7 @@ impl ConfigReader {
             })
             .collect::<Vec<_>>();
         let file_descriptor_metadata = try_join_all(file_descriptor_metadata).await?;
-        // let protobuf_links_paths = protobuf_links
-        //     .iter()
-        //     .map(|v| Self::resolve_path(&v.src, parent_dir))
-        //     .collect::<Vec<String>>();
-        // let file_descriptor_metadata =
-        // self.proto_reader.read_all(&protobuf_links_paths).await?;
+
         for (i, file_descriptor_set) in file_descriptor_metadata.iter().enumerate() {
             let id = Valid::from_option(
                 file_descriptor_set.package.clone(),

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -65,10 +65,7 @@ impl ConfigReader {
             .iter()
             .map(|v| Self::resolve_path(&v.src, parent_dir))
             .collect::<Vec<String>>();
-        let file_descriptor_sets = self
-            .proto_reader
-            .resolve_protos(&protobuf_links_paths)
-            .await?;
+        let file_descriptor_sets = self.proto_reader.read_all(&protobuf_links_paths).await?;
         for (i, file_descriptor_set) in file_descriptor_sets.iter().enumerate() {
             let config_link = protobuf_links.get(i).unwrap();
             let id = Valid::from_option(

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -65,22 +65,13 @@ impl ConfigReader {
             .iter()
             .map(|v| Self::resolve_path(&v.src, parent_dir))
             .collect::<Vec<String>>();
-        let file_descriptor_sets = self.proto_reader.read_all(&protobuf_links_paths).await?;
-        for (i, file_descriptor_set) in file_descriptor_sets.iter().enumerate() {
-            let config_link = protobuf_links.get(i).unwrap();
+        let file_descriptor_metadata = self.proto_reader.read_all(&protobuf_links_paths).await?;
+        for (i, file_descriptor_set) in file_descriptor_metadata.iter().enumerate() {
             let id = Valid::from_option(
                 file_descriptor_set.package.clone(),
                 format!(
-                    "Package name is not defined for proto file: {:?} with link id: {:?}",
-                    file_descriptor_set
-                        .descriptor_set
-                        .file
-                        .first()
-                        .unwrap()
-                        .name
-                        .as_ref()
-                        .unwrap(),
-                    config_link.id
+                    "Package name is not defined for proto file: {:?}",
+                    file_descriptor_set.name
                 ),
             )
             .trace(&format!("link[{}]", i))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod merge_right;
 pub mod mustache;
 pub mod path;
 pub mod print_schema;
+mod proto_reader;
 mod resource_reader;
 mod rest;
 pub mod runtime;

--- a/src/proto_reader.rs
+++ b/src/proto_reader.rs
@@ -23,15 +23,6 @@ impl ProtoReader {
         Self { resource_reader: ResourceReader::init(runtime) }
     }
 
-    #[allow(dead_code)] // TODO might be used in builder reader
-    pub async fn read_all<T: AsRef<str>>(&self, paths: &[T]) -> anyhow::Result<Vec<ProtoMetadata>> {
-        let resolved_protos = join_all(paths.iter().map(|v| self.read(v.as_ref())))
-            .await
-            .into_iter()
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        Ok(resolved_protos)
-    }
-
     pub async fn read<T: AsRef<str>>(&self, path: T) -> anyhow::Result<ProtoMetadata> {
         let proto = self.read_proto(path.as_ref()).await?;
         let package = proto.package.clone();
@@ -156,17 +147,6 @@ mod test_proto_config {
         }
 
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_read_all() {
-        let runtime = crate::runtime::test::init(None);
-        let reader = ProtoReader::init(runtime);
-        let resolved_protos = reader
-            .read_all(&["google/protobuf/empty.proto"])
-            .await
-            .unwrap();
-        assert_eq!(resolved_protos.len(), 1);
     }
 
     fn path_to_file_name(path: &Path) -> Option<String> {

--- a/src/proto_reader.rs
+++ b/src/proto_reader.rs
@@ -23,6 +23,7 @@ impl ProtoReader {
         Self { resource_reader: ResourceReader::init(runtime) }
     }
 
+    #[allow(dead_code)] // TODO might be used in builder reader
     pub async fn read_all<T: AsRef<str>>(&self, paths: &[T]) -> anyhow::Result<Vec<ProtoMetadata>> {
         let resolved_protos = join_all(paths.iter().map(|v| self.read(v.as_ref())))
             .await

--- a/src/proto_reader.rs
+++ b/src/proto_reader.rs
@@ -14,6 +14,7 @@ pub struct ProtoReader {
 
 pub struct ProtoMetadata {
     pub package: Option<String>,
+    pub name: Option<String>,
     pub descriptor_set: FileDescriptorSet,
 }
 
@@ -33,9 +34,11 @@ impl ProtoReader {
     pub async fn read<T: AsRef<str>>(&self, path: T) -> anyhow::Result<ProtoMetadata> {
         let proto = self.read_proto(path.as_ref()).await?;
         let package = proto.package.clone();
+        let name = proto.name.clone();
         let descriptors = self.resolve_descriptors(proto).await?;
         let metadata = ProtoMetadata {
             package,
+            name,
             descriptor_set: FileDescriptorSet { file: descriptors },
         };
         Ok(metadata)

--- a/src/proto_reader.rs
+++ b/src/proto_reader.rs
@@ -1,0 +1,169 @@
+use std::collections::{HashMap, VecDeque};
+
+use anyhow::Context;
+use futures_util::future::join_all;
+use prost_reflect::prost_types::{FileDescriptorProto, FileDescriptorSet};
+use protox::file::{FileResolver, GoogleFileResolver};
+
+use crate::resource_reader::ResourceReader;
+use crate::runtime::TargetRuntime;
+
+pub struct ProtoReader {
+    resource_reader: ResourceReader,
+}
+
+pub struct ProtoMetadata {
+    pub package: Option<String>,
+    pub descriptor_set: FileDescriptorSet,
+}
+
+impl ProtoReader {
+    pub fn init(runtime: TargetRuntime) -> Self {
+        Self { resource_reader: ResourceReader::init(runtime) }
+    }
+
+    pub async fn resolve_protos<T: AsRef<str>>(
+        &self,
+        paths: &[T],
+    ) -> anyhow::Result<Vec<ProtoMetadata>> {
+        let resolved_protos = join_all(paths.iter().map(|v| self.resolve_proto(v.as_ref())))
+            .await
+            .into_iter()
+            .collect::<anyhow::Result<Vec<ProtoMetadata>>>()?;
+        Ok(resolved_protos)
+    }
+
+    pub async fn resolve_proto<T: AsRef<str>>(&self, path: T) -> anyhow::Result<ProtoMetadata> {
+        let proto = self.read_proto(path.as_ref()).await?;
+        let package = proto.package.clone();
+        let descriptors = self.resolve_descriptors(proto).await?;
+        let metadata = ProtoMetadata {
+            package,
+            descriptor_set: FileDescriptorSet { file: descriptors },
+        };
+        Ok(metadata)
+    }
+
+    /// Performs BFS to import all nested proto files
+    async fn resolve_descriptors(
+        &self,
+        parent_proto: FileDescriptorProto,
+    ) -> anyhow::Result<Vec<FileDescriptorProto>> {
+        let mut descriptors: HashMap<String, FileDescriptorProto> = HashMap::new();
+        let mut queue = VecDeque::new();
+        queue.push_back(parent_proto.clone());
+
+        while let Some(file) = queue.pop_front() {
+            for import in file.dependency.iter() {
+                let proto = self.read_proto(import).await?;
+                if descriptors.get(import).is_none() {
+                    queue.push_back(proto.clone());
+                    descriptors.insert(import.clone(), proto);
+                }
+            }
+        }
+        let mut descriptors = descriptors
+            .into_values()
+            .collect::<Vec<FileDescriptorProto>>();
+        descriptors.push(parent_proto);
+        Ok(descriptors)
+    }
+
+    /// Tries to load well-known google proto files and if not found uses normal
+    /// file and http IO to resolve them
+    async fn read_proto(&self, path: &str) -> anyhow::Result<FileDescriptorProto> {
+        let content = if let Ok(file) = GoogleFileResolver::new().open_file(path) {
+            file.source()
+                .context("Unable to extract content of google well-known proto file")?
+                .to_string()
+        } else {
+            self.resource_reader.read_file(path).await?.content
+        };
+
+        Ok(protox_parse::parse(path, &content)?)
+    }
+}
+
+#[cfg(test)]
+mod test_proto_config {
+    use std::path::{Path, PathBuf};
+
+    use anyhow::{Context, Result};
+    use pretty_assertions::assert_eq;
+
+    use crate::proto_reader::ProtoReader;
+
+    #[tokio::test]
+    async fn test_resolve() {
+        // Skipping IO tests as they are covered in reader.rs
+        let reader = ProtoReader::init(crate::runtime::test::init(None));
+        reader
+            .read_proto("google/protobuf/empty.proto")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_nested_imports() -> Result<()> {
+        let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut test_dir = root_dir.join(file!());
+        test_dir.pop(); // src
+
+        let mut root = test_dir.clone();
+        root.pop();
+
+        test_dir.push("grpc"); // grpc
+        test_dir.push("tests"); // tests
+        test_dir.push("proto"); // proto
+
+        let mut test_file = test_dir.clone();
+
+        test_file.push("nested0.proto"); // nested0.proto
+        assert!(test_file.exists());
+        let test_file = test_file.to_str().unwrap().to_string();
+
+        let runtime = crate::runtime::test::init(None);
+        let file_rt = runtime.file.clone();
+
+        let reader = ProtoReader::init(runtime);
+        let helper_map = reader
+            .resolve_descriptors(reader.read_proto(&test_file).await?)
+            .await?;
+        let files = test_dir.read_dir()?;
+        for file in files {
+            let file = file?;
+            let path = file.path();
+            let path_str =
+                path_to_file_name(path.as_path()).context("It must be able to extract path")?;
+            let source = file_rt.read(&path_str).await?;
+            let expected = protox_parse::parse(&path_str, &source)?;
+            let actual = helper_map
+                .iter()
+                .find(|v| v.package.eq(&expected.package))
+                .unwrap();
+
+            assert_eq!(&expected.dependency, &actual.dependency);
+        }
+
+        Ok(())
+    }
+
+    fn path_to_file_name(path: &Path) -> Option<String> {
+        let components: Vec<_> = path.components().collect();
+
+        // Find the index of the "src" component
+        if let Some(src_index) = components.iter().position(|&c| c.as_os_str() == "src") {
+            // Reconstruct the path from the "src" component onwards
+            let after_src_components = &components[src_index..];
+            let result = after_src_components
+                .iter()
+                .fold(PathBuf::new(), |mut acc, comp| {
+                    acc.push(comp);
+                    acc
+                });
+            Some(result.to_str().unwrap().to_string())
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
**Issue Reference(s):**  
Fixes #1619



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new way to resolve and parse Protocol Buffer (protobuf) files, including handling nested imports and well-known Google proto files.
- **Refactor**
	- Revamped the logic for handling protobuf links and grpc file descriptors, enhancing efficiency and clarity.
- **Tests**
	- Added testing for the resolution of proto files and their nested imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->