### PR TITLE
perf: moving `Expression` inside `Arc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,7 @@ opt-level = 3
 codegen-units = 1
 panic = 'abort'
 lto = 'thin'
-debug = false
+debug = true
 incremental = false
 overflow-checks = false
 

--- a/src/core/blueprint/from_config.rs
+++ b/src/core/blueprint/from_config.rs
@@ -56,11 +56,12 @@ pub fn apply_batching(mut blueprint: Blueprint) -> Blueprint {
     for def in blueprint.definitions.iter() {
         if let Definition::Object(object_type_definition) = def {
             for field in object_type_definition.fields.iter() {
-                if let Some(Expression::IO(IO::Http { group_by: Some(_), .. })) =
-                    field.resolver.clone()
-                {
-                    blueprint.upstream.batch = blueprint.upstream.batch.or(Some(Batch::default()));
-                    return blueprint;
+                if let Some(expr) = field.resolver.as_ref() {
+                    if let Expression::IO(IO::Http { group_by: Some(_), .. }) = expr.as_ref() {
+                        blueprint.upstream.batch =
+                            blueprint.upstream.batch.or(Some(Batch::default()));
+                        return blueprint;
+                    }
                 }
             }
         }

--- a/src/core/blueprint/mod.rs
+++ b/src/core/blueprint/mod.rs
@@ -25,7 +25,6 @@ pub use links::*;
 pub use operators::*;
 pub use schema::*;
 pub use server::*;
-pub use timeout::GlobalTimeout;
 pub use upstream::*;
 
 use crate::core::config::{Arg, ConfigModule, Field};

--- a/src/core/blueprint/operators/call.rs
+++ b/src/core/blueprint/operators/call.rs
@@ -120,7 +120,7 @@ fn compile_call(
                     b_field_next
                         .resolver
                         .as_ref()
-                        .map(|other_expr| expr.clone().and_then(other_expr.clone()))
+                        .map(|other_expr| expr.clone().and_then(other_expr.as_ref().clone()))
                         .unwrap_or(expr)
                 });
 

--- a/src/core/blueprint/operators/expr.rs
+++ b/src/core/blueprint/operators/expr.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_graphql_value::ConstValue;
 
 use crate::core::blueprint::*;
@@ -74,7 +76,7 @@ pub fn update_const_field<'a>(
                 value: &const_field.body,
                 validate: true,
             })
-            .map(|resolver| b_field.resolver(Some(resolver)))
+            .map(|resolver| b_field.resolver(Some(Arc::new(resolver))))
         },
     )
 }

--- a/src/core/blueprint/operators/graphql.rs
+++ b/src/core/blueprint/operators/graphql.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::core::blueprint::FieldDefinition;
 use crate::core::config::{self, ConfigModule, Field, GraphQLOperationType};
 use crate::core::graphql::RequestTemplate;
@@ -50,7 +52,7 @@ pub fn update_graphql<'a>(
             };
 
             compile_graphql(config, operation_type, graphql)
-                .map(|resolver| b_field.resolver(Some(resolver)))
+                .map(|resolver| b_field.resolver(Some(Arc::new(resolver))))
                 .and_then(|b_field| b_field.validate_field(type_of, config).map_to(b_field))
         },
     )

--- a/src/core/blueprint/operators/grpc.rs
+++ b/src/core/blueprint/operators/grpc.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::sync::Arc;
 
 use prost_reflect::prost_types::FileDescriptorSet;
 use prost_reflect::FieldDescriptor;
@@ -227,7 +228,7 @@ pub fn update_grpc<'a>(
                 grpc,
                 validate_with_schema: true,
             })
-            .map(|resolver| b_field.resolver(Some(resolver)))
+            .map(|resolver| b_field.resolver(Some(Arc::new(resolver))))
             .and_then(|b_field| {
                 b_field
                     .validate_field(type_of, config_module)

--- a/src/core/blueprint/operators/http.rs
+++ b/src/core/blueprint/operators/http.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::core::blueprint::*;
 use crate::core::config::group_by::GroupBy;
 use crate::core::config::Field;
@@ -81,7 +83,7 @@ pub fn update_http<'a>(
             };
 
             compile_http(config_module, field, http)
-                .map(|resolver| b_field.resolver(Some(resolver)))
+                .map(|resolver| b_field.resolver(Some(Arc::new(resolver))))
                 .and_then(|b_field| {
                     b_field
                         .validate_field(type_of, config_module)

--- a/src/core/blueprint/operators/modify.rs
+++ b/src/core/blueprint/operators/modify.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::core::blueprint::*;
 use crate::core::config;
 use crate::core::config::Field;
@@ -22,8 +24,8 @@ pub fn update_modify<'a>(
                             }
                         }
                     }
-                    b_field.resolver = Some(b_field.resolver.unwrap_or(Expression::Context(
-                        Context::Path(vec![b_field.name.clone()]),
+                    b_field.resolver = Some(b_field.resolver.unwrap_or(Arc::new(
+                        Expression::Context(Context::Path(vec![b_field.name.clone()])),
                     )));
                     b_field = b_field.name(new_name.clone());
                 }

--- a/src/core/blueprint/operators/protected.rs
+++ b/src/core/blueprint/operators/protected.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::core::blueprint::FieldDefinition;
 use crate::core::config::{self, ConfigModule, Field};
 use crate::core::lambda::{Context, Expression};
@@ -27,8 +29,14 @@ pub fn update_protected<'a>(
                     );
                 }
 
-                b_field.resolver = Some(Expression::Protect(Box::new(b_field.resolver.unwrap_or(
-                    Expression::Context(Context::Path(vec![b_field.name.clone()])),
+                b_field.resolver = Some(Arc::new(Expression::Protect(Box::new(
+                    b_field
+                        .resolver
+                        .unwrap_or(Arc::new(Expression::Context(Context::Path(vec![b_field
+                            .name
+                            .clone()]))))
+                        .as_ref()
+                        .clone(),
                 ))));
             }
 

--- a/tailcall-query-plan/src/plan.rs
+++ b/tailcall-query-plan/src/plan.rs
@@ -86,7 +86,8 @@ impl FieldTree {
                     let depends_on: Vec<Id> =
                         current_field_plan_id.map(|id| vec![id]).unwrap_or_default();
                     let id = field_plans.len().into();
-                    let field_plan = FieldPlan { id, resolver, depends_on };
+                    let field_plan =
+                        FieldPlan { id, resolver: resolver.as_ref().clone(), depends_on };
                     field_plans.push(field_plan);
                     Some(id)
                 } else {


### PR DESCRIPTION
**Summary:** 
Flamegraph before:

![flamegraph](https://github.com/tailcallhq/tailcall/assets/27275148/5cd989c5-452e-4a3b-9c01-c26d46d58738)

The highlighted area shows the cpu utilization due to `Expression::clone`

<img width="1505" alt="image" src="https://github.com/tailcallhq/tailcall/assets/27275148/85af3108-5320-4123-a58a-f09ec9d4df95">


Flamegraph after:

![flamegraph](https://github.com/tailcallhq/tailcall/assets/27275148/f931db33-f821-47de-9e64-6fa0a9dbcd65)

The `Expression::clone` part has disappeared

<img width="1506" alt="image" src="https://github.com/tailcallhq/tailcall/assets/27275148/f4c7bc73-509e-438d-acf2-1255996cb3aa">


**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
