### PR TITLE
ci: run jit tests only when pr label is present

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -226,5 +226,11 @@
     "color": "F9D0C4",
     "description": "Runs benchmarks",
     "aliases": ["ci:benchmark"]
+  },
+  {
+    "name": "ci: test-jit",
+    "color": "F9D0C4",
+    "description": "Run all integration tests for the JIT optimized engine",
+    "aliases": ["ci:lint"]
   }
 ]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   macro_benchmarks:
     name: Macro Benchmarks
-    if: "contains(github.event.pull_request.labels.*.name, 'ci: benchmark') || github.event_name == 'push'"
+    if: "${{ contains(github.event.pull_request.labels.*.name, 'ci: benchmark') || github.event_name == 'push' }}"
     runs-on: benchmarking-runner
     permissions:
       pull-requests: write

--- a/.github/workflows/benchmark_pr_run.yml
+++ b/.github/workflows/benchmark_pr_run.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   micro_benchmarks_pr_run:
     name: Micro Benchmarks for PR
-    if: "contains(github.event.pull_request.labels.*.name, 'ci: benchmark')"
+    if: "${{ contains(github.event.pull_request.labels.*.name, 'ci: benchmark') }}"
     runs-on: benchmarking-runner
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-jit.yml
+++ b/.github/workflows/test-jit.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +20,7 @@ jobs:
     name: Run JIT tests on ${{ matrix.build }}
     runs-on: ${{ matrix.os || '-latest' }}
     needs: setup_build_matrix
+    if: "${{ contains(github.event.pull_request.labels.*.name, 'ci: test-jit') || github.event_name == 'push' }}"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
