### PR TITLE
chore: dropped pub fields from config module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6433aac097572ea8ccc60b3f2e756c661c9aeed9225cdd4d0cb119cb7ff6ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,7 +2237,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -5093,6 +5104,7 @@ dependencies = [
  "convert_case",
  "criterion",
  "datatest-stable",
+ "derive-getters",
  "derive_setters",
  "dotenvy",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }
 derive_setters = "0.1.6"
+derive-getters = "0.4.0"
 thiserror = "1.0.59"
 serde_json = { workspace = true }
 serde = { workspace = true }

--- a/benches/handle_request_bench.rs
+++ b/benches/handle_request_bench.rs
@@ -17,7 +17,7 @@ pub fn benchmark_handle_request(c: &mut Criterion) {
     let config_module: ConfigModule = Config::from_sdl(sdl.as_str()).to_result().unwrap().into();
 
     let blueprint = Blueprint::try_from(&config_module).unwrap();
-    let endpoints = config_module.extensions.endpoint_set;
+    let endpoints = config_module.extensions().endpoint_set.clone();
 
     let server_config = tokio_runtime
         .block_on(ServerConfig::new(blueprint, endpoints))

--- a/src/cli/server/http_server.rs
+++ b/src/cli/server/http_server.rs
@@ -36,7 +36,7 @@ impl Server {
         let server_config = Arc::new(
             ServerConfig::new(
                 blueprint.clone(),
-                self.config_module.extensions.endpoint_set,
+                self.config_module.extensions().endpoint_set.clone(),
             )
             .await?,
         );

--- a/src/cli/tc.rs
+++ b/src/cli/tc.rs
@@ -48,15 +48,15 @@ pub async fn run() -> Result<()> {
     match cli.command {
         Command::Start { file_paths } => {
             let config_module = config_reader.read_all(&file_paths).await?;
-            log_endpoint_set(&config_module.extensions.endpoint_set);
-            Fmt::log_n_plus_one(false, &config_module.config);
+            log_endpoint_set(&config_module.extensions().endpoint_set);
+            Fmt::log_n_plus_one(false, config_module.config());
             let server = Server::new(config_module);
             server.fork_start().await?;
             Ok(())
         }
         Command::Check { file_paths, n_plus_one_queries, schema, format } => {
             let config_module = (config_reader.read_all(&file_paths)).await?;
-            log_endpoint_set(&config_module.extensions.endpoint_set);
+            log_endpoint_set(&config_module.extensions().endpoint_set);
             if let Some(format) = format {
                 Fmt::display(format.encode(&config_module)?);
             }
@@ -65,11 +65,12 @@ pub async fn run() -> Result<()> {
             match blueprint {
                 Ok(blueprint) => {
                     tracing::info!("Config {} ... ok", file_paths.join(", "));
-                    Fmt::log_n_plus_one(n_plus_one_queries, &config_module.config);
+                    Fmt::log_n_plus_one(n_plus_one_queries, config_module.config());
                     // Check the endpoints' schema
                     let _ = config_module
-                        .extensions
+                        .extensions()
                         .endpoint_set
+                        .clone()
                         .into_checked(&blueprint, runtime)
                         .await?;
                     if schema {

--- a/src/core/blueprint/auth.rs
+++ b/src/core/blueprint/auth.rs
@@ -34,13 +34,13 @@ pub enum Auth {
 
 impl Auth {
     pub fn make(config_module: &ConfigModule) -> Valid<Option<Auth>, String> {
-        let htpasswd = config_module.extensions.htpasswd.iter().map(|htpasswd| {
+        let htpasswd = config_module.extensions().htpasswd.iter().map(|htpasswd| {
             Auth::Provider(Provider::Basic(Basic {
                 htpasswd: htpasswd.content.clone(),
             }))
         });
 
-        let jwks = config_module.extensions.jwks.iter().map(|jwks| {
+        let jwks = config_module.extensions().jwks.iter().map(|jwks| {
             Auth::Provider(Provider::Jwt(Jwt {
                 jwks: jwks.content.clone(),
                 // TODO: read those options from link instead of using defaults

--- a/src/core/blueprint/definitions.rs
+++ b/src/core/blueprint/definitions.rs
@@ -520,8 +520,8 @@ pub fn to_field_definition(
 
 pub fn to_definitions<'a>() -> TryFold<'a, ConfigModule, Vec<Definition>, String> {
     TryFold::<ConfigModule, Vec<Definition>, String>::new(|config_module, _| {
-        let output_types = &config_module.output_types;
-        let input_types = &config_module.input_types;
+        let output_types = config_module.output_types();
+        let input_types = config_module.input_types();
 
         Valid::from_iter(config_module.types.iter(), |(name, type_)| {
             let dbl_usage = input_types.contains(name) && output_types.contains(name);
@@ -534,9 +534,9 @@ pub fn to_definitions<'a>() -> TryFold<'a, ConfigModule, Vec<Definition>, String
                     .trace(name)
                     .and_then(|definition| match definition.clone() {
                         Definition::Object(object_type_definition) => {
-                            if config_module.input_types.contains(name) {
+                            if config_module.input_types().contains(name) {
                                 to_input_object_type_definition(object_type_definition).trace(name)
-                            } else if config_module.interface_types.contains(name) {
+                            } else if config_module.interface_types().contains(name) {
                                 to_interface_type_definition(object_type_definition).trace(name)
                             } else {
                                 Valid::succeed(definition)

--- a/src/core/blueprint/operators/call.rs
+++ b/src/core/blueprint/operators/call.rs
@@ -151,7 +151,7 @@ fn get_field_and_field_name<'a>(
     )
     .and_then(|(type_name, field_name)| {
         Valid::from_option(
-            config_module.config.find_type(&type_name),
+            config_module.config().find_type(&type_name),
             format!("{} type not found on config", type_name),
         )
         .and_then(|query_type| {

--- a/src/core/blueprint/operators/grpc.rs
+++ b/src/core/blueprint/operators/grpc.rs
@@ -165,7 +165,7 @@ pub fn compile_grpc(inputs: CompileGrpc) -> Valid<IR, String> {
 
     Valid::from(GrpcMethod::try_from(grpc.method.as_str()))
         .and_then(|method| {
-            let file_descriptor_set = config_module.extensions.get_file_descriptor_set();
+            let file_descriptor_set = config_module.extensions().get_file_descriptor_set();
 
             if file_descriptor_set.file.is_empty() {
                 return Valid::fail("Protobuf files were not specified in the config".to_string());

--- a/src/core/blueprint/operators/js.rs
+++ b/src/core/blueprint/operators/js.rs
@@ -25,7 +25,7 @@ pub fn update_js_field<'a>(
                 return Valid::succeed(b_field);
             };
 
-            compile_js(CompileJs { script: &module.extensions.script, name: &js.name })
+            compile_js(CompileJs { script: &module.extensions().script, name: &js.name })
                 .map(|resolver| b_field.resolver(Some(resolver)))
         },
     )

--- a/src/core/blueprint/operators/protected.rs
+++ b/src/core/blueprint/operators/protected.rs
@@ -17,11 +17,11 @@ pub fn update_protected<'a>(
                     .and_then(|type_| type_.protected.as_ref())
                     .is_some()
             {
-                if config.input_types.contains(type_name) {
+                if config.input_types().contains(type_name) {
                     return Valid::fail("Input types can not be protected".to_owned());
                 }
 
-                if !config.extensions.has_auth() {
+                if !config.extensions().has_auth() {
                     return Valid::fail(
                         "@protected operator is used but there is no @link definitions for auth providers".to_owned(),
                     );

--- a/src/core/blueprint/server.rs
+++ b/src/core/blueprint/server.rs
@@ -91,15 +91,15 @@ impl TryFrom<crate::core::config::ConfigModule> for Server {
 
         let http_server = match config_server.clone().get_version() {
             HttpVersion::HTTP2 => {
-                if config_module.extensions.cert.is_empty() {
+                if config_module.extensions().cert.is_empty() {
                     return Valid::fail("Certificate is required for HTTP2".to_string())
                         .to_result();
                 }
 
-                let cert = config_module.extensions.cert.clone();
+                let cert = config_module.extensions().cert.clone();
 
                 let key_file: PrivateKeyDer<'_> = config_module
-                    .extensions
+                    .extensions()
                     .keys
                     .first()
                     .ok_or_else(|| ValidationError::new("Key is required for HTTP2".to_string()))?
@@ -160,7 +160,7 @@ impl TryFrom<crate::core::config::ConfigModule> for Server {
 }
 
 fn to_script(config_module: &crate::core::config::ConfigModule) -> Valid<Option<Script>, String> {
-    config_module.extensions.script.as_ref().map_or_else(
+    config_module.extensions().script.as_ref().map_or_else(
         || Valid::succeed(None),
         |script| {
             Valid::succeed(Some(Script {

--- a/src/core/blueprint/upstream.rs
+++ b/src/core/blueprint/upstream.rs
@@ -57,7 +57,7 @@ impl TryFrom<&ConfigModule> for Upstream {
 
         let mut allowed_headers = config_upstream.get_allowed_headers();
 
-        if config_module.extensions.has_auth() {
+        if config_module.extensions().has_auth() {
             // force add auth specific headers to use it to make actual validation
             allowed_headers.insert(hyper::header::AUTHORIZATION.to_string());
         }

--- a/src/core/config/config_module.rs
+++ b/src/core/config/config_module.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::sync::Arc;
 
-use derive_setters::Setters;
+use derive_getters::Getters;
 use jsonwebtoken::jwk::JwkSet;
 use prost_reflect::prost_types::{FileDescriptorProto, FileDescriptorSet};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
@@ -15,13 +15,22 @@ use crate::core::rest::{EndpointSet, Unchecked};
 
 /// A wrapper on top of Config that contains all the resolved extensions and
 /// computed values.
-#[derive(Clone, Debug, Default, Setters, MergeRight)]
+#[derive(Clone, Debug, Default, Getters, MergeRight)]
 pub struct ConfigModule {
-    pub config: Config,
-    pub extensions: Extensions,
-    pub input_types: HashSet<String>,
-    pub output_types: HashSet<String>,
-    pub interface_types: HashSet<String>,
+    config: Config,
+    extensions: Extensions,
+    input_types: HashSet<String>,
+    output_types: HashSet<String>,
+    interface_types: HashSet<String>,
+}
+
+impl ConfigModule {
+    pub fn config_mut(&mut self) -> &mut Config {
+        &mut self.config
+    }
+    pub fn set_extensions(&mut self, extensions: Extensions) {
+        self.extensions = extensions;
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/core/config/into_document.rs
+++ b/src/core/config/into_document.rs
@@ -59,7 +59,7 @@ fn config_document(config: &ConfigModule) -> ServiceDocument {
     };
     definitions.push(TypeSystemDefinition::Schema(pos(schema_definition)));
     for (type_name, type_def) in config.types.iter() {
-        let kind = if config.interface_types.contains(type_name) {
+        let kind = if config.interface_types().contains(type_name) {
             TypeKind::Interface(InterfaceType {
                 implements: type_def
                     .implements
@@ -91,7 +91,7 @@ fn config_document(config: &ConfigModule) -> ServiceDocument {
                     })
                     .collect::<Vec<Positioned<FieldDefinition>>>(),
             })
-        } else if config.input_types.contains(type_name) {
+        } else if config.input_types().contains(type_name) {
             TypeKind::InputObject(InputObjectType {
                 fields: type_def
                     .fields

--- a/src/core/config/reader.rs
+++ b/src/core/config/reader.rs
@@ -41,7 +41,7 @@ impl ConfigReader {
         parent_dir: Option<&'async_recursion Path>,
     ) -> anyhow::Result<ConfigModule> {
         let links: Vec<Link> = config_module
-            .config
+            .config()
             .links
             .clone()
             .iter()
@@ -56,6 +56,8 @@ impl ConfigReader {
         if links.is_empty() {
             return Ok(config_module);
         }
+
+        let mut extensions = config_module.extensions().clone();
 
         for link in links.iter() {
             let path = Self::resolve_path(&link.src, parent_dir);
@@ -81,38 +83,34 @@ impl ConfigReader {
                 }
                 LinkType::Protobuf => {
                     let meta = self.proto_reader.read(path).await?;
-                    config_module.extensions.add_proto(meta);
+                    extensions.add_proto(meta);
                 }
                 LinkType::Script => {
                     let source = self.resource_reader.read_file(&path).await?;
                     let content = source.content;
-                    config_module.extensions.script = Some(content);
+                    extensions.script = Some(content);
                 }
                 LinkType::Cert => {
                     let source = self.resource_reader.read_file(&path).await?;
                     let content = source.content;
-                    config_module
-                        .extensions
-                        .cert
-                        .extend(self.load_cert(content).await?);
+                    extensions.cert.extend(self.load_cert(content).await?);
                 }
                 LinkType::Key => {
                     let source = self.resource_reader.read_file(&path).await?;
                     let content = source.content;
-                    config_module.extensions.keys = Arc::new(self.load_private_key(content).await?)
+                    extensions.keys = Arc::new(self.load_private_key(content).await?)
                 }
                 LinkType::Operation => {
                     let source = self.resource_reader.read_file(&path).await?;
                     let content = source.content;
 
-                    config_module.extensions.endpoint_set = EndpointSet::try_new(&content)?;
+                    extensions.endpoint_set = EndpointSet::try_new(&content)?;
                 }
                 LinkType::Htpasswd => {
                     let source = self.resource_reader.read_file(&path).await?;
                     let content = source.content;
 
-                    config_module
-                        .extensions
+                    extensions
                         .htpasswd
                         .push(Content { id: link.id.clone(), content });
                 }
@@ -122,7 +120,7 @@ impl ConfigReader {
 
                     let de = &mut serde_json::Deserializer::from_str(&content);
 
-                    config_module.extensions.jwks.push(Content {
+                    extensions.jwks.push(Content {
                         id: link.id.clone(),
                         content: serde_path_to_error::deserialize(de)?,
                     })
@@ -131,7 +129,7 @@ impl ConfigReader {
                     let meta = self.proto_reader.fetch(link.src.as_str()).await?;
 
                     for m in meta {
-                        config_module.extensions.add_proto(m);
+                        extensions.add_proto(m);
                     }
                 }
             }
@@ -139,8 +137,8 @@ impl ConfigReader {
 
         // Recreating the ConfigModule in order to recompute the values of
         // `input_types`, `output_types` and `interface_types`
-        let mut final_config_module = ConfigModule::from(config_module.config);
-        final_config_module.extensions = config_module.extensions;
+        let mut final_config_module = ConfigModule::from(config_module.config().clone());
+        final_config_module.set_extensions(extensions);
         Ok(final_config_module)
     }
 
@@ -219,7 +217,7 @@ impl ConfigReader {
         // Extend it with the links
         let mut config_module = self.ext_links(config_module, parent_dir).await?;
 
-        let server = &mut config_module.config.server;
+        let server = &mut config_module.config_mut().server;
         let reader_ctx = ConfigReaderContext {
             runtime: &self.runtime,
             vars: &server
@@ -231,7 +229,7 @@ impl ConfigReader {
         };
 
         config_module
-            .config
+            .config_mut()
             .telemetry
             .render_mustache(&reader_ctx)?;
 
@@ -360,7 +358,10 @@ mod reader_tests {
         let path = format!("{}/examples/scripts/echo.js", cargo_manifest);
         let content = file_rt.read(&path).await;
 
-        assert_eq!(content.unwrap(), config.extensions.script.unwrap());
+        assert_eq!(
+            content.unwrap(),
+            config.extensions().script.clone().unwrap()
+        );
     }
 
     #[test]

--- a/src/core/config/transformer/ambiguous_type.rs
+++ b/src/core/config/transformer/ambiguous_type.rs
@@ -241,7 +241,7 @@ mod tests {
             .generate(false)?;
 
         let mut config = AmbiguousType::default()
-            .transform(cfg_module.config)
+            .transform(cfg_module.config().clone())
             .to_result()?;
 
         // remove links since they break snapshot tests

--- a/src/core/generator/generator.rs
+++ b/src/core/generator/generator.rs
@@ -173,7 +173,7 @@ mod test {
             })])
             .generate(false)?;
 
-        insta::assert_snapshot!(cfg_module.config.to_sdl());
+        insta::assert_snapshot!(cfg_module.config().to_sdl());
         Ok(())
     }
 
@@ -186,7 +186,7 @@ mod test {
             }])
             .generate(true)?;
 
-        insta::assert_snapshot!(cfg_module.config.to_sdl());
+        insta::assert_snapshot!(cfg_module.config().to_sdl());
         Ok(())
     }
 
@@ -202,7 +202,7 @@ mod test {
             }])
             .transformers(vec![Box::new(Preset::default())])
             .generate(true)?;
-        insta::assert_snapshot!(cfg_module.config.to_sdl());
+        insta::assert_snapshot!(cfg_module.config().to_sdl());
         Ok(())
     }
 
@@ -238,7 +238,7 @@ mod test {
             .generate(true)?;
 
         // Assert the combined output
-        insta::assert_snapshot!(cfg_module.config.to_sdl());
+        insta::assert_snapshot!(cfg_module.config().to_sdl());
         Ok(())
     }
 
@@ -264,7 +264,7 @@ mod test {
             .inputs(inputs)
             .transformers(vec![Box::new(Preset::default())])
             .generate(true)?;
-        insta::assert_snapshot!(cfg_module.config.to_sdl());
+        insta::assert_snapshot!(cfg_module.config().to_sdl());
         Ok(())
     }
 }

--- a/src/core/generator/tests/json_to_config_spec.rs
+++ b/src/core/generator/tests/json_to_config_spec.rs
@@ -43,8 +43,7 @@ fn test_spec(path: &Path, url: Url, body: Value) -> anyhow::Result<()> {
             response: body,
             field_name: "f1".to_string(),
         }])
-        .generate(true)?
-        .config;
+        .generate(true)?;
 
     let snapshot_name = path.file_name().unwrap().to_str().unwrap();
     insta::assert_snapshot!(snapshot_name, config.to_sdl());

--- a/src/core/grpc/data_loader_request.rs
+++ b/src/core/grpc/data_loader_request.rs
@@ -90,7 +90,7 @@ mod tests {
         let config_module = reader.resolve(config, None).await.unwrap();
 
         let protobuf_set =
-            ProtobufSet::from_proto_file(config_module.extensions.get_file_descriptor_set())
+            ProtobufSet::from_proto_file(config_module.extensions().get_file_descriptor_set())
                 .unwrap();
 
         let service = protobuf_set.find_service(&method).unwrap();

--- a/src/core/grpc/protobuf.rs
+++ b/src/core/grpc/protobuf.rs
@@ -278,7 +278,7 @@ pub mod tests {
         Ok(reader
             .resolve(config, None)
             .await?
-            .extensions
+            .extensions()
             .get_file_descriptor_set())
     }
 

--- a/src/core/grpc/request_template.rs
+++ b/src/core/grpc/request_template.rs
@@ -162,7 +162,7 @@ mod tests {
                 .resolve(config, None)
                 .await
                 .unwrap()
-                .extensions
+                .extensions()
                 .get_file_descriptor_set(),
         )
         .unwrap();

--- a/tailcall-aws-lambda/src/main.rs
+++ b/tailcall-aws-lambda/src/main.rs
@@ -35,8 +35,9 @@ async fn main() -> Result<(), Error> {
         .await?;
     let blueprint = Blueprint::try_from(&config)?;
     let endpoints = config
-        .extensions
+        .extensions()
         .endpoint_set
+        .clone()
         .into_checked(&blueprint, runtime.clone())
         .await?;
 

--- a/tests/core/parse.rs
+++ b/tests/core/parse.rs
@@ -303,7 +303,7 @@ impl ExecutionSpec {
         };
 
         let endpoints = config
-            .extensions
+            .extensions()
             .endpoint_set
             .clone()
             .into_checked(&blueprint, runtime.clone())


### PR DESCRIPTION
**Summary:**  
_chore: dropped pub fields from config module_

**Issue Reference(s):**  
Fixes #2256
/claim #2256 
**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
