### PR TITLE
fix:  Enable JS build for all architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,6 @@ jobs:
             os: ubuntu-latest
             rust: stable
             target: i686-pc-windows-gnu
-            features: --no-default-features --features cli
             cross: true
             libc: glibc
             ext: ".exe"


### PR DESCRIPTION
**Summary:**  
Updated the CI to build Tailcall on all supported platforms without any feature flags

- Unsupported platforms

- [x]    linux-x64-musl
- [x]    linux-arm64-musl
- [x]    linux-ia32-gnu
- [x]    win32-x64-gnu
- [x]    win32-arm64-msvc
- [x]    win32-ia32-gnu

**Issue Reference(s):**  

Fixes #1869 
/claim #1869 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
