### PR TITLE
fix(grpc): import the same proto from multiple linked proto files

### DIFF
--- a/src/config/config_module.rs
+++ b/src/config/config_module.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::sync::Arc;
 
 use derive_setters::Setters;
 use jsonwebtoken::jwk::JwkSet;
-use prost_reflect::prost_types::FileDescriptorSet;
+use prost_reflect::prost_types::{FileDescriptorProto, FileDescriptorSet};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 
 use crate::config::Config;
@@ -43,7 +43,7 @@ impl<A> Deref for Content<A> {
 #[derive(Clone, Debug, Default, MergeRight)]
 pub struct Extensions {
     /// Contains the file descriptor set resolved from the links to proto files
-    pub grpc_file_descriptor_set: Option<FileDescriptorSet>,
+    pub grpc_file_descriptors: HashMap<String, FileDescriptorProto>,
 
     /// Contains the contents of the JS file
     pub script: Option<String>,
@@ -64,17 +64,14 @@ pub struct Extensions {
 
 impl Extensions {
     pub fn add_proto(&mut self, metadata: ProtoMetadata) {
-        if let Some(set) = self.grpc_file_descriptor_set.as_mut() {
-            set.file.extend(metadata.descriptor_set.file);
-        } else {
-            let _ = self
-                .grpc_file_descriptor_set
-                .insert(metadata.descriptor_set);
+        for file in metadata.descriptor_set.file {
+            self.grpc_file_descriptors
+                .insert(file.name().to_string(), file);
         }
     }
 
-    pub fn get_file_descriptor_set(&self) -> Option<&FileDescriptorSet> {
-        self.grpc_file_descriptor_set.as_ref()
+    pub fn get_file_descriptor_set(&self) -> FileDescriptorSet {
+        FileDescriptorSet { file: self.grpc_file_descriptors.values().cloned().collect() }
     }
 
     pub fn has_auth(&self) -> bool {
@@ -161,95 +158,5 @@ impl From<Config> for ConfigModule {
         let output_types = get_output_types(&config, &input_types);
 
         ConfigModule { config, input_types, output_types, ..Default::default() }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    mod extensions {
-        mod merge_right {
-            use std::path::Path;
-
-            use prost_reflect::prost_types::FileDescriptorSet;
-
-            use crate::config::Extensions;
-            use crate::merge_right::MergeRight;
-
-            #[test]
-            fn grpc_file_descriptor_set_none() {
-                let extensions1 = Extensions::default();
-                let extensions2 = Extensions::default();
-
-                assert_eq!(
-                    extensions1
-                        .merge_right(extensions2)
-                        .grpc_file_descriptor_set,
-                    None
-                );
-            }
-
-            #[test]
-            fn grpc_file_descriptor_set_single() {
-                let greetings_path = Path::new("src/grpc/tests/proto/greetings.proto");
-
-                let file_descriptor_set = protox::compile([greetings_path], ["."]).unwrap();
-                let extensions1 = Extensions {
-                    grpc_file_descriptor_set: Some(file_descriptor_set.clone()),
-                    ..Default::default()
-                };
-                let extensions2 = Extensions::default();
-
-                assert_eq!(
-                    extensions1
-                        .merge_right(extensions2)
-                        .grpc_file_descriptor_set,
-                    Some(file_descriptor_set.clone())
-                );
-
-                let extensions1 = Extensions::default();
-                let extensions2 = Extensions {
-                    grpc_file_descriptor_set: Some(file_descriptor_set.clone()),
-                    ..Default::default()
-                };
-
-                assert_eq!(
-                    extensions1
-                        .merge_right(extensions2)
-                        .grpc_file_descriptor_set,
-                    Some(file_descriptor_set)
-                );
-            }
-
-            #[test]
-            fn grpc_file_descriptor_set_both() {
-                let greetings_path = Path::new("src/grpc/tests/proto/greetings.proto");
-                let news_path = Path::new("src/grpc/tests/proto/news.proto");
-
-                let file_descriptor_set_greetings =
-                    protox::compile([greetings_path], ["."]).unwrap();
-                let file_descriptor_set_news = protox::compile([news_path], ["."]).unwrap();
-                let extensions1 = Extensions {
-                    grpc_file_descriptor_set: Some(file_descriptor_set_greetings.clone()),
-                    ..Default::default()
-                };
-                let extensions2 = Extensions {
-                    grpc_file_descriptor_set: Some(file_descriptor_set_news.clone()),
-                    ..Default::default()
-                };
-
-                assert_eq!(
-                    extensions1
-                        .merge_right(extensions2)
-                        .grpc_file_descriptor_set,
-                    Some(FileDescriptorSet {
-                        file: file_descriptor_set_greetings
-                            .file
-                            .into_iter()
-                            .chain(file_descriptor_set_news.file)
-                            .collect()
-                    })
-                );
-            }
-        }
     }
 }

--- a/src/grpc/data_loader_request.rs
+++ b/src/grpc/data_loader_request.rs
@@ -95,14 +95,9 @@ mod tests {
         let reader = ConfigReader::init(runtime);
         let config_module = reader.resolve(config, None).await.unwrap();
 
-        let protobuf_set = ProtobufSet::from_proto_file(
-            config_module
-                .extensions
-                .get_file_descriptor_set()
-                .unwrap()
-                .clone(),
-        )
-        .unwrap();
+        let protobuf_set =
+            ProtobufSet::from_proto_file(config_module.extensions.get_file_descriptor_set())
+                .unwrap();
 
         let service = protobuf_set.find_service(&method).unwrap();
 

--- a/src/grpc/protobuf.rs
+++ b/src/grpc/protobuf.rs
@@ -299,9 +299,7 @@ pub mod tests {
             .resolve(config, None)
             .await?
             .extensions
-            .get_file_descriptor_set()
-            .unwrap()
-            .to_owned())
+            .get_file_descriptor_set())
     }
 
     #[test]

--- a/src/grpc/request_template.rs
+++ b/src/grpc/request_template.rs
@@ -169,9 +169,7 @@ mod tests {
                 .await
                 .unwrap()
                 .extensions
-                .get_file_descriptor_set()
-                .unwrap()
-                .clone(),
+                .get_file_descriptor_set(),
         )
         .unwrap();
 

--- a/src/merge_right.rs
+++ b/src/merge_right.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 pub trait MergeRight {
@@ -61,6 +61,16 @@ where
 impl<V> MergeRight for HashSet<V>
 where
     V: Eq + std::hash::Hash,
+{
+    fn merge_right(mut self, other: Self) -> Self {
+        self.extend(other);
+        self
+    }
+}
+
+impl<K, V> MergeRight for HashMap<K, V>
+where
+    K: Eq + std::hash::Hash,
 {
     fn merge_right(mut self, other: Self) -> Self {
         self.extend(other);

--- a/tests/execution/grpc-proto-with-same-package.md
+++ b/tests/execution/grpc-proto-with-same-package.md
@@ -19,18 +19,17 @@ service FooService {
 ```protobuf @file:bar.proto
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
+
 package test;
 
-message Input {
-
-}
 
 message Bar {
   string bar = 1;
 }
 
 service BarService {
-  rpc GetBar (Input) returns (Bar) {}
+  rpc GetBar (google.protobuf.Empty) returns (Bar) {}
 }
 ```
 


### PR DESCRIPTION
**Summary:**  
The https://github.com/tailcallhq/tailcall/pull/1733 introduced new issue for case when multiple proto files imports the same proto file (e.g. google.protobuf.Empty). It was working before because `src/proto_reader.rs` handle the case for duplication files and we had all linked proto as separated FileDescriptorSet. But after mentioned pr config_module now stores single FileDescriptorSet that contains all the linked and imported proto files and that can lead to error 

```
Caused by:
    Validation Error
    • a different file named 'google/protobuf/empty.proto' has already been added [Query, bar, @grpc]
    • a different file named 'google/protobuf/empty.proto' has already been added [Query, foo, @grpc]
```

This pr tries to fix this by using hashmap inside config_module and dedupe all the imported proto files

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new implementation for merging operations in `HashMap`.

- **Refactor**
	- Streamlined the handling of protobuf files for more efficient processing.
	- Simplified instantiation and handling of protobuf sets in various modules.
	- Removed unnecessary cloning and method calls for cleaner code.

- **Bug Fixes**
	- Updated an RPC method in a service definition to take `google.protobuf.Empty` as input, ensuring correct data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->