### PR TITLE
fix: making `dedupe` nullable in `.tailcallrc.graphql`

### DIFF
--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -353,7 +353,7 @@ directive @upstream(
   When set to `true`, it will ensure no HTTP, GRPC, or any other IO call is made more 
   than once within the context of a single GraphQL request.
   """
-  dedupe: Boolean!
+  dedupe: Boolean
   """
   The `http2Only` setting allows you to specify whether the client should always issue 
   HTTP2 requests, without checking if the server supports it or not. By default it 

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -1341,7 +1341,10 @@
         },
         "dedupe": {
           "description": "When set to `true`, it will ensure no HTTP, GRPC, or any other IO call is made more than once within the context of a single GraphQL request.",
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "http2Only": {
           "description": "The `http2Only` setting allows you to specify whether the client should always issue HTTP2 requests, without checking if the server supports it or not. By default it is set to `false` for all HTTP requests made by the server, but is automatically set to true for GRPC.",

--- a/src/config/upstream.rs
+++ b/src/config/upstream.rs
@@ -139,7 +139,7 @@ pub struct Upstream {
     #[serde(default, skip_serializing_if = "is_default")]
     /// When set to `true`, it will ensure no HTTP, GRPC, or any other IO call
     /// is made more than once within the context of a single GraphQL request.
-    pub dedupe: bool,
+    pub dedupe: Option<bool>,
 }
 
 impl Upstream {
@@ -193,7 +193,7 @@ impl Upstream {
     }
 
     pub fn get_dedupe(&self) -> bool {
-        self.dedupe
+        self.dedupe.unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
