### PR TITLE
fix: parse empty response body as Value::Null

### DIFF
--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -53,6 +53,14 @@ impl Type {
             Type::ListType { non_null, .. } => *non_null,
         }
     }
+
+    /// checks if the type is a list
+    pub fn is_list(&self) -> bool {
+        match self {
+            Type::NamedType { .. } => false,
+            Type::ListType { .. } => true,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/blueprint/blueprint.rs
+++ b/src/blueprint/blueprint.rs
@@ -53,14 +53,6 @@ impl Type {
             Type::ListType { non_null, .. } => *non_null,
         }
     }
-
-    /// checks if the type is a list
-    pub fn is_list(&self) -> bool {
-        match self {
-            Type::NamedType { .. } => false,
-            Type::ListType { .. } => true,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/blueprint/into_schema.rs
+++ b/src/blueprint/into_schema.rs
@@ -75,11 +75,11 @@ fn to_type(def: &Definition) -> dynamic::Type {
                                             ConstValue::List(a) => Some(FieldValue::list(a)),
                                             a => {
                                                 if a == ConstValue::Null && is_list {
-                                                     FieldValue::NONE
+                                                    FieldValue::NONE
                                                 } else {
-                                                    FieldValue::try_from(a).ok()
+                                                    Some(FieldValue::from(a))
                                                 }
-                                            },
+                                            }
                                         };
                                         Ok(p)
                                     }

--- a/src/blueprint/into_schema.rs
+++ b/src/blueprint/into_schema.rs
@@ -41,7 +41,6 @@ fn to_type(def: &Definition) -> dynamic::Type {
                 let field = field.clone();
                 let type_ref = to_type_ref(&field.of_type);
                 let field_name = &field.name.clone();
-                let is_list = field.of_type.is_list();
                 let mut dyn_schema_field = dynamic::Field::new(
                     field_name,
                     type_ref.clone(),
@@ -73,13 +72,8 @@ fn to_type(def: &Definition) -> dynamic::Type {
                                             expr.eval(ctx, &Concurrent::Sequential).await?;
                                         let p = match const_value {
                                             ConstValue::List(a) => Some(FieldValue::list(a)),
-                                            a => {
-                                                if a == ConstValue::Null && is_list {
-                                                    FieldValue::NONE
-                                                } else {
-                                                    Some(FieldValue::from(a))
-                                                }
-                                            }
+                                            ConstValue::Null => FieldValue::NONE,
+                                            a => Some(FieldValue::from(a)),
                                         };
                                         Ok(p)
                                     }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -34,7 +34,14 @@ impl Response<Bytes> {
         }
     }
 
-    pub fn to_json<T: DeserializeOwned>(self) -> Result<Response<T>> {
+    pub fn to_json<T: DeserializeOwned + Default>(self) -> Result<Response<T>> {
+        if self.body.is_empty() {
+            return Ok(Response {
+                status: self.status,
+                headers: self.headers,
+                body: Default::default(),
+            });
+        }
         let body = serde_json::from_slice::<T>(&self.body)?;
         Ok(Response { status: self.status, headers: self.headers, body })
     }

--- a/tests/execution/test-null-in-array.md
+++ b/tests/execution/test-null-in-array.md
@@ -1,0 +1,30 @@
+# Empty Array Response
+
+```graphql @server
+schema @server {
+  query: Query
+}
+
+type Query {
+  hi(id: ID!): [Company] @http(baseURL: "http://localhost:3000", path: "/hi")
+}
+type Company {
+  name: String
+  id: ID
+}
+```
+
+```yml @mock
+- request:
+    method: GET
+    url: http://localhost:3000/hi
+  response:
+    status: 200
+```
+
+```yml @test
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: "query { hi (id: 1) { name id } }"
+```

--- a/tests/execution/test-null-in-object.md
+++ b/tests/execution/test-null-in-object.md
@@ -1,0 +1,30 @@
+# Empty Object Response
+
+```graphql @server
+schema @server {
+  query: Query
+}
+
+type Query {
+  hi(id: ID!): Company @http(baseURL: "http://localhost:3000", path: "/hi")
+}
+type Company {
+  name: String
+  id: ID
+}
+```
+
+```yml @mock
+- request:
+    method: GET
+    url: http://localhost:3000/hi
+  response:
+    status: 200
+```
+
+```yml @test
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: "query { hi (id: 1) { name id } }"
+```

--- a/tests/snapshots/execution_spec__graphql-datasource-errors.md_test_0.snap
+++ b/tests/snapshots/execution_spec__graphql-datasource-errors.md_test_0.snap
@@ -9,9 +9,7 @@ expression: response
   },
   "body": {
     "data": {
-      "user": {
-        "name": null
-      }
+      "user": null
     },
     "errors": [
       {

--- a/tests/snapshots/execution_spec__test-null-in-array.md_client.snap
+++ b/tests/snapshots/execution_spec__test-null-in-array.md_client.snap
@@ -1,0 +1,28 @@
+---
+source: tests/execution_spec.rs
+expression: client
+---
+type Company {
+  id: ID
+  name: String
+}
+
+scalar Date
+
+scalar Email
+
+scalar Empty
+
+scalar JSON
+
+scalar PhoneNumber
+
+type Query {
+  hi(id: ID!): [Company]
+}
+
+scalar Url
+
+schema {
+  query: Query
+}

--- a/tests/snapshots/execution_spec__test-null-in-array.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-null-in-array.md_merged.snap
@@ -1,0 +1,16 @@
+---
+source: tests/execution_spec.rs
+expression: merged
+---
+schema @server @upstream {
+  query: Query
+}
+
+type Company {
+  id: ID
+  name: String
+}
+
+type Query {
+  hi(id: ID!): [Company] @http(baseURL: "http://localhost:3000", path: "/hi")
+}

--- a/tests/snapshots/execution_spec__test-null-in-array.md_test_0.snap
+++ b/tests/snapshots/execution_spec__test-null-in-array.md_test_0.snap
@@ -1,0 +1,15 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "hi": null
+    }
+  }
+}

--- a/tests/snapshots/execution_spec__test-null-in-object.md_client.snap
+++ b/tests/snapshots/execution_spec__test-null-in-object.md_client.snap
@@ -1,0 +1,28 @@
+---
+source: tests/execution_spec.rs
+expression: client
+---
+type Company {
+  id: ID
+  name: String
+}
+
+scalar Date
+
+scalar Email
+
+scalar Empty
+
+scalar JSON
+
+scalar PhoneNumber
+
+type Query {
+  hi(id: ID!): Company
+}
+
+scalar Url
+
+schema {
+  query: Query
+}

--- a/tests/snapshots/execution_spec__test-null-in-object.md_merged.snap
+++ b/tests/snapshots/execution_spec__test-null-in-object.md_merged.snap
@@ -1,0 +1,16 @@
+---
+source: tests/execution_spec.rs
+expression: merged
+---
+schema @server @upstream {
+  query: Query
+}
+
+type Company {
+  id: ID
+  name: String
+}
+
+type Query {
+  hi(id: ID!): Company @http(baseURL: "http://localhost:3000", path: "/hi")
+}

--- a/tests/snapshots/execution_spec__test-null-in-object.md_test_0.snap
+++ b/tests/snapshots/execution_spec__test-null-in-object.md_test_0.snap
@@ -1,0 +1,18 @@
+---
+source: tests/execution_spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "hi": {
+        "name": null,
+        "id": null
+      }
+    }
+  }
+}

--- a/tests/snapshots/execution_spec__test-null-in-object.md_test_0.snap
+++ b/tests/snapshots/execution_spec__test-null-in-object.md_test_0.snap
@@ -9,10 +9,7 @@ expression: response
   },
   "body": {
     "data": {
-      "hi": {
-        "name": null,
-        "id": null
-      }
+      "hi": null
     }
   }
 }


### PR DESCRIPTION
**Problem 1**
Empty string could not be deserialized as JSON
**Problem 2**
We were wrapping null value in some, that is why the expected array error was thrown by graphql executor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced type handling to support list structures more effectively.
	- Improved API response handling to provide default values when expected data is missing.

- **Tests**
	- Added tests to ensure correct handling of empty arrays and objects in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->