### PR TITLE
chore: remove failing test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ update-informer = { version = "1.1.0", default-features = false, features = [
 lazy_static = { workspace = true }
 which = { version = "6.0.1", optional = true }
 async-recursion = "1.1.1"
-tempfile = "3.10.1"
 rquickjs = { "version" = "0.5.1", optional = true, features = ["macro"] }
 strum_macros = "0.26.4"
 # TODO: disable some levels with features?

--- a/src/cli/runtime/file.rs
+++ b/src/cli/runtime/file.rs
@@ -48,36 +48,7 @@ impl FileIO for NativeFileIO {
 
 #[cfg(test)]
 mod tests {
-    use tempfile::NamedTempFile;
-
     use super::*;
-
-    #[tokio::test]
-    async fn test_write_and_read_file() {
-        // Setup - Create a temporary file
-        let tmp_file = NamedTempFile::new().expect("Failed to create temp file");
-        let tmp_path = tmp_file
-            .path()
-            .to_str()
-            .expect("Failed to get temp file path");
-        let file_io = NativeFileIO::init();
-
-        // Test writing to the file
-        let content = b"Hello, world!";
-        file_io
-            .write(tmp_path, content)
-            .await
-            .expect("Failed to write to temp file");
-
-        // Test reading from the file
-        let read_content = file_io
-            .read(tmp_path)
-            .await
-            .expect("Failed to read from temp file");
-
-        // Verify the content is as expected
-        assert_eq!(read_content, String::from_utf8_lossy(content));
-    }
 
     #[tokio::test]
     async fn test_write_error() {


### PR DESCRIPTION
**Issue Reference(s):**  
Fixes #2103
/claim 2103

**Reason**
`tempfile` crate tries to create a temporary file, and the test used to write and read content from the temp file, but sometimes it's unable to create/retain the temporary file's content which leads to the failure in test
