### PR TITLE
fix: handle plural singular type name as one.

### DIFF
--- a/src/core/config/transformer/snapshots/tailcall__core__config__transformer__type_name_generator__test__type_name_generator.snap
+++ b/src/core/config/transformer/snapshots/tailcall__core__config__transformer__type_name_generator__test__type_name_generator.snap
@@ -1,0 +1,26 @@
+---
+source: src/core/config/transformer/type_name_generator.rs
+expression: transformed_config.to_sdl()
+---
+schema @server(hostname: "0.0.0.0", port: 8000) @upstream(baseURL: "http://example.typicode.com", httpCache: 42) {
+  query: Query
+}
+
+type Color {
+  colors: [T3]
+  isColorPageExists: Boolean
+  isColorsImageAvailable: Boolean
+}
+
+type F1 {
+  color: Color
+}
+
+type Query {
+  f1: F1 @http(path: "/colors")
+}
+
+type T3 {
+  hexCode: String
+  name: String
+}

--- a/src/core/config/transformer/type_name_generator.rs
+++ b/src/core/config/transformer/type_name_generator.rs
@@ -40,14 +40,16 @@ impl<'a> CandidateConvergence<'a> {
             if let Some((candidate_name, _)) = candidate_list
                 .iter()
                 .filter(|(candidate_name, _)| {
-                    !converged_candidate_set.contains(candidate_name)
-                        && !self.config.types.contains_key(*candidate_name)
+                    let singularized_candidate_name = candidate_name.to_singular().to_pascal_case();
+                    !converged_candidate_set.contains(&singularized_candidate_name)
+                        && !self.config.types.contains_key(&singularized_candidate_name)
                 })
                 .max_by_key(|&(_, candidate)| (candidate.frequency, candidate.priority))
             {
                 let singularized_candidate_name = candidate_name.to_singular().to_pascal_case();
-                finalized_candidates.insert(type_name.to_owned(), singularized_candidate_name);
-                converged_candidate_set.insert(candidate_name);
+                finalized_candidates
+                    .insert(type_name.to_owned(), singularized_candidate_name.clone());
+                converged_candidate_set.insert(singularized_candidate_name);
             }
         }
 
@@ -170,6 +172,18 @@ mod test {
     #[test]
     fn test_type_name_generator_with_cyclic_types() -> anyhow::Result<()> {
         let config = Config::from_sdl(read_fixture(configs::CYCLIC_CONFIG).as_str())
+            .to_result()
+            .unwrap();
+
+        let transformed_config = TypeNameGenerator.transform(config).to_result().unwrap();
+        insta::assert_snapshot!(transformed_config.to_sdl());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_type_name_generator() -> anyhow::Result<()> {
+        let config = Config::from_sdl(read_fixture(configs::NAME_GENERATION).as_str())
             .to_result()
             .unwrap();
 

--- a/tailcall-fixtures/fixtures/configs/name-generation.graphql
+++ b/tailcall-fixtures/fixtures/configs/name-generation.graphql
@@ -1,0 +1,21 @@
+schema @server(port: 8000, hostname: "0.0.0.0") @upstream(baseURL: "http://example.typicode.com", httpCache: 42) {
+  query: Query
+}
+type T3 {
+  name: String
+  hexCode: String
+}
+
+type T2 {
+  colors: [T3]
+  isColorPageExists: Boolean
+  isColorsImageAvailable: Boolean
+}
+
+type T1 {
+  color: T2
+}
+
+type Query {
+  f1: T1 @http(path: "/colors")
+}


### PR DESCRIPTION
**Summary:**  
- This PR addresses an issue where singular and plural forms of candidates were not consistently recognized by the filtering logic.
- This PR adds the processed candidate into set and processes every candidate and then checks in set for existence.

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
