### PR TITLE
fix: js build on some architectures 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,6 @@ jobs:
             os: ubuntu-latest
             rust: stable
             target: x86_64-unknown-linux-musl
-            features: --no-default-features --features cli
             libc: musl
             cross: true
 
@@ -278,7 +277,6 @@ jobs:
             os: ubuntu-latest
             rust: stable
             target: aarch64-unknown-linux-musl
-            features: --no-default-features --features cli
             libc: musl
             cross: true
 
@@ -286,7 +284,6 @@ jobs:
             os: ubuntu-latest
             rust: stable
             target: i686-unknown-linux-gnu
-            features: --no-default-features --features cli
             libc: glibc
             cross: true
 
@@ -312,7 +309,6 @@ jobs:
             os: windows-latest
             rust: stable
             target: x86_64-pc-windows-gnu
-            features: --no-default-features --features cli
             libc: glibc
             ext: ".exe"
 
@@ -320,7 +316,6 @@ jobs:
             os: windows-latest
             rust: stable
             target: aarch64-pc-windows-msvc
-            features: --no-default-features --features cli
             libc: msvc
             ext: ".exe"
 


### PR DESCRIPTION
This PR fixes tailcall build on these platforms:

linux-x64-musl
linux-arm64-musl
linux-ia32-gnu
win32-x64-gnu
win32-arm64-msvc

/claim #1869 