### PR TITLE
fix: mark only rs and md files as text for git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+*.rs text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.rs text eol=lf
+*.md text eol=lf


### PR DESCRIPTION
**Summary:**  
Fixes the issue with binary files that always appear as staged

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
    - Modified `.gitattributes` to treat `.rs` files as text with LF line endings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->