### PR TITLE
fix: dummy.proto compilation error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,7 @@
-use std::path::Path;
-
-const PROTO_PATH: &str = "benches/grpc/dummy.proto";
+const PROTO_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/benches/grpc/dummy.proto");
 
 fn main() {
     let path = protoc_bin_vendored::protoc_bin_path().expect("Failed to find protoc binary");
     std::env::set_var("PROTOC", format!("{}", path.display()));
-    let proto_file_path = Path::new(PROTO_PATH);
-    tonic_build::configure()
-        .compile(&[proto_file_path], &["proto"])
-        .unwrap();
+    tonic_build::compile_protos(PROTO_PATH).unwrap();
 }


### PR DESCRIPTION
**Summary:**  
I was getting the error:

```
Caused by:
  process didn't exit successfully: /Users/ssdd/RustroverProjects/tco/target/debug/build/tailcall-723743a2630484bd/build-script-build (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=/Users/ssdd/RustroverProjects/tco/benches/grpc/dummy.proto
  cargo:rerun-if-changed=proto
  --- stderr
  thread 'main' panicked at build.rs:11:10:
  called Result::unwrap() on an Err value: Custom { kind: Other, error: "protoc failed: /Users/ssdd/RustroverProjects/tco/benches/grpc/dummy.proto: File does not reside within any path specified using --proto_path (or -I).  You must specify a --proto_path which encompasses this file.  Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths (e.g. absolute and relative) are equivalent (it's harder than you think).\n" }
```
While trying to build taicall. This pr fixes the issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified code logic in the build process by optimizing protocol buffer compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->