### PR TITLE
feat: @validate directive for custom scalars

### DIFF
--- a/examples/scripts/validate.js
+++ b/examples/scripts/validate.js
@@ -1,0 +1,3 @@
+function isEven(num) {
+	return num % 2 === 0
+}

--- a/examples/validate_custom_scalar.graphql
+++ b/examples/validate_custom_scalar.graphql
@@ -1,0 +1,12 @@
+scalar EvenNumber 
+
+schema 
+  @server(port: 8000, hostname: "localhost")
+  @link(type: Script, src: "scripts/validate.js") {
+  query: Query
+}
+
+type Query {
+  any(value: EvenNumber!): EvenNumber!
+    @expr(body: "{{.args.value}}")
+}

--- a/src/blueprint/definitions.rs
+++ b/src/blueprint/definitions.rs
@@ -506,6 +506,7 @@ pub fn to_field_definition(
         .and(fix_dangling_resolvers())
         .and(update_cache_resolvers())
         .and(update_protected(object_name).trace(Protected::trace_name().as_str()))
+        .and(update_validate(object_name).trace(config::Validate::trace_name().as_str()))
         .try_fold(
             &(config_module, field, type_of, name),
             FieldDefinition::default(),

--- a/src/blueprint/operators/mod.rs
+++ b/src/blueprint/operators/mod.rs
@@ -5,6 +5,7 @@ mod grpc;
 mod http;
 mod modify;
 mod protected;
+// mod validate;
 
 pub use call::*;
 pub use expr::*;
@@ -13,3 +14,4 @@ pub use grpc::*;
 pub use http::*;
 pub use modify::*;
 pub use protected::*;
+// pub use validate::*;

--- a/src/blueprint/operators/mod.rs
+++ b/src/blueprint/operators/mod.rs
@@ -5,7 +5,7 @@ mod grpc;
 mod http;
 mod modify;
 mod protected;
-// mod validate;
+mod validate;
 
 pub use call::*;
 pub use expr::*;
@@ -14,4 +14,4 @@ pub use grpc::*;
 pub use http::*;
 pub use modify::*;
 pub use protected::*;
-// pub use validate::*;
+pub use validate::*;

--- a/src/blueprint/operators/validate.rs
+++ b/src/blueprint/operators/validate.rs
@@ -1,0 +1,26 @@
+// use crate::blueprint::FieldDefinition;
+// use crate::config::{self, ConfigModule, Field};
+// use crate::lambda::{Expression, IO};
+// use crate::try_fold::TryFold;
+// use crate::valid::Valid;
+
+// pub fn update_validate<'a>(
+//     type_name: &'a str,
+// ) -> TryFold<'a, (&'a ConfigModule, &'a Field, &'a config::Type, &'a str), FieldDefinition, String>
+// {
+//     TryFold::<(&ConfigModule, &Field, &config::Type, &'a str), FieldDefinition, String>::new(
+//         |(config_module, field, _type, _), mut b_field| {
+//             if field.validate.is_some()
+//                 || _type.validate.is_some()
+//                 || config_module
+//                     .find_type(&field.type_of)
+//                     .and_then(|_type| _type.validate.as_ref())
+//                     .is_some()
+//             {
+//                 if !config_module.is_scalar(type_name) {
+//                     return Valid::fail("@validate can only be used on custom scalars".to_owned());
+//                 }
+//             }
+//         }
+//     )
+// }

--- a/src/blueprint/operators/validate.rs
+++ b/src/blueprint/operators/validate.rs
@@ -48,10 +48,10 @@ pub fn update_validate<'a>(
                 source: config_module.extensions.script.clone().expect("script is required"),
                 timeout: config_module.server.script.clone().map_or_else(|| None, |script| script.timeout).map(Duration::from_millis),
             };
-            let js_func = &field.validate.unwrap().js;
+            let js_func = &field.validate.as_ref().unwrap().js;
             let runtime = Runtime::new(script);
             let value = &field.const_field;
-            todo!()
+            todo!();
 
             Valid::succeed(b_field)
         }

--- a/src/blueprint/operators/validate.rs
+++ b/src/blueprint/operators/validate.rs
@@ -1,12 +1,69 @@
 use crate::blueprint::*;
 use crate::config::{self, ConfigModule, Field};
-use core::time::Duration;
-use crate::lambda::{Expression, IO};
 use crate::try_fold::TryFold;
 use crate::valid::{Valid, ValidationError, Validator};
 use rquickjs::{Runtime, Context, Function, FromJs};
+use serde_json;
 use crate::cli::javascript::setup_builtins;
 
+
+fn json_to_js<'js>(value: serde_json::Value, ctx: &rquickjs::Ctx<'js>) -> rquickjs::Result<(rquickjs::Value<'js>,)> {
+    let object = rquickjs::Object::new(ctx.clone())?;
+
+    match value {
+        serde_json::Value::Number(num) => {
+            if num.is_i64() {
+                object.set("value", num.as_i64().unwrap())?;
+            } else if num.is_f64() {
+                object.set("value", num.as_f64().unwrap())?;
+            }
+        }
+        serde_json::Value::String(string) => {
+            object.set("value", string)?;
+        }
+        serde_json::Value::Bool(boolean) => {
+            object.set("value", boolean)?;
+        }
+        serde_json::Value::Object(obj) => {
+            for (key, value) in obj {
+                let (value,) = json_to_js(value, ctx)?;
+                object.set(key, value)?;
+            }
+        }
+        _ => {}
+    }
+
+    Ok((object.into_value(),))
+}
+
+
+fn call(func: String, val: serde_json::Value, src: String) -> () {
+    let js_runtime = Runtime::new().ok().unwrap();
+    let context = Context::full(&js_runtime).ok().unwrap();
+
+    // context.with(|ctx| {
+    //     setup_builtins(&ctx).ok().unwrap();
+    //     ctx.eval(src)
+    // });
+
+    context.with(|ctx| {
+        let fn_as_value = ctx
+            .globals()
+            .get::<&str, Function>(func.as_str())
+            .map_err(|_| anyhow::anyhow!("globalThis not initialized"))
+            .ok().unwrap();
+
+        let function = fn_as_value
+            .as_function()
+            .ok_or(anyhow::anyhow!("`{func}` is not a function"))
+            .ok().unwrap();
+
+        let custom_scalar = json_to_js(val.clone(), &ctx).ok().unwrap();
+        let command: Option<rquickjs::Value> = function.call(custom_scalar).ok();
+
+        ()
+    });
+}
 
 pub fn update_validate<'a>(
     type_name: &'a str,
@@ -32,23 +89,6 @@ pub fn update_validate<'a>(
             let script = config_module.extensions.script.clone().expect("script is required");
             let js_runtime = Runtime::new().ok().unwrap();
             let context = Context::full(&js_runtime).ok().unwrap();
-
-            // context.with(|ctx| {
-            //     setup_builtins(&ctx).ok().unwrap();
-            //     ctx.eval(script)
-            // });
-
-            context.with(|ctx| {
-                let fn_as_value = ctx
-                    .globals()
-                    .get::<&str, Function>(js_func.as_str())
-                    .map_err(|_| anyhow::anyhow!("globalThis not initialized"));
-
-                let function = fn_as_value.ok().unwrap()
-                    .as_function()
-                    .ok_or(anyhow::anyhow!("`{js_func}` is not a function"));
-
-            });
 
             todo!();
 

--- a/src/blueprint/operators/validate.rs
+++ b/src/blueprint/operators/validate.rs
@@ -1,26 +1,59 @@
-// use crate::blueprint::FieldDefinition;
-// use crate::config::{self, ConfigModule, Field};
-// use crate::lambda::{Expression, IO};
-// use crate::try_fold::TryFold;
-// use crate::valid::Valid;
+use crate::blueprint::*;
+use crate::config::{self, ConfigModule, Field};
+use core::time::Duration;
+use crate::lambda::{Expression, IO};
+use crate::try_fold::TryFold;
+use crate::valid::{Valid, ValidationError, Validator};
+use crate::cli::javascript::Runtime;
+// use crate::cli::javascript::call;
+// use crate::cli::javascript::{Event, Command, setup_builtins};
+// use opentelemetry::trace::FutureExt;
+// use rquickjs::{Context, Runtime};
+// use rquickjs;
+// use reqwest::Request;
 
-// pub fn update_validate<'a>(
-//     type_name: &'a str,
-// ) -> TryFold<'a, (&'a ConfigModule, &'a Field, &'a config::Type, &'a str), FieldDefinition, String>
-// {
-//     TryFold::<(&ConfigModule, &Field, &config::Type, &'a str), FieldDefinition, String>::new(
-//         |(config_module, field, _type, _), mut b_field| {
-//             if field.validate.is_some()
-//                 || _type.validate.is_some()
-//                 || config_module
-//                     .find_type(&field.type_of)
-//                     .and_then(|_type| _type.validate.as_ref())
-//                     .is_some()
-//             {
-//                 if !config_module.is_scalar(type_name) {
-//                     return Valid::fail("@validate can only be used on custom scalars".to_owned());
-//                 }
-//             }
-//         }
-//     )
+
+// pub fn compile_validate(
+//     config_module: &ConfigModule,
+//     field: &Field,
+//     value: &serde_json::Value,
+//     validate: bool,
+// ) -> Valid<Expression, String> {
+//     Valid::fail("The validation function does not return a boolean".to_string())
+//         .when(
+//             call()
+//         )
 // }
+
+
+pub fn update_validate<'a>(
+    type_name: &'a str,
+) -> TryFold<'a, (&'a ConfigModule, &'a Field, &'a config::Type, &'a str), FieldDefinition, String>
+{
+    TryFold::<(&ConfigModule, &Field, &config::Type, &'a str), FieldDefinition, String>::new(
+        |(config_module, field, _type, _), mut b_field| {
+            if field.validate.is_some()
+                || _type.validate.is_some()
+                || config_module
+                    .find_type(&field.type_of)
+                    .and_then(|_type| _type.validate.as_ref())
+                    .is_some()
+            {
+                if !config_module.is_scalar(type_name) {
+                    return Valid::fail("@validate can only be used on custom scalars".to_owned());
+                }
+            }
+
+            let script = Script {
+                source: config_module.extensions.script.clone().expect("script is required"),
+                timeout: config_module.server.script.clone().map_or_else(|| None, |script| script.timeout).map(Duration::from_millis),
+            };
+            let js_func = &field.validate.unwrap().js;
+            let runtime = Runtime::new(script);
+            let value = &field.const_field;
+            todo!()
+
+            Valid::succeed(b_field)
+        }
+    )
+}

--- a/src/cli/javascript/mod.rs
+++ b/src/cli/javascript/mod.rs
@@ -11,7 +11,7 @@ mod runtime;
 pub use js_request::JsRequest;
 pub use js_response::JsResponse;
 pub use request_filter::RequestFilter;
-pub use runtime::Runtime;
+pub use runtime::{Runtime, setup_builtins};
 
 use crate::{blueprint, HttpIO};
 

--- a/src/cli/javascript/runtime.rs
+++ b/src/cli/javascript/runtime.rs
@@ -23,7 +23,7 @@ fn qjs_print(msg: String, is_err: bool) {
     }
 }
 
-fn setup_builtins(ctx: &Ctx<'_>) -> rquickjs::Result<()> {
+pub fn setup_builtins(ctx: &Ctx<'_>) -> rquickjs::Result<()> {
     ctx.globals().set("__qjs_print", js_qjs_print)?;
     let _: Value = ctx.eval_file("src/cli/javascript/shim/console.js")?;
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -111,6 +111,10 @@ pub struct Type {
     ///
     /// Contains source information for the type.
     pub tag: Option<Tag>,
+    ///
+    /// Indicates if a custom scalar type is valid
+    /// for a given JS function
+    pub validate: Option<Validate>,
 }
 
 impl Type {
@@ -603,10 +607,10 @@ pub struct Expr {
     pub body: Value,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Eq, schemars::JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Eq, schemars::JsonSchema, MergeRight)]
 pub struct Validate {
     /// Name of the JS function
-    pub js: JS,
+    pub js: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -266,6 +266,11 @@ pub struct Field {
     /// Marks field as protected by auth provider
     #[serde(default)]
     pub protected: Option<Protected>,
+
+    ///
+    /// Inserts a validation resolver for the field.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub validate: Option<Validate>,
 }
 
 // It's a terminal implementation of MergeRight
@@ -283,6 +288,7 @@ impl Field {
             || self.graphql.is_some()
             || self.grpc.is_some()
             || self.call.is_some()
+            || self.validate.is_some()
     }
 
     /// Returns a list of resolvable directives for the field.
@@ -305,6 +311,9 @@ impl Field {
         }
         if self.call.is_some() {
             directives.push(Call::trace_name());
+        }
+        if self.validate.is_some() {
+            directives.push(Validate::trace_name());
         }
         directives
     }
@@ -592,6 +601,12 @@ impl Display for GraphQLOperationType {
 /// template. schema.
 pub struct Expr {
     pub body: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Eq, schemars::JsonSchema)]
+pub struct Validate {
+    /// Name of the JS function
+    pub js: JS,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -11,8 +11,8 @@ use async_graphql::Name;
 use super::telemetry::Telemetry;
 use super::{Tag, JS};
 use crate::config::{
-    self, Cache, Call, Config, Enum, GraphQL, Grpc, Link, Modify, Omit, Protected, RootSchema,
-    Server, Union, Upstream,
+    self, Cache, Call, Config, Enum, GraphQL, Grpc, Link, Modify, Omit, Protected, RootSchema, 
+    Validate, Server, Union, Upstream,
 };
 use crate::directive::DirectiveCodec;
 use crate::valid::{Valid, Validator};
@@ -315,8 +315,9 @@ where
         .fuse(JS::from_directives(directives.iter()))
         .fuse(Call::from_directives(directives.iter()))
         .fuse(Protected::from_directives(directives.iter()))
+        .fuse(Validate::from_directives(directives.iter()))
         .map(
-            |(http, graphql, cache, grpc, omit, modify, script, call, protected)| {
+            |(http, graphql, cache, grpc, omit, modify, script, call, protected, validate)| {
                 let const_field = to_const_field(directives);
                 config::Field {
                     type_of,
@@ -335,6 +336,7 @@ where
                     cache,
                     call,
                     protected,
+                    validate,
                 }
             },
         )

--- a/src/config/from_document.rs
+++ b/src/config/from_document.rs
@@ -243,11 +243,12 @@ where
         .fuse(to_fields(fields))
         .fuse(Protected::from_directives(directives.iter()))
         .fuse(Tag::from_directives(directives.iter()))
-        .map(|(cache, fields, protected, tag)| {
+        .fuse(Validate::from_directives(directives.iter()))
+        .map(|(cache, fields, protected, tag, validate)| {
             let doc = description.to_owned().map(|pos| pos.node);
             let implements = implements.iter().map(|pos| pos.node.to_string()).collect();
             let added_fields = to_add_fields_from_directives(directives);
-            config::Type { fields, added_fields, doc, implements, cache, protected, tag }
+            config::Type { fields, added_fields, doc, implements, cache, protected, tag, validate }
         })
 }
 fn to_input_object(

--- a/src/config/into_document.rs
+++ b/src/config/into_document.rs
@@ -266,6 +266,7 @@ fn get_directives(field: &crate::config::Field) -> Vec<Positioned<ConstDirective
         field.cache.as_ref().map(|d| pos(d.to_directive())),
         field.call.as_ref().map(|d| pos(d.to_directive())),
         field.protected.as_ref().map(|d| pos(d.to_directive())),
+        field.validate.as_ref().map(|d| pos(d.to_directive())),
     ];
 
     directives.into_iter().flatten().collect()

--- a/src/lambda/modify.rs
+++ b/src/lambda/modify.rs
@@ -46,6 +46,9 @@ impl Expression {
                         Expression::Path(expr.modify_box(modifier), path)
                     }
                     Expression::Protect(expr) => Expression::Protect(expr.modify_box(modifier)),
+                    Expression::ScalarValidation(expr) => {
+                        Expression::ScalarValidation(expr.modify_box(modifier))
+                    },
                 }
             }
         }

--- a/tailcall-autogen/src/gen_gql_schema.rs
+++ b/tailcall-autogen/src/gen_gql_schema.rs
@@ -40,6 +40,7 @@ lazy_static! {
         ),
         ("js", vec![Entity::FieldDefinition], false),
         ("tag", vec![Entity::Object], false),
+        ("validate", vec![Entity::FieldDefinition], true),
     ];
 }
 
@@ -70,6 +71,7 @@ static OBJECT_WHITELIST: &[&str] = &[
     "PrometheusExporter",
     "Apollo",
     "Cors",
+    "Validate",
 ];
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
**Summary:**  
Adds the `@validate` directive for custom scalars. Currently, there is no mechanism to validate custom scalars as opposed to the other types in Tailcall.

**Issue Reference(s):**  
/claim #1847
closes #1847

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
