### PR TITLE
fix: remove extra trailing " using env variables

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -90,9 +90,9 @@ impl<'a, Ctx: ResolverContextLike<'a>> PathGraphql for EvaluationContext<'a, Ctx
             .and_then(|(head, tail)| match head.as_ref() {
                 "value" => Some(ctx.path_value(tail)?.to_string()),
                 "args" => Some(ctx.path_arg(tail)?.to_string()),
-                "headers" => ctx.header(tail[0].as_ref()).map(|v| format!(r#""{v}""#)),
-                "vars" => ctx.var(tail[0].as_ref()).map(|v| format!(r#""{v}""#)),
-                "env" => ctx.env_var(tail[0].as_ref()).map(|v| format!(r#""{v}""#)),
+                "headers" => ctx.header(tail[0].as_ref()).map(|v| format!(r#"{v}"#)),
+                "vars" => ctx.var(tail[0].as_ref()).map(|v| format!(r#"{v}"#)),
+                "env" => ctx.env_var(tail[0].as_ref()).map(|v| format!(r#"{v}"#)),
                 _ => None,
             })
     }


### PR DESCRIPTION
extra " like authorization: "'Bearer......." to be removed

**Summary:**  
Removed and extra `"` around env vars 

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved formatting in the display of "headers", "vars", and "env" values by removing extraneous quotes, enhancing readability and consistency for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->