### PR TITLE
fix: use mi-malloc in lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
+// Required for the #[global_allocator] proc macro
+#![allow(clippy::too_many_arguments)]
+
 pub mod core;
 
 #[cfg(feature = "cli")]
 pub mod cli;
+
+use mimalloc::MiMalloc;
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,8 @@
-// Required for the #[global_allocator] proc macro
-#![allow(clippy::too_many_arguments)]
-
 use std::cell::Cell;
 
-use mimalloc::MiMalloc;
 use tailcall::cli::CLIError;
 use tailcall::core::tracing::default_tracing_tailcall;
 use tracing::subscriber::DefaultGuard;
-
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
 
 thread_local! {
     static TRACING_GUARD: Cell<Option<DefaultGuard>> = const { Cell::new(None) };


### PR DESCRIPTION
This is done so that mi-malloc is used in integration tests also.