### PR TITLE
feat: New transformer to flatten out types with single field

### DIFF
--- a/src/cli/generator/snapshots/tailcall__cli__generator__generator__test__generator_spec__src__cli__generator__tests__fixtures__generator__deezer.json.snap
+++ b/src/cli/generator/snapshots/tailcall__cli__generator__generator__test__generator_spec__src__cli__generator__tests__fixtures__generator__deezer.json.snap
@@ -84,10 +84,6 @@ type Editorial {
   total: Int
 }
 
-type Genre {
-  data: [T5]
-}
-
 type Playlist {
   checksum: String
   collaborative: Boolean
@@ -301,10 +297,6 @@ type T37 {
   type: String
 }
 
-type T38 {
-  data: [T37]
-}
-
 type T39 {
   artist: T8
   available: Boolean
@@ -320,7 +312,7 @@ type T39 {
   explicit_lyrics: Boolean
   fans: Int
   genre_id: Int
-  genres: Genre
+  genres: [T5]
   id: Int
   label: String
   link: String
@@ -331,7 +323,7 @@ type T39 {
   share: String
   title: String
   tracklist: String
-  tracks: T38
+  tracks: [T37]
   type: String
   upc: String
 }

--- a/src/core/config/transformer/flatten_single_types.rs
+++ b/src/core/config/transformer/flatten_single_types.rs
@@ -1,0 +1,176 @@
+use std::collections::BTreeMap;
+
+use crate::core::config::{Config, Field, Type};
+use crate::core::transform::{self, Transform};
+use crate::core::valid::Valid;
+
+/// Flatten single types
+/// If a type has only one field, it is considered a single type.
+/// If a field references a single type, it will be flattened.
+#[derive(Default)]
+pub struct FlattenSingleTypes;
+
+impl Transform for FlattenSingleTypes {
+    type Value = Config;
+    type Error = String;
+
+    fn transform(&self, mut config: Config) -> Valid<Config, String> {
+        let single_types = get_single_types(&config);
+        let root_types = get_root_types(&config);
+        let mut still_referenced_single_types = Vec::<String>::new();
+
+        config.types.iter_mut().for_each(|(_, ty)| {
+            let fields_referencing_single_type = ty
+                .fields
+                .iter_mut()
+                .filter(|(_, field)| single_types.contains_key(&field.type_of));
+
+            // Skip fields with resolver and prevent array of array
+            let (skipped_fields, fields_to_flatten): (Vec<_>, Vec<_>) =
+                fields_referencing_single_type.partition(|(_, field)| {
+                    field.has_resolver() || (field.list && single_types[&field.type_of].list)
+                });
+
+            // Keep track of single types that are still referenced
+            still_referenced_single_types.extend(
+                skipped_fields
+                    .iter()
+                    .map(|(_, field)| field.type_of.clone()),
+            );
+
+            fields_to_flatten.into_iter().for_each(|(_, field)| {
+                *field = flatten_field(field.clone(), &single_types);
+            });
+        });
+
+        // Remove all single types, take care of keeping root types even if it's a single type
+        // Also keep single types that are still referenced
+        config.types.retain(|type_name, ty| {
+            root_types.contains(type_name)
+                || !is_single_type(ty)
+                || still_referenced_single_types.contains(type_name)
+        });
+
+        transform::default().transform(config)
+    }
+}
+
+fn get_root_types(config: &Config) -> Vec<String> {
+    vec![
+        config.schema.query.clone().unwrap_or("Query".to_string()),
+        config
+            .schema
+            .mutation
+            .clone()
+            .unwrap_or("Mutation".to_string()),
+        config
+            .schema
+            .subscription
+            .clone()
+            .unwrap_or("Subscription".to_string()),
+    ]
+}
+
+/// Collect all single types and their unique field type
+fn get_single_types(config: &Config) -> BTreeMap<String, Field> {
+    config
+        .types
+        .iter()
+        .filter(|(_, ty)| is_single_type(ty))
+        .map(|(name, ty)| (name.clone(), ty.fields.values().next().unwrap().clone()))
+        .collect()
+}
+
+/// Recursively resolve single types
+fn flatten_field(field: Field, single_types: &BTreeMap<String, Field>) -> Field {
+    if let Some(single_type_field) = single_types.get(&field.type_of) {
+        let mut new_field = single_type_field.clone();
+
+        // If one of the merged field is a list, the new type will be a list
+        new_field.list = single_type_field.list || field.list;
+
+        // If all the merged fields are required, the new type will be required
+        // There is special case for list, we prevented array of array in the transform
+        if single_type_field.list {
+            new_field.required = field.required && single_type_field.required;
+            new_field.list_type_required = single_type_field.list_type_required;
+        } else if field.list {
+            new_field.required = field.required;
+            new_field.list_type_required = field.list_type_required && single_type_field.required;
+        } else {
+            new_field.required = field.required && single_type_field.required;
+        }
+
+        flatten_field(new_field, single_types)
+    } else {
+        field
+    }
+}
+
+/// Check if type is single type
+fn is_single_type(ty: &Type) -> bool {
+    let not_omitted_fields_count = ty
+        .fields
+        .iter()
+        .filter(|(_, field)| field.omit.is_none())
+        .count();
+    let added_fields_count = ty.added_fields.len();
+    let total_fields_count = not_omitted_fields_count + added_fields_count;
+
+    // Flattened types should not have any tag
+    ty.tag.is_none() && total_fields_count == 1
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+    use std::fs;
+    use tailcall_fixtures::configs;
+
+    use super::FlattenSingleTypes;
+    use crate::core::config::Config;
+    use crate::core::transform::Transform;
+    use crate::core::valid::Validator;
+
+    #[test]
+    fn test_flatten_single_types_transform() {
+        let config = Config::from_sdl(
+            fs::read_to_string(configs::FLATTEN_SINGLE_TYPES_CONFIG)
+                .unwrap()
+                .as_str(),
+        )
+        .to_result()
+        .unwrap();
+
+        let transformed_config = FlattenSingleTypes.transform(config).to_result().unwrap();
+        assert_snapshot!(transformed_config.to_sdl());
+    }
+
+    #[test]
+    fn test_flatten_single_types_with_array_transform() {
+        let config = Config::from_sdl(
+            fs::read_to_string(configs::FLATTEN_SINGLE_TYPES_WITH_ARRAY_CONFIG)
+                .unwrap()
+                .as_str(),
+        )
+        .to_result()
+        .unwrap();
+
+        let transformed_config = FlattenSingleTypes.transform(config).to_result().unwrap();
+        assert_snapshot!(transformed_config.to_sdl());
+    }
+
+    #[test]
+    fn test_flatten_single_types_with_resolver_transform() {
+        let config = Config::from_sdl(
+            fs::read_to_string(configs::FLATTEN_SINGLE_TYPES_WITH_RESOLVER_CONFIG)
+                .unwrap()
+                .as_str(),
+        )
+        .to_result()
+        .unwrap();
+
+        let transformed_config = FlattenSingleTypes.transform(config).to_result().unwrap();
+        assert_snapshot!(transformed_config.to_sdl());
+    }
+}

--- a/src/core/config/transformer/mod.rs
+++ b/src/core/config/transformer/mod.rs
@@ -1,5 +1,6 @@
 mod ambiguous_type;
 mod consolidate_url;
+mod flatten_single_types;
 mod improve_type_names;
 mod merge_types;
 mod nested_unions;
@@ -10,6 +11,7 @@ mod union_input_type;
 
 pub use ambiguous_type::{AmbiguousType, Resolution};
 pub use consolidate_url::ConsolidateURL;
+pub use flatten_single_types::FlattenSingleTypes;
 pub use improve_type_names::ImproveTypeNames;
 pub use merge_types::TypeMerger;
 pub use nested_unions::NestedUnions;

--- a/src/core/config/transformer/preset.rs
+++ b/src/core/config/transformer/preset.rs
@@ -10,6 +10,7 @@ pub struct Preset {
     merge_type: f32,
     consolidate_url: f32,
     tree_shake: bool,
+    flatten_single_types: bool,
     use_better_names: bool,
 }
 
@@ -26,6 +27,7 @@ impl Transform for Preset {
             .pipe(super::TreeShake.when(self.tree_shake))
             .pipe(super::TypeMerger::new(self.merge_type))
             .pipe(super::ImproveTypeNames.when(self.use_better_names))
+            .pipe(super::FlattenSingleTypes.when(self.flatten_single_types))
             .pipe(super::ConsolidateURL::new(self.consolidate_url))
             .transform(config)
     }
@@ -36,8 +38,9 @@ impl Default for Preset {
         Self {
             merge_type: 1.0,
             consolidate_url: 0.5,
-            use_better_names: true,
             tree_shake: true,
+            flatten_single_types: true,
+            use_better_names: true,
         }
     }
 }

--- a/src/core/config/transformer/snapshots/tailcall__core__config__transformer__flatten_single_types__tests__flatten_single_types_transform.snap
+++ b/src/core/config/transformer/snapshots/tailcall__core__config__transformer__flatten_single_types__tests__flatten_single_types_transform.snap
@@ -1,0 +1,27 @@
+---
+source: src/core/config/transformer/flatten_single_types.rs
+expression: transformed_config.to_sdl()
+---
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Bar3 {
+  a: Int
+  b: Int
+}
+
+type Foo2 {
+  b: String
+  bar: Int
+}
+
+type Mutation {
+  foo1: Int
+}
+
+type Query {
+  foo1: Int
+  foo2: Foo2
+  foo3: Bar3!
+}

--- a/src/core/config/transformer/snapshots/tailcall__core__config__transformer__flatten_single_types__tests__flatten_single_types_with_array_transform.snap
+++ b/src/core/config/transformer/snapshots/tailcall__core__config__transformer__flatten_single_types__tests__flatten_single_types_with_array_transform.snap
@@ -1,0 +1,29 @@
+---
+source: src/core/config/transformer/flatten_single_types.rs
+expression: transformed_config.to_sdl()
+---
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Bar4 {
+  a: Int
+  b: Int
+}
+
+type Foo1 {
+  b: String
+  bar: Int
+}
+
+type Foo5 {
+  bar: [Int]
+}
+
+type Query {
+  foo1: [Foo1]
+  foo2: [Int]!
+  foo3: [Int!]
+  foo4: [Bar4!]!
+  foo5: [Foo5]
+}

--- a/src/core/config/transformer/snapshots/tailcall__core__config__transformer__flatten_single_types__tests__flatten_single_types_with_resolver_transform.snap
+++ b/src/core/config/transformer/snapshots/tailcall__core__config__transformer__flatten_single_types__tests__flatten_single_types_with_resolver_transform.snap
@@ -1,0 +1,15 @@
+---
+source: src/core/config/transformer/flatten_single_types.rs
+expression: transformed_config.to_sdl()
+---
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Foo {
+  a: Int
+}
+
+type Query {
+  foo: Foo @grpc(method: "news.NewsService.GetAllNews")
+}

--- a/src/core/generator/snapshots/tailcall__core__generator__from_json__tests__generate_config_from_json.snap
+++ b/src/core/generator/snapshots/tailcall__core__generator__from_json__tests__generate_config_from_json.snap
@@ -13,10 +13,6 @@ type Children {
   name: String
 }
 
-type Container {
-  age: Int
-}
-
 type F1 {
   campaignTemplates: Any
   colors: [Any]
@@ -45,7 +41,7 @@ type Query {
 }
 
 type T6 {
-  container: Container
+  container: Int
   name: String
 }
 

--- a/tailcall-fixtures/fixtures/configs/flatten-single-types-config.graphql
+++ b/tailcall-fixtures/fixtures/configs/flatten-single-types-config.graphql
@@ -1,0 +1,39 @@
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  foo1: Foo1!
+  foo2: Foo2
+  foo3: Foo3!
+}
+
+type Mutation {
+  foo1: Foo1
+}
+
+type Foo1 {
+  bar: Bar1
+}
+
+type Bar1 {
+  a: Int
+}
+
+type Foo2 {
+  bar: Bar1
+  b: String
+}
+
+type Bar2 {
+  a: Int
+}
+
+type Foo3 {
+  bar: Bar3!
+}
+
+type Bar3 {
+  a: Int
+  b: Int
+}

--- a/tailcall-fixtures/fixtures/configs/flatten-single-types-with-array-config.graphql
+++ b/tailcall-fixtures/fixtures/configs/flatten-single-types-with-array-config.graphql
@@ -1,0 +1,49 @@
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  foo1: [Foo1]
+  foo2: [Foo2!]!
+  foo3: Foo3
+  foo4: Foo4!
+  foo5: [Foo5]
+}
+
+type Foo1 {
+  bar: Bar1
+  b: String
+}
+
+type Bar1 {
+  a: Int
+}
+
+type Foo2 {
+  bar: Bar2!
+}
+
+type Bar2 {
+  a: Int
+}
+
+type Foo3 {
+  bar: [Bar3!]!
+}
+
+type Bar3 {
+  a: Int!
+}
+
+type Foo4 {
+  bar: [Bar4!]!
+}
+
+type Bar4 {
+  a: Int
+  b: Int
+}
+
+type Foo5 {
+  bar: [Int]
+}

--- a/tailcall-fixtures/fixtures/configs/flatten-single-types-with-resolver-config.graphql
+++ b/tailcall-fixtures/fixtures/configs/flatten-single-types-with-resolver-config.graphql
@@ -1,0 +1,11 @@
+schema @server @upstream(baseURL: "http://jsonplacheholder.typicode.com") {
+  query: Query
+}
+
+type Query {
+  foo: Foo @grpc(method: "news.NewsService.GetAllNews")
+}
+
+type Foo {
+  a: Int
+}


### PR DESCRIPTION
**Summary:**  

(That's my first contribution ever on an open source project, I hope it will not be too bad)

I took some liberty on implementation, I'll comment the PR to explain my choices.

/claim #2343

Write a config/transformer that unwraps types with one field.

FROM:

```graphql
type Query {
  foo: Foo
}

# Type with only one field
type Foo { 
  bar: Bar
}

# Type with only one field
type Bar {
  a: Int
}
```

TO:

```graphql
type Query {
  foo: Int
}
```

**Issue Reference(s):**  
Fixes #2343

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
