### PR TITLE
fix: input types loose out on provided graphQL documentation

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -835,4 +835,30 @@ mod tests {
         )]);
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn test_from_sdl_description() {
+        let actual = Config::from_sdl(
+            r#"
+                """
+                Some Documentation
+                """
+                input Foo {
+                    id: Int!
+                }
+                "#,
+        )
+        .to_result()
+        .unwrap();
+
+        let expected = Config::default().types(vec![(
+            "Foo",
+            Type {
+                doc: Some("Some Documentation".to_string()),
+                ..Default::default()
+            }
+            .fields(vec![("id", Field::int().required(true))]),
+        )]);
+        assert_eq!(actual, expected);
+    }
 }

--- a/tests/execution/test-input-documentation.md
+++ b/tests/execution/test-input-documentation.md
@@ -1,0 +1,18 @@
+---
+check_identity: true
+---
+
+# test-input-documentation
+
+```graphql @server
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  input: Foo
+}
+
+"""
+This is a test
+"""
+input Foo {
+  id: Int!
+}
+```


### PR DESCRIPTION
**Summary:**  
Add descriptions to input object types

**Issue Reference(s):**  
Fixes #1625

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs

/claim #1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced parsing capabilities for SDL descriptions, improving the creation of types with documentation and fields.
- **Tests**
	- Added a new test for verifying the improved parsing functionality of SDL descriptions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->