### PR TITLE
chore: make `ProtobufOperation::convert_output` generic

### DIFF
--- a/benches/protobuf_convert_output.rs
+++ b/benches/protobuf_convert_output.rs
@@ -44,7 +44,11 @@ fn benchmark_convert_output(c: &mut Criterion) {
 
     c.bench_function("test_batched_body", |b| {
         b.iter(|| {
-            black_box(protobuf_operation.convert_output(&msg).unwrap());
+            black_box(
+                protobuf_operation
+                    .convert_output::<serde_json::Value>(&msg)
+                    .unwrap(),
+            );
         })
     });
 }

--- a/src/grpc/protobuf.rs
+++ b/src/grpc/protobuf.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use anyhow::{anyhow, bail, Context, Result};
-use async_graphql::Value;
 use prost::bytes::BufMut;
 use prost::Message;
 use prost_reflect::prost_types::FileDescriptorSet;
@@ -202,7 +201,7 @@ impl ProtobufOperation {
         message_to_bytes(message).map(|result| (result, ids))
     }
 
-    pub fn convert_output(&self, bytes: &[u8]) -> Result<Value> {
+    pub fn convert_output<T: serde::de::DeserializeOwned>(&self, bytes: &[u8]) -> Result<T> {
         if bytes.len() < 5 {
             bail!("Empty response");
         }
@@ -220,7 +219,7 @@ impl ProtobufOperation {
 
         let mut ser = serde_json::Serializer::new(vec![]);
         message.serialize_with_options(&mut ser, &self.serialize_options)?;
-        let json = serde_json::from_slice::<Value>(ser.into_inner().as_ref())?;
+        let json = serde_json::from_slice::<T>(ser.into_inner().as_ref())?;
         Ok(json)
     }
 }
@@ -360,7 +359,7 @@ pub mod tests {
 
         let output = b"\0\0\0\0\x0e\n\x0ctest message";
 
-        let parsed = operation.convert_output(output)?;
+        let parsed = operation.convert_output::<serde_json::Value>(output)?;
 
         assert_eq!(
             serde_json::to_value(parsed)?,
@@ -386,7 +385,7 @@ pub mod tests {
 
         let output = b"\0\0\0\x005\x08\x01\x12\x06Note 1\x1a\tContent 1\"\x0cPost image 1";
 
-        let parsed = operation.convert_output(output)?;
+        let parsed = operation.convert_output::<serde_json::Value>(output)?;
 
         assert_eq!(
             serde_json::to_value(parsed)?,
@@ -421,7 +420,7 @@ pub mod tests {
 
         let output = b"\0\0\0\0o\n#\x08\x01\x12\x06Note 1\x1a\tContent 1\"\x0cPost image 1\n#\x08\x03\x12\x06Note 3\x1a\tContent 3\"\x0cPost image 3\n#\x08\x05\x12\x06Note 5\x1a\tContent 5\"\x0cPost image 5";
 
-        let parsed = multiple_operation.convert_output(output)?;
+        let parsed = multiple_operation.convert_output::<serde_json::Value>(output)?;
 
         assert_eq!(
             serde_json::to_value(parsed)?,

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -38,7 +38,7 @@ impl Response<Bytes> {
         operation: &ProtobufOperation,
     ) -> Result<Response<async_graphql::Value>> {
         let mut resp = Response::default();
-        let body = operation.convert_output(&self.body)?;
+        let body = operation.convert_output::<async_graphql::Value>(&self.body)?;
         resp.body = body;
         resp.status = self.status;
         resp.headers = self.headers;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced the flexibility of the `convert_output` method to support deserialization to different types, improving the adaptability of protobuf message handling.
	- Updated method calls to `convert_output` across the codebase to explicitly specify target types, ensuring type safety and clarity in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->