### PR TITLE
fix(config): overflow issue in get_all_used_type_names in case of cyclic type

### DIFF
--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -790,6 +790,10 @@ impl Config {
         }
         while let Some(type_name) = stack.pop() {
             if let Some(typ) = self.types.get(&type_name) {
+                if set.contains(&type_name) {
+                    continue;
+                }
+
                 set.insert(type_name);
                 for field in typ.fields.values() {
                     stack.extend(field.args.values().map(|arg| arg.type_of.clone()));
@@ -849,6 +853,32 @@ mod tests {
             "Foo",
             Type::default().fields(vec![("a", Field::int())]),
         )]);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_unused_types_with_cyclic_types() {
+        let config = Config::from_sdl(
+            "
+            type Bar {a: Int}
+            type Foo {a: [Foo]}
+
+            type Query {
+                foos: [Foo]
+            }
+
+            schema {
+                query: Query
+            }
+            ",
+        )
+        .to_result()
+        .unwrap();
+
+        let actual = config.unused_types();
+        let mut expected = HashSet::new();
+        expected.insert("Bar".to_string());
+
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
**Summary:**  

- Adds a simple check to know if the node was visited before 

**Issue Reference(s):**  
Fixes #2106 

**Build & Testing:**

- [X] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [X] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [X] I have performed a self-review of my code.
- [X] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
