### PR TITLE
ci: Track benchmarks with Bencher

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macro_benchmark:
+  macro_benchmarks:
     name: Macro Benchmarks
     if: "contains(github.event.pull_request.labels.*.name, 'ci: benchmark') || github.event_name == 'push'"
     runs-on: benchmarking-runner
@@ -68,68 +68,3 @@ jobs:
         with:
           name: body
           path: ci-benchmark/body.md
-
-  Cache_Benchmarks:
-    name: Cache Micro Benchmarks result
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    permissions:
-      pull-requests: write
-      contents: write
-    runs-on: benchmarking-runner
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Run Benchmarks
-        run: |
-          cargo install cargo-criterion rust-script
-          cargo criterion --message-format=json > benches/main_benchmarks.json
-          ./scripts/json_to_md.rs benches/main_benchmarks.json > benches/main_benchmarks.md
-          cat benches/main_benchmarks.md
-
-      - name: Cache Criterion Benchmarks Json
-        uses: actions/cache@v4
-        with:
-          path: benches/main_benchmarks.json
-          key: criterion_benchmarks_${{ github.sha }}
-
-  Criterion_Compare:
-    name: Comparing Micro Benchmarks
-    if: "contains(github.event.pull_request.labels.*.name, 'ci: benchmark')"
-    runs-on: benchmarking-runner
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Run Criterion Benchmarks
-        run: |
-          cargo install cargo-criterion rust-script
-          cargo criterion --message-format=json > benches/benchmarks.json
-          ./scripts/json_to_md.rs benches/benchmarks.json > benches/change_benchmarks.md
-
-      - name: Print Criterion Benchmarks
-        run: cat benches/change_benchmarks.md
-
-      - name: Restore file
-        uses: actions/cache@v4
-        with:
-          path: benches/main_benchmarks.json
-          key: criterion_benchmarks_${{ github.event.pull_request.base.sha }}
-          fail-on-cache-miss: true
-
-      - name: Print Benchmark Comparision
-        run: ./scripts/criterion_compare.rs benches/main_benchmarks.json benches/benchmarks.json table
-
-      - name: Check Degradation
-        run: ./scripts/criterion_compare.rs  benches/main_benchmarks.json benches/benchmarks.json check

--- a/.github/workflows/benchmark_comment.yml
+++ b/.github/workflows/benchmark_comment.yml
@@ -1,4 +1,4 @@
-name: Comment on commit
+name: Benchmark comment on commit
 
 on:
   workflow_run:
@@ -7,8 +7,8 @@ on:
       - completed
 
 jobs:
-  comment:
-    name: Comment on commit
+  macro_benchmarks_comment:
+    name: Benchmark comment on commit
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/benchmark_main.yml
+++ b/.github/workflows/benchmark_main.yml
@@ -1,0 +1,35 @@
+name: Benchmark main
+
+on:
+  push:
+    paths-ignore: ["docs/**", "**.md"]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  micro_benchmarks:
+    name: Micro Benchmarks
+    runs-on: benchmarking-runner
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install Bencher CLI
+        uses: bencherdev/bencher@main
+
+      - name: Run Benchmarks
+        run: |
+          bencher run \
+          --project tailcall \
+          --branch main \
+          --testbed benchmarking-runner \
+          --token "${{ secrets.BENCHER_API_TOKEN }}" \
+          --adapter rust_criterion \
+          cargo bench

--- a/.github/workflows/benchmark_pr_run.yml
+++ b/.github/workflows/benchmark_pr_run.yml
@@ -1,0 +1,30 @@
+name: Benchmark PR Run
+
+on:
+  pull_request:
+    paths-ignore: ["docs/**", "**.md"]
+    types: [opened, reopened, edited, synchronize, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  micro_benchmarks_pr_run:
+    name: Micro Benchmarks for PR
+    if: "contains(github.event.pull_request.labels.*.name, 'ci: benchmark')"
+    runs-on: benchmarking-runner
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Benchmarks
+        run: cargo bench > benchmark_results.txt
+      - name: Upload Benchmark Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark_results.txt
+          path: ./benchmark_results.txt
+      - name: Upload GitHub Pull Request Event
+        uses: actions/upload-artifact@v4
+        with:
+          name: event.json
+          path: ${{ github.event_path }}

--- a/.github/workflows/benchmark_pr_track.yml
+++ b/.github/workflows/benchmark_pr_track.yml
@@ -1,0 +1,75 @@
+name: Benchmark PR Track
+
+on:
+  workflow_run:
+    workflows: [Benchmark PR Run]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  micro_benchmarks_pr_track:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      BENCHMARK_RESULTS: benchmark_results.txt
+      PR_EVENT: event.json
+    steps:
+      - name: Download Benchmark Results
+        uses: actions/github-script@v6
+        with:
+          script: |
+            async function downloadArtifact(artifactName) {
+              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+              });
+              let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+                return artifact.name == artifactName
+              })[0];
+              if (!matchArtifact) {
+                core.setFailed(`Failed to find artifact: ${artifactName}`);
+              }
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+              let fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`, Buffer.from(download.data));
+            }
+            await downloadArtifact(process.env.BENCHMARK_RESULTS);
+            await downloadArtifact(process.env.PR_EVENT);
+      - name: Unzip Benchmark Results
+        run: |
+          unzip $BENCHMARK_RESULTS.zip
+          unzip $PR_EVENT.zip
+      - name: Export PR Event Data
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let fs = require('fs');
+            let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
+            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
+            core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
+            core.exportVariable("PR_NUMBER", prEvent.number);
+      - uses: bencherdev/bencher@main
+      - name: Track Benchmarks with Bencher
+        run: |
+          bencher run \
+          --project tailcall \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch '${{ env.PR_HEAD }}' \
+          --branch-start-point '${{ env.PR_BASE }}' \
+          --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
+          --testbed benchmarking-runner \
+          --adapter rust_criterion \
+          --err \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --ci-number '${{ env.PR_NUMBER }}' \
+          --file "$BENCHMARK_RESULTS"


### PR DESCRIPTION
**Summary:**  
@tusharmath these changes move Tailcall over to using Bencher for tracking both the `main` branch micro-benchmarks and running micro-benchmarks on pull requests that have the label `ci: benchmark`. The results for PR runs will be posted as a comment on the pull request.

The macro-benchmarks are not yet moved over until there is a `wrk`  adapter added to Bencher: https://github.com/bencherdev/bencher/issues/347

In order for things to work in the `tailcallhq/tailcall` repo, you will need to have the `BENCHER_API_TOKEN` added as a Repository secret. I believe this is already in place from https://github.com/tailcallhq/tailcall/pull/1441, but I just wanted to make sure 😃

I have gone ahead and [created a Threshold](https://bencher.dev/docs/explanation/thresholds/) for the `main` branch, the `benchmarking-runner` testbed, and the `Latency` measure ([used by Criterion](https://bencher.dev/docs/explanation/adapters/#-rust-criterion)): https://bencher.dev/perf/tailcall/thresholds/1ff7a58c-8add-4a72-a759-bdeccbf6ffa1
This will be used to detect performance regressions on the `main` branch, and it will be cloned and used for all pull requests.
Feel free to reconfigure this Threshold to suite you all's needs.

This is an overview of the benchmarking GitHub Actions files:
- `benchmark_main.yml`: Runs the micro-benchmarks on pushes to the `main` branch
- `benchmark_pr_run.yml`: Runs the micro-benchmarks on PRs with the tag `ci: benchmark` and caches the results
- `benchmark_pr_track.yml`: Posts the micro-benchmark cached results to the PR as a comment
- `benchmark.yml`: Runs the macro-benchmarks on pushes to `main` and PRs with the `ci: benchmark` tag
- `benchmark_comment.yml`: Posts the macro-benchmark results to the commit as a comment

The documentation for the strategy used to track micro-benchmarks for PRs in GitHub Actions can be found there: https://bencher.dev/docs/how-to/github-actions/#benchmark-fork-pr-and-upload-from-default-branch

**Issue Reference(s):**  
Relates to: https://github.com/tailcallhq/tailcall/issues/436
Implements: https://github.com/tailcallhq/tailcall/issues/1300
Fixes: https://github.com/tailcallhq/tailcall/pull/1441

**Build & Testing:**

Testing this out requires changing the default branch for the repo, as required by `workflow_run`, and using `ubuntu-latest` as the `runs-on` testbed.
I did this in my fork using the `bencher_main` branch: https://github.com/epompeii/tailcall/tree/bencher_main
I also created a separate branch to test out creating a PR: https://github.com/epompeii/tailcall/tree/bencher_retry
This is the example pull request: https://github.com/epompeii/tailcall/pull/1
Which now includes a pull request comment made by Bencher with the micro-benchmark results: https://github.com/epompeii/tailcall/pull/1#issuecomment-2054039469

Again, my apologies for the hubris to not test things out the first time around. 🤦🏽‍♂️


- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Renamed and streamlined GitHub Actions workflows related to benchmarking.
- **Chores**
	- Removed specific benchmarking jobs to optimize workflow performance.
- **New Features**
	- Improved benchmarking processes for pull requests and main branch commits, enhancing feedback on performance changes.
- **Documentation**
	- Updated job names and descriptions for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->