### PR TITLE
chore: add subscription to blueprint

### DIFF
--- a/src/core/blueprint/blueprint.rs
+++ b/src/core/blueprint/blueprint.rs
@@ -147,6 +147,7 @@ pub struct EnumValueDefinition {
 pub struct SchemaDefinition {
     pub query: String,
     pub mutation: Option<String>,
+    pub subscription: Option<String>,
     pub directives: Vec<Directive>,
 }
 
@@ -226,6 +227,10 @@ impl Blueprint {
 
     pub fn mutation(&self) -> Option<String> {
         self.schema.mutation.clone()
+    }
+
+    pub fn subscription(&self) -> Option<String> {
+        self.schema.subscription.clone()
     }
 
     fn drop_resolvers(mut self) -> Self {

--- a/src/core/blueprint/compress.rs
+++ b/src/core/blueprint/compress.rs
@@ -14,10 +14,14 @@ pub fn compress(mut blueprint: Blueprint) -> Blueprint {
     // for root-definitions.
     let defined_query_type = blueprint.query().clone();
     let mutation = blueprint.mutation().unwrap_or("Mutation".to_string());
+    let subscription = blueprint
+        .subscription()
+        .unwrap_or("Subscription".to_string());
 
     // Push to root-types
     root_type.push(defined_query_type.as_str());
     root_type.push(mutation.as_str());
+    root_type.push(subscription.as_str());
 
     let mut referenced_types = identify_referenced_types(&graph, root_type);
     referenced_types.insert("Query".to_string());

--- a/src/core/blueprint/definitions.rs
+++ b/src/core/blueprint/definitions.rs
@@ -377,6 +377,13 @@ fn to_fields(
         .eq(&Some(object_name))
     {
         GraphQLOperationType::Mutation
+    } else if config_module
+        .schema
+        .subscription
+        .as_deref()
+        .eq(&Some(object_name))
+    {
+        GraphQLOperationType::Subscription
     } else {
         GraphQLOperationType::Query
     };

--- a/src/core/blueprint/index.rs
+++ b/src/core/blueprint/index.rs
@@ -42,6 +42,10 @@ impl Index {
     pub fn get_mutation(&self) -> Option<&str> {
         self.schema.mutation.as_deref()
     }
+
+    pub fn get_subscription(&self) -> Option<&str> {
+        self.schema.subscription.as_deref()
+    }
 }
 
 impl From<&Blueprint> for Index {

--- a/src/core/blueprint/into_schema.rs
+++ b/src/core/blueprint/into_schema.rs
@@ -225,7 +225,8 @@ impl From<&Blueprint> for SchemaBuilder {
     fn from(blueprint: &Blueprint) -> Self {
         let query = blueprint.query();
         let mutation = blueprint.mutation();
-        let mut schema = dynamic::Schema::build(query.as_str(), mutation.as_deref(), None);
+        let subscription = blueprint.subscription();
+        let mut schema = dynamic::Schema::build(query.as_str(), mutation.as_deref(), subscription.as_deref());
 
         for (k, v) in CUSTOM_SCALARS.iter() {
             schema = schema.register(dynamic::Type::Scalar(

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -622,6 +622,7 @@ pub enum GraphQLOperationType {
     #[default]
     Query,
     Mutation,
+    Subscription,
 }
 
 impl Display for GraphQLOperationType {
@@ -629,6 +630,7 @@ impl Display for GraphQLOperationType {
         f.write_str(match self {
             Self::Query => "query",
             Self::Mutation => "mutation",
+            Self::Subscription => "subscription",
         })
     }
 }
@@ -809,6 +811,10 @@ impl Config {
             types = self.find_connections(mutation, types);
         }
 
+        if let Some(ref subscription) = &self.schema.subscription {
+            types = self.find_connections(subscription, types);
+        }
+
         types
     }
 
@@ -863,6 +869,9 @@ impl Config {
         }
         if let Some(mutation) = &self.schema.mutation {
             stack.push(mutation.clone());
+        }
+        if let Some(subscription) = &self.schema.subscription {
+            stack.push(subscription.clone());
         }
         while let Some(type_name) = stack.pop() {
             if set.contains(&type_name) {

--- a/src/core/document.rs
+++ b/src/core/document.rs
@@ -33,7 +33,7 @@ fn print_schema(schema: &SchemaDefinition) -> String {
         .subscription
         .as_ref()
         .map_or(String::new(), |s| format!("  subscription: {}\n", s.node));
-    if mutation.is_empty() && query.is_empty() {
+    if subscription.is_empty() && mutation.is_empty() && query.is_empty() {
         return String::new();
     }
     format!(

--- a/src/core/jit/builder.rs
+++ b/src/core/jit/builder.rs
@@ -120,7 +120,7 @@ impl Builder {
         match ty {
             OperationType::Query => Some(self.index.get_query()),
             OperationType::Mutation => self.index.get_mutation(),
-            OperationType::Subscription => None,
+            OperationType::Subscription => self.index.get_subscription(),
         }
     }
 


### PR DESCRIPTION
First step to support subscriptions.

After that we need:
 * A websocket server (probably using `hyper-tungstenite`, version "0.11.0" is the last to support hyper pre 1.0).
   * Later, we can add SSE too.
 * Update taillcallhq playground to initiate ws connection on subscription
 * Add grpc stream over HTTP/2 (requires a lot of changes to support `Stream` in `eval_io`)
 * Add graphql resolver subscription
 * Think how to do subscription with HTTP resolvers?

I don't have time (or [energy](https://github.com/tailcallhq/tailcall/issues/2426)) in the near future for all of this, but you can take a look (and copy) at what I started here: https://github.com/tontinton/tailcall/pull/1