### PR TITLE
fix(scalar): custom scalars should return data as is

### DIFF
--- a/src/blueprint/schema.rs
+++ b/src/blueprint/schema.rs
@@ -51,7 +51,7 @@ pub fn validate_field_has_resolver(
                 let type_name = &field.type_of;
                 if let Some(ty) = types.get(type_name) {
                     // It's an enum
-                    if ty.variants.is_some() {
+                    if ty.variants.is_some() || ty.scalar {
                         return true;
                     }
                     let res = validate_type_has_resolvers(type_name, ty, types);

--- a/src/config/config_module.rs
+++ b/src/config/config_module.rs
@@ -117,6 +117,10 @@ fn get_input_types(config: &Config) -> HashSet<String> {
                     .filter(|(_, arg)| !scalar::is_scalar(&arg.type_of))
                 {
                     if let Some(t) = config.find_type(&arg.type_of) {
+                        if t.scalar {
+                            continue;
+                        }
+
                         t.fields.iter().for_each(|(_, f)| {
                             types.insert(f.type_of.clone());
                             recurse_type(config, &f.type_of, &mut types)

--- a/tests/core/snapshots/test-scalars.md_4.snap
+++ b/tests/core/snapshots/test-scalars.md_4.snap
@@ -8,20 +8,11 @@ expression: response
     "content-type": "application/json"
   },
   "body": {
-    "data": null,
-    "errors": [
-      {
-        "message": "internal: invalid value for scalar \"Email\", expected \"FieldValue::Value\"",
-        "locations": [
-          {
-            "line": 1,
-            "column": 3
-          }
-        ],
-        "path": [
-          "email"
-        ]
-      }
-    ]
+    "data": {
+      "any1": {
+        "test": "abc"
+      },
+      "any2": "string-value"
+    }
   }
 }

--- a/tests/core/snapshots/test-scalars.md_5.snap
+++ b/tests/core/snapshots/test-scalars.md_5.snap
@@ -11,7 +11,7 @@ expression: response
     "data": null,
     "errors": [
       {
-        "message": "internal: invalid value for scalar \"PhoneNumber\", expected \"FieldValue::Value\"",
+        "message": "internal: invalid value for scalar \"Email\", expected \"FieldValue::Value\"",
         "locations": [
           {
             "line": 1,
@@ -19,7 +19,7 @@ expression: response
           }
         ],
         "path": [
-          "phone"
+          "email"
         ]
       }
     ]

--- a/tests/core/snapshots/test-scalars.md_7.snap
+++ b/tests/core/snapshots/test-scalars.md_7.snap
@@ -11,7 +11,7 @@ expression: response
     "data": null,
     "errors": [
       {
-        "message": "internal: invalid value for scalar \"Date\", expected \"FieldValue::Value\"",
+        "message": "internal: invalid value for scalar \"PhoneNumber\", expected \"FieldValue::Value\"",
         "locations": [
           {
             "line": 1,
@@ -19,7 +19,7 @@ expression: response
           }
         ],
         "path": [
-          "date"
+          "phone"
         ]
       }
     ]

--- a/tests/core/snapshots/test-scalars.md_9.snap
+++ b/tests/core/snapshots/test-scalars.md_9.snap
@@ -11,7 +11,7 @@ expression: response
     "data": null,
     "errors": [
       {
-        "message": "internal: invalid value for scalar \"Date\", expected \"FieldValue::Value\"",
+        "message": "internal: invalid value for scalar \"Url\", expected \"FieldValue::Value\"",
         "locations": [
           {
             "line": 1,
@@ -19,7 +19,7 @@ expression: response
           }
         ],
         "path": [
-          "date"
+          "url"
         ]
       }
     ]

--- a/tests/core/snapshots/test-scalars.md_client.snap
+++ b/tests/core/snapshots/test-scalars.md_client.snap
@@ -2,6 +2,8 @@
 source: tests/core/spec.rs
 expression: client
 ---
+scalar AnyScalar
+
 scalar Date
 
 scalar Email
@@ -13,6 +15,7 @@ scalar JSON
 scalar PhoneNumber
 
 type Query {
+  any(value: AnyScalar!): AnyScalar
   date(value: Date!): Date!
   email(value: Email!): Email!
   phone(value: PhoneNumber!): PhoneNumber!

--- a/tests/core/snapshots/test-scalars.md_merged.snap
+++ b/tests/core/snapshots/test-scalars.md_merged.snap
@@ -6,15 +6,12 @@ schema @server(hostname: "localhost", port: 8000) @upstream {
   query: Query
 }
 
-scalar Date
+scalar AnyScalar
 
 scalar Email
 
-scalar PhoneNumber
-
-scalar Url
-
 type Query {
+  any(value: AnyScalar!): AnyScalar @expr(body: "{{.args.value}}")
   date(value: Date!): Date! @expr(body: "{{.args.value}}")
   email(value: Email!): Email! @expr(body: "{{.args.value}}")
   phone(value: PhoneNumber!): PhoneNumber! @expr(body: "{{.args.value}}")

--- a/tests/execution/test-scalars.md
+++ b/tests/execution/test-scalars.md
@@ -1,10 +1,11 @@
 # test-scalar-email
 
 ```graphql @server
+# this is already defined scalars in tailcall
 scalar Email
-scalar PhoneNumber
-scalar Date
-scalar Url
+
+# this is custom scalars in config
+scalar AnyScalar
 
 schema @server(port: 8000, hostname: "localhost") {
   query: Query
@@ -15,6 +16,7 @@ type Query {
   phone(value: PhoneNumber!): PhoneNumber! @expr(body: "{{.args.value}}")
   date(value: Date!): Date! @expr(body: "{{.args.value}}")
   url(value: Url!): Url! @expr(body: "{{.args.value}}")
+  any(value: AnyScalar!): AnyScalar @expr(body: "{{.args.value}}")
 }
 ```
 
@@ -38,6 +40,11 @@ type Query {
   url: http://localhost:8000/graphql
   body:
     query: '{ url(value: "https://tailcall.run/") }'
+
+- method: POST
+  url: http://localhost:8000/graphql
+  body:
+    query: '{ any1: any(value: { test: "abc" } ), any2: any(value: "string-value") }'
 
 # Invalid value test
 


### PR DESCRIPTION
**Summary:**  

Using custom scalar type was returning `{}` instead of the value itself

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
