### PR TITLE
fix: Update .tailcallrc.graphql with @protected definition

### DIFF
--- a/autogen/src/gen_gql_schema.rs
+++ b/autogen/src/gen_gql_schema.rs
@@ -27,7 +27,11 @@ lazy_static! {
         ("omit", vec![Entity::FieldDefinition], false),
         ("groupBy", vec![Entity::FieldDefinition], false),
         ("const", vec![Entity::FieldDefinition], false),
-        ("protected", vec![Entity::FieldDefinition], false),
+        (
+            "protected",
+            vec![Entity::Object, Entity::FieldDefinition],
+            false
+        ),
         ("graphQL", vec![Entity::FieldDefinition], false),
         (
             "cache",

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -212,7 +212,7 @@ Used to omit a field from public consumption.
 """
 directive @omit on FIELD_DEFINITION
 
-directive @protected on OBJECT
+directive @protected on OBJECT | FIELD_DEFINITION
 
 """
 The `@server` directive, when applied at the schema level, offers a comprehensive 

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -212,7 +212,7 @@ Used to omit a field from public consumption.
 """
 directive @omit on FIELD_DEFINITION
 
-directive @protected on FIELD_DEFINITION
+directive @protected on OBJECT
 
 """
 The `@server` directive, when applied at the schema level, offers a comprehensive 


### PR DESCRIPTION
**Issue Reference(s):**  
Fixes #1628
/claim 1628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced security by updating the application of the `@protected` directive from field definitions to entire objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->