### PR TITLE
fix(grpc): show additional error info from expression

### DIFF
--- a/src/blueprint/into_schema.rs
+++ b/src/blueprint/into_schema.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use async_graphql::dynamic::{self, FieldFuture, FieldValue, SchemaBuilder};
+use async_graphql::ErrorExtensions;
 use async_graphql_value::ConstValue;
 use futures_util::TryFutureExt;
 use tracing::Instrument;
@@ -68,8 +69,10 @@ fn to_type(def: &Definition) -> dynamic::Type {
                                         let ctx: ResolverContext = ctx.into();
                                         let ctx = EvaluationContext::new(req_ctx, &ctx);
 
-                                        let const_value =
-                                            expr.eval(ctx, &Concurrent::Sequential).await?;
+                                        let const_value = expr
+                                            .eval(ctx, &Concurrent::Sequential)
+                                            .await
+                                            .map_err(|err| err.extend())?;
                                         let p = match const_value {
                                             ConstValue::List(a) => Some(FieldValue::list(a)),
                                             ConstValue::Null => FieldValue::NONE,

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -15,6 +15,7 @@ use crate::graphql::GraphqlDataLoader;
 use crate::grpc;
 use crate::grpc::data_loader::GrpcDataLoader;
 use crate::http::{AppContext, DataLoaderRequest, HttpDataLoader};
+use crate::lambda::EvaluationError;
 use crate::runtime::TargetRuntime;
 
 #[derive(Setters)]
@@ -33,7 +34,7 @@ pub struct RequestContext {
     pub min_max_age: Arc<Mutex<Option<i32>>>,
     pub cache_public: Arc<Mutex<Option<bool>>>,
     pub runtime: TargetRuntime,
-    pub cache: AsyncCache<u64, ConstValue, String>,
+    pub cache: AsyncCache<u64, ConstValue, EvaluationError>,
 }
 
 impl RequestContext {

--- a/src/lambda/cache.rs
+++ b/src/lambda/cache.rs
@@ -3,10 +3,11 @@ use std::num::NonZeroU64;
 use std::ops::Deref;
 use std::pin::Pin;
 
-use anyhow::Result;
 use async_graphql_value::ConstValue;
 
-use super::{Concurrent, Eval, EvaluationContext, Expression, ResolverContextLike};
+use super::{
+    Concurrent, Eval, EvaluationContext, EvaluationError, Expression, ResolverContextLike,
+};
 
 pub trait CacheKey<Ctx> {
     fn cache_key(&self, ctx: &Ctx) -> u64;
@@ -39,7 +40,7 @@ impl Eval for Cache {
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ConstValue, EvaluationError>> + 'a + Send>> {
         Box::pin(async move {
             if let Expression::IO(io) = self.expr.deref() {
                 let key = io.cache_key(&ctx);

--- a/src/lambda/concurrent.rs
+++ b/src/lambda/concurrent.rs
@@ -1,6 +1,8 @@
 use futures_util::stream::FuturesUnordered;
 use futures_util::{Future, StreamExt};
 
+use super::EvaluationError;
+
 ///
 /// Concurrent controls the concurrency of a fold or foreach operation on lists.
 /// It's a flag that is set based on operators that are applied on a list.
@@ -19,7 +21,7 @@ impl Concurrent {
         iter: impl Iterator<Item = F>,
         acc: B,
         f: impl Fn(B, A) -> anyhow::Result<B>,
-    ) -> anyhow::Result<B>
+    ) -> Result<B, EvaluationError>
     where
         F: Future<Output = A>,
     {
@@ -46,9 +48,9 @@ impl Concurrent {
         &self,
         iter: impl Iterator<Item = F>,
         f: impl Fn(A) -> B,
-    ) -> anyhow::Result<Vec<B>>
+    ) -> Result<Vec<B>, EvaluationError>
     where
-        F: Future<Output = anyhow::Result<A>>,
+        F: Future<Output = Result<A, EvaluationError>>,
     {
         self.fold(iter, vec![], |mut acc, val| {
             acc.push(f(val?));

--- a/src/lambda/eval.rs
+++ b/src/lambda/eval.rs
@@ -1,9 +1,7 @@
 use core::future::Future;
 use std::pin::Pin;
 
-use anyhow::Result;
-
-use super::{Concurrent, EvaluationContext, ResolverContextLike};
+use super::{Concurrent, EvaluationContext, EvaluationError, ResolverContextLike};
 
 pub trait Eval<Output = async_graphql::Value>
 where
@@ -13,7 +11,7 @@ where
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<Output>> + 'a + Send>>
+    ) -> Pin<Box<dyn Future<Output = Result<Output, EvaluationError>> + 'a + Send>>
     where
         Output: 'a;
 }

--- a/src/lambda/io.rs
+++ b/src/lambda/io.rs
@@ -2,7 +2,7 @@ use core::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use anyhow::Result;
+use async_graphql::from_value;
 use async_graphql_value::ConstValue;
 use reqwest::Request;
 
@@ -49,20 +49,15 @@ impl Eval for IO {
         &'a self,
         ctx: super::EvaluationContext<'a, Ctx>,
         _conc: &'a super::Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ConstValue, EvaluationError>> + 'a + Send>> {
         let key = self.cache_key(&ctx);
         Box::pin(async move {
             ctx.request_ctx
                 .cache
                 .get_or_eval(key, move || {
-                    Box::pin(async {
-                        self.eval_inner(ctx, _conc)
-                            .await
-                            .map_err(|err| err.to_string())
-                    })
+                    Box::pin(async { self.eval_inner(ctx, _conc).await })
                 })
                 .await
-                .map_err(|err| anyhow::anyhow!(err))
         })
     }
 }
@@ -72,7 +67,7 @@ impl IO {
         &'a self,
         ctx: super::EvaluationContext<'a, Ctx>,
         _conc: &'a super::Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ConstValue, EvaluationError>> + 'a + Send>> {
         Box::pin(async move {
             match self {
                 IO::Http { req_template, dl_id, .. } => {
@@ -190,7 +185,7 @@ fn set_cookie_headers<'ctx, Ctx: ResolverContextLike<'ctx>>(
 async fn execute_raw_request<'ctx, Ctx: ResolverContextLike<'ctx>>(
     ctx: &EvaluationContext<'ctx, Ctx>,
     req: Request,
-) -> Result<Response<async_graphql::Value>> {
+) -> Result<Response<async_graphql::Value>, EvaluationError> {
     let response = ctx
         .request_ctx
         .runtime
@@ -207,12 +202,10 @@ async fn execute_raw_grpc_request<'ctx, Ctx: ResolverContextLike<'ctx>>(
     ctx: &EvaluationContext<'ctx, Ctx>,
     req: Request,
     operation: &ProtobufOperation,
-) -> Result<Response<async_graphql::Value>> {
-    Ok(
-        execute_grpc_request(&ctx.request_ctx.runtime, operation, req)
-            .await
-            .map_err(EvaluationError::from)?,
-    )
+) -> Result<Response<async_graphql::Value>, EvaluationError> {
+    execute_grpc_request(&ctx.request_ctx.runtime, operation, req)
+        .await
+        .map_err(EvaluationError::from)
 }
 
 async fn execute_grpc_request_with_dl<
@@ -227,7 +220,7 @@ async fn execute_grpc_request_with_dl<
     ctx: &EvaluationContext<'ctx, Ctx>,
     rendered: RenderedRequestTemplate,
     data_loader: Option<&DataLoader<grpc::DataLoaderRequest, Dl>>,
-) -> Result<Response<async_graphql::Value>> {
+) -> Result<Response<async_graphql::Value>, EvaluationError> {
     let headers = ctx
         .request_ctx
         .upstream
@@ -253,7 +246,7 @@ async fn execute_request_with_dl<
     ctx: &EvaluationContext<'ctx, Ctx>,
     req: Request,
     data_loader: Option<&DataLoader<DataLoaderRequest, Dl>>,
-) -> Result<Response<async_graphql::Value>> {
+) -> Result<Response<async_graphql::Value>, EvaluationError> {
     let headers = ctx
         .request_ctx
         .upstream
@@ -275,8 +268,9 @@ fn parse_graphql_response<'ctx, Ctx: ResolverContextLike<'ctx>>(
     ctx: &EvaluationContext<'ctx, Ctx>,
     res: Response<async_graphql::Value>,
     field_name: &str,
-) -> Result<async_graphql::Value> {
-    let res: async_graphql::Response = serde_json::from_value(res.body.into_json()?)?;
+) -> Result<async_graphql::Value, EvaluationError> {
+    let res: async_graphql::Response =
+        from_value(res.body).map_err(|err| EvaluationError::DeserializeError(err.to_string()))?;
 
     for error in res.errors {
         ctx.add_error(error);

--- a/src/lambda/list.rs
+++ b/src/lambda/list.rs
@@ -1,7 +1,6 @@
 use core::future::Future;
 use std::pin::Pin;
 
-use anyhow::Result;
 use async_graphql_value::ConstValue;
 use futures_util::future::join_all;
 
@@ -19,7 +18,7 @@ impl Eval for List {
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ConstValue, EvaluationError>> + 'a + Send>> {
         Box::pin(async move {
             match self {
                 List::Concat(list) => {
@@ -52,7 +51,7 @@ where
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<C>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<C, EvaluationError>> + 'a + Send>> {
         Box::pin(async move {
             let future_iter = self
                 .as_ref()
@@ -62,7 +61,7 @@ where
                 Concurrent::Parallel => join_all(future_iter)
                     .await
                     .into_iter()
-                    .collect::<Result<C>>(),
+                    .collect::<Result<C, _>>(),
                 Concurrent::Sequential => {
                     let mut results = Vec::with_capacity(self.as_ref().len());
                     for future in future_iter {

--- a/src/lambda/logic.rs
+++ b/src/lambda/logic.rs
@@ -1,10 +1,11 @@
 use core::future::Future;
 use std::pin::Pin;
 
-use anyhow::Result;
 use async_graphql_value::ConstValue;
 
-use super::{Concurrent, Eval, EvaluationContext, Expression, ResolverContextLike};
+use super::{
+    Concurrent, Eval, EvaluationContext, EvaluationError, Expression, ResolverContextLike,
+};
 
 #[derive(Clone, Debug, strum_macros::Display)]
 pub enum Logic {
@@ -26,7 +27,7 @@ impl Eval for Logic {
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ConstValue, EvaluationError>> + 'a + Send>> {
         Box::pin(async move {
             Ok(match self {
                 Logic::Or(list) => {

--- a/src/lambda/math.rs
+++ b/src/lambda/math.rs
@@ -2,7 +2,6 @@ use core::future::Future;
 use std::ops;
 use std::pin::Pin;
 
-use anyhow::Result;
 use async_graphql_value::ConstValue;
 
 use super::{
@@ -29,7 +28,7 @@ impl Eval for Math {
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ConstValue, EvaluationError>> + 'a + Send>> {
         Box::pin(async move {
             Ok(match self {
                 Math::Mod(lhs, rhs) => {

--- a/src/lambda/relation.rs
+++ b/src/lambda/relation.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::pin::Pin;
 
-use anyhow::Result;
 use async_graphql_value::ConstValue;
 use futures_util::future::join_all;
 
@@ -35,7 +34,7 @@ impl Eval for Relation {
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
         conc: &'a Concurrent,
-    ) -> Pin<Box<dyn Future<Output = Result<ConstValue>> + 'a + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ConstValue, EvaluationError>> + 'a + Send>> {
         Box::pin(async move {
             Ok(match self {
                 Relation::Intersection(exprs) => {
@@ -290,7 +289,7 @@ async fn set_operation<'a, 'b, Ctx: ResolverContextLike<'a> + Sync + Send, F>(
     lhs: &'a [Expression],
     rhs: &'a [Expression],
     operation: F,
-) -> Result<ConstValue>
+) -> Result<ConstValue, EvaluationError>
 where
     F: Fn(HashSet<HashableConstValue>, HashSet<HashableConstValue>) -> Vec<ConstValue>,
 {

--- a/tailcall-query-plan/src/resolver.rs
+++ b/tailcall-query-plan/src/resolver.rs
@@ -59,7 +59,7 @@ impl FieldPlan {
         &'a self,
         ctx: EvaluationContext<'a, Ctx>,
     ) -> Result<Value> {
-        self.resolver.eval(ctx, &Concurrent::Sequential).await
+        Ok(self.resolver.eval(ctx, &Concurrent::Sequential).await?)
     }
 }
 

--- a/tests/expression_spec.rs
+++ b/tests/expression_spec.rs
@@ -5,10 +5,12 @@ mod tests {
     use serde_json::json;
     use tailcall::blueprint::{Blueprint, DynamicValue};
     use tailcall::http::RequestContext;
-    use tailcall::lambda::{Concurrent, EmptyResolverContext, Eval, EvaluationContext, Expression};
+    use tailcall::lambda::{
+        Concurrent, EmptyResolverContext, Eval, EvaluationContext, EvaluationError, Expression,
+    };
     use tailcall::mustache::Mustache;
 
-    async fn eval(expr: &Expression) -> anyhow::Result<Value> {
+    async fn eval(expr: &Expression) -> Result<Value, EvaluationError> {
         let runtime = tailcall::cli::runtime::init(&Blueprint::default());
         let req_ctx = RequestContext::new(runtime);
         let res_ctx = EmptyResolverContext {};

--- a/tests/snapshots/execution_spec__grpc-error.md_test_0.snap
+++ b/tests/snapshots/execution_spec__grpc-error.md_test_0.snap
@@ -17,7 +17,17 @@ expression: response
             "line": 1,
             "column": 9
           }
-        ]
+        ],
+        "extensions": {
+          "grpc_code": 3,
+          "grpc_description": "Client specified an invalid argument",
+          "grpc_status_details": {
+            "code": 3,
+            "message": "error message",
+            "details": []
+          },
+          "grpc_status_message": "grpc message"
+        }
       }
     ]
   }


### PR DESCRIPTION
**Summary:**  
Pass error extension info from grpc upstream in response. To make it mostly replace anyhow::Error with explicit EvaluationError and work with it

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
