### PR TITLE
chore(into_children): avoid having children as root nodes

### DIFF
--- a/src/core/ir/jit/model.rs
+++ b/src/core/ir/jit/model.rs
@@ -96,9 +96,7 @@ impl Field<Parent> {
         } else {
             Some(Children(children))
         };
-        if set.contains(&self.id) {
-            return None;
-        }
+
         Some(Field {
             id: self.id,
             name: self.name,

--- a/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__default_value.snap
+++ b/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__default_value.snap
@@ -95,10 +95,5 @@ ExecutionPlan {
                 ),
             ),
         },
-        Field {
-            id: 1,
-            name: "id",
-            type_of: Int!,
-        },
     ],
 }

--- a/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__from_document.snap
+++ b/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__from_document.snap
@@ -71,37 +71,5 @@ ExecutionPlan {
                 ),
             ),
         },
-        Field {
-            id: 1,
-            name: "user",
-            ir: "Some(..)",
-            type_of: User,
-            refs: Some(
-                Children(
-                    [
-                        Field {
-                            id: 2,
-                            name: "id",
-                            type_of: Int!,
-                        },
-                        Field {
-                            id: 3,
-                            name: "name",
-                            type_of: String!,
-                        },
-                    ],
-                ),
-            ),
-        },
-        Field {
-            id: 2,
-            name: "id",
-            type_of: Int!,
-        },
-        Field {
-            id: 3,
-            name: "name",
-            type_of: String!,
-        },
     ],
 }

--- a/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__multiple_operations.snap
+++ b/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__multiple_operations.snap
@@ -99,16 +99,6 @@ ExecutionPlan {
             ),
         },
         Field {
-            id: 1,
-            name: "id",
-            type_of: Int!,
-        },
-        Field {
-            id: 2,
-            name: "username",
-            type_of: String!,
-        },
-        Field {
             id: 3,
             name: "posts",
             ir: "Some(..)",
@@ -129,16 +119,6 @@ ExecutionPlan {
                     ],
                 ),
             ),
-        },
-        Field {
-            id: 4,
-            name: "id",
-            type_of: Int!,
-        },
-        Field {
-            id: 5,
-            name: "title",
-            type_of: String!,
         },
     ],
 }

--- a/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__simple_mutation.snap
+++ b/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__simple_mutation.snap
@@ -190,35 +190,5 @@ ExecutionPlan {
                 ),
             ),
         },
-        Field {
-            id: 1,
-            name: "id",
-            type_of: Int!,
-        },
-        Field {
-            id: 2,
-            name: "name",
-            type_of: String!,
-        },
-        Field {
-            id: 3,
-            name: "email",
-            type_of: String!,
-        },
-        Field {
-            id: 4,
-            name: "phone",
-            type_of: String,
-        },
-        Field {
-            id: 5,
-            name: "website",
-            type_of: String,
-        },
-        Field {
-            id: 6,
-            name: "username",
-            type_of: String!,
-        },
     ],
 }

--- a/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__simple_query.snap
+++ b/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__simple_query.snap
@@ -58,27 +58,5 @@ ExecutionPlan {
                 ),
             ),
         },
-        Field {
-            id: 1,
-            name: "user",
-            ir: "Some(..)",
-            type_of: User,
-            refs: Some(
-                Children(
-                    [
-                        Field {
-                            id: 2,
-                            name: "id",
-                            type_of: Int!,
-                        },
-                    ],
-                ),
-            ),
-        },
-        Field {
-            id: 2,
-            name: "id",
-            type_of: Int!,
-        },
     ],
 }

--- a/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__variables.snap
+++ b/src/core/ir/jit/snapshots/tailcall__core__ir__jit__builder__tests__variables.snap
@@ -80,15 +80,5 @@ ExecutionPlan {
                 ),
             ),
         },
-        Field {
-            id: 1,
-            name: "id",
-            type_of: Int!,
-        },
-        Field {
-            id: 2,
-            name: "name",
-            type_of: String!,
-        },
     ],
 }


### PR DESCRIPTION
ext of: #2105 and hence #2090

**Description**

Currently while creating/reading store, we need to iterate over Vec<Field<Children>> but the vector might contain a copy of child nodes at its root level. This change makes sure that proper tree is created which contains only the root nodes at root level.