### PR TITLE
fix: duplicate reading of proto file

### DIFF
--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -57,13 +57,10 @@ impl ConfigReader {
 
         for link in links.iter() {
             let path = Self::resolve_path(&link.src, parent_dir);
-
-            let source = self.resource_reader.read_file(&path).await?;
-
-            let content = source.content;
-
             match link.type_of {
                 LinkType::Config => {
+                    let source = self.resource_reader.read_file(&path).await?;
+                    let content = source.content;
                     let config = Config::from_source(Source::detect(&source.path)?, &content)?;
 
                     config_module = config_module.merge_right(ConfigModule::from(config.clone()));
@@ -90,28 +87,40 @@ impl ConfigReader {
                         });
                 }
                 LinkType::Script => {
+                    let source = self.resource_reader.read_file(&path).await?;
+                    let content = source.content;
                     config_module.extensions.script = Some(content);
                 }
                 LinkType::Cert => {
+                    let source = self.resource_reader.read_file(&path).await?;
+                    let content = source.content;
                     config_module
                         .extensions
                         .cert
                         .extend(self.load_cert(content.clone()).await?);
                 }
                 LinkType::Key => {
+                    let source = self.resource_reader.read_file(&path).await?;
+                    let content = source.content;
                     config_module.extensions.keys =
                         Arc::new(self.load_private_key(content.clone()).await?)
                 }
                 LinkType::Operation => {
+                    let source = self.resource_reader.read_file(&path).await?;
+                    let content = source.content;
                     config_module.extensions.endpoint_set = EndpointSet::try_new(&content)?;
                 }
                 LinkType::Htpasswd => {
+                    let source = self.resource_reader.read_file(&path).await?;
+                    let content = source.content;
                     config_module
                         .extensions
                         .htpasswd
                         .push(Content { id: link.id.clone(), content: content.clone() });
                 }
                 LinkType::Jwks => {
+                    let source = self.resource_reader.read_file(&path).await?;
+                    let content = source.content;
                     let de = &mut serde_json::Deserializer::from_str(&content);
 
                     config_module.extensions.jwks.push(Content {

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -97,13 +97,12 @@ impl ConfigReader {
                     config_module
                         .extensions
                         .cert
-                        .extend(self.load_cert(content.clone()).await?);
+                        .extend(self.load_cert(content).await?);
                 }
                 LinkType::Key => {
                     let source = self.resource_reader.read_file(&path).await?;
                     let content = source.content;
-                    config_module.extensions.keys =
-                        Arc::new(self.load_private_key(content.clone()).await?)
+                    config_module.extensions.keys = Arc::new(self.load_private_key(content).await?)
                 }
                 LinkType::Operation => {
                     let source = self.resource_reader.read_file(&path).await?;
@@ -116,7 +115,7 @@ impl ConfigReader {
                     config_module
                         .extensions
                         .htpasswd
-                        .push(Content { id: link.id.clone(), content: content.clone() });
+                        .push(Content { id: link.id.clone(), content });
                 }
                 LinkType::Jwks => {
                     let source = self.resource_reader.read_file(&path).await?;


### PR DESCRIPTION
**Summary:**  
Issue: In case of `LinkType::Protobuf`, the file reading happens by `proto_reader.read()`. The duplication was happening at line 61 `resource_reader.read_file()`.
Fix: separating file reading logic for different link types
![image](https://github.com/tailcallhq/tailcall/assets/28844854/796c243c-eba4-40bf-a230-779e5d85e58e)


**Issue Reference(s):**  
Fixes #1734
/claim #1734

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Improved clarity in configuration reading by separating content retrieval logic for different link types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->