### PR TITLE
fix: Duplicated CLI output related to read files

### DIFF
--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -26,7 +26,7 @@ impl ConfigReader {
     pub fn init(runtime: TargetRuntime) -> Self {
         Self {
             runtime: runtime.clone(),
-            resource_reader: ResourceReader::init(runtime.clone()),
+            resource_reader: ResourceReader::init(runtime.clone(), true),
             proto_reader: ProtoReader::init(runtime),
         }
     }
@@ -57,68 +57,68 @@ impl ConfigReader {
 
         for link in links.iter() {
             let path = Self::resolve_path(&link.src, parent_dir);
-            if link.type_of != LinkType::Protobuf {
-                // Read the file only if the type is not Protobuf
-                let source = self.resource_reader.read_file(&path).await?;
-                let content = source.content;
 
-                match link.type_of {
-                    LinkType::Config => {
-                        let config = Config::from_source(Source::detect(&source.path)?, &content)?;
+            let source = self.resource_reader.read_file(&path).await?;
 
-                        config_module =
-                            config_module.merge_right(ConfigModule::from(config.clone()));
+            let content = source.content;
 
-                        if !config.links.is_empty() {
-                            config_module = config_module.merge_right(
-                                self.ext_links(
-                                    ConfigModule::from(config),
-                                    Path::new(&link.src).parent(),
-                                )
-                                .await?,
-                            );
-                        }
-                    }
-                    LinkType::Protobuf => {}
-                    LinkType::Script => {
-                        config_module.extensions.script = Some(content);
-                    }
-                    LinkType::Cert => {
-                        config_module
-                            .extensions
-                            .cert
-                            .extend(self.load_cert(content.clone()).await?);
-                    }
-                    LinkType::Key => {
-                        config_module.extensions.keys =
-                            Arc::new(self.load_private_key(content.clone()).await?)
-                    }
-                    LinkType::Operation => {
-                        config_module.extensions.endpoint_set = EndpointSet::try_new(&content)?;
-                    }
-                    LinkType::Htpasswd => {
-                        config_module
-                            .extensions
-                            .htpasswd
-                            .push(Content { id: link.id.clone(), content: content.clone() });
-                    }
-                    LinkType::Jwks => {
-                        let de = &mut serde_json::Deserializer::from_str(&content);
+            match link.type_of {
+                LinkType::Config => {
+                    let config = Config::from_source(Source::detect(&source.path)?, &content)?;
 
-                        config_module.extensions.jwks.push(Content {
-                            id: link.id.clone(),
-                            content: serde_path_to_error::deserialize(de)?,
-                        })
+                    config_module = config_module.merge_right(ConfigModule::from(config.clone()));
+
+                    if !config.links.is_empty() {
+                        config_module = config_module.merge_right(
+                            self.ext_links(
+                                ConfigModule::from(config),
+                                Path::new(&link.src).parent(),
+                            )
+                            .await?,
+                        );
                     }
                 }
-            } else {
-                let path = Self::resolve_path(&link.src, parent_dir);
+                LinkType::Protobuf => {
+                    let path = Self::resolve_path(&link.src, parent_dir);
+                    let meta = self.proto_reader.read(path).await?;
+                    config_module
+                        .extensions
+                        .grpc_file_descriptors
+                        .push(Content {
+                            id: link.id.clone(),
+                            content: meta.descriptor_set.clone(),
+                        });
+                }
+                LinkType::Script => {
+                    config_module.extensions.script = Some(content);
+                }
+                LinkType::Cert => {
+                    config_module
+                        .extensions
+                        .cert
+                        .extend(self.load_cert(content.clone()).await?);
+                }
+                LinkType::Key => {
+                    config_module.extensions.keys =
+                        Arc::new(self.load_private_key(content.clone()).await?)
+                }
+                LinkType::Operation => {
+                    config_module.extensions.endpoint_set = EndpointSet::try_new(&content)?;
+                }
+                LinkType::Htpasswd => {
+                    config_module
+                        .extensions
+                        .htpasswd
+                        .push(Content { id: link.id.clone(), content: content.clone() });
+                }
+                LinkType::Jwks => {
+                    let de = &mut serde_json::Deserializer::from_str(&content);
 
-                let meta = self.proto_reader.read(path).await?;
-                config_module
-                    .extensions
-                    .grpc_file_descriptors
-                    .push(Content { id: link.id.clone(), content: meta.descriptor_set.clone() });
+                    config_module.extensions.jwks.push(Content {
+                        id: link.id.clone(),
+                        content: serde_path_to_error::deserialize(de)?,
+                    })
+                }
             }
         }
 

--- a/src/proto_reader.rs
+++ b/src/proto_reader.rs
@@ -19,7 +19,7 @@ pub struct ProtoMetadata {
 
 impl ProtoReader {
     pub fn init(runtime: TargetRuntime) -> Self {
-        Self { resource_reader: ResourceReader::init(runtime) }
+        Self { resource_reader: ResourceReader::init(runtime, true) }
     }
 
     pub async fn read_all<T: AsRef<str>>(&self, paths: &[T]) -> anyhow::Result<Vec<ProtoMetadata>> {


### PR DESCRIPTION
- fix duplicate logs
- fix: #1734
- /claim #1734
![image](https://github.com/tailcallhq/tailcall/assets/70096901/ba0d3149-d68d-4bea-aacb-7e4023935002)


**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
    - Improved handling of file reading in the configuration settings, ensuring more efficient processing for different file types.
    - Adjusted logic for reading files based on link type, with a separate handling for Protobuf files.
    - Refactored Protobuf link handling to a separate block for better organization.
    - Introduced a global cache using `lazy_static` and `Mutex` in `ResourceReader`, enabling content caching for improved performance.
    - Added an `enable_cache` field in `ResourceReader` to enable caching functionality in the `read_file` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->