### PR TITLE
refactor: use display macro instead of manual implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ which = { version = "6.0.1", optional = true }
 async-recursion = "1.1.1"
 tempfile = "3.10.1"
 rquickjs = { "version" = "0.5.1", optional = true, features = ["macro"] }
-strum_macros = "0.26.2"
+strum_macros = "0.26.4"
 # TODO: disable some levels with features?
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.18", features = [

--- a/src/core/ir/mod.rs
+++ b/src/core/ir/mod.rs
@@ -8,7 +8,7 @@ mod modify;
 mod resolver_context_like;
 
 use core::future::Future;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::pin::Pin;
 
 use async_graphql_value::ConstValue;
@@ -19,32 +19,21 @@ pub use evaluation_context::EvaluationContext;
 pub use graphql_operation_context::GraphQLOperationContext;
 pub use io::*;
 pub use resolver_context_like::{EmptyResolverContext, ResolverContext, ResolverContextLike};
+use strum_macros::Display;
 
 use crate::core::blueprint::DynamicValue;
 use crate::core::json::JsonLike;
 use crate::core::serde_value_ext::ValueExt;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Display)]
 pub enum IR {
     Context(Context),
     Dynamic(DynamicValue),
+    #[strum(to_string = "{0}")]
     IO(IO),
     Cache(Cache),
     Path(Box<IR>, Vec<String>),
     Protect(Box<IR>),
-}
-
-impl Display for IR {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            IR::Context(_) => write!(f, "Context"),
-            IR::Dynamic(_) => write!(f, "Literal"),
-            IR::IO(io) => write!(f, "{io}"),
-            IR::Cache(_) => write!(f, "Cache"),
-            IR::Path(_, _) => write!(f, "Input"),
-            IR::Protect(expr) => write!(f, "Protected({expr})"),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
**Summary:**  
Just a small change in Display implementation for IR that is now possible with latest version of `strum_macros`

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
