### PR TITLE
chore(telemetry): update `async-graphql-extension-apollo-tracing` to `3.2.15`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,8 +297,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-extension-apollo-tracing"
-version = "3.2.14"
-source = "git+https://github.com/tailcallhq/async_graphql_apollo_studio_extension/#b7537c56bef0ae0152d879f98c3676b82506f4cb"
+version = "3.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c4d3cc0bb90e426ddedb5a0b30bd9c0a9aaec1351d0e96556d5919a18ff954"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ opentelemetry-appender-tracing = { version = "0.3.0" }
 opentelemetry-prometheus = "0.15.0"
 phonenumber = "0.3.4"
 chrono = "0.4.38"
-async-graphql-extension-apollo-tracing = { git = "https://github.com/tailcallhq/async_graphql_apollo_studio_extension/" }
+async-graphql-extension-apollo-tracing = { version = "3.2.15" }
 headers = "0.3.9" # previous version until hyper is updated to 1+
 mime = "0.3.17"
 htpasswd-verify = { version = "0.3.0", git = "https://github.com/twistedfall/htpasswd-verify", rev = "ff14703083cbd639f7d05622b398926f3e718d61" } # fork version that is wasm compatible


### PR DESCRIPTION
use released version instead of fork

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of `async-graphql-extension-apollo-tracing` to `3.2.15` to enhance stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->