### PR TITLE
fix: allow users to specify extraction path

### DIFF
--- a/examples/grpc-reflection.graphql
+++ b/examples/grpc-reflection.graphql
@@ -10,7 +10,7 @@ type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(method: "news.NewsService.GetNews", body: "{{args.news}}")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{args.news}}", batchKey: ["news", "id"])
+    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{args.news}}", batch: {batchKey: "id", extractionPath: ["news", "id"]})
 }
 
 type News {

--- a/examples/grpc-reflection.graphql
+++ b/examples/grpc-reflection.graphql
@@ -10,7 +10,11 @@ type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(method: "news.NewsService.GetNews", body: "{{args.news}}")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{args.news}}", batch: {batchKey: "id", extractionPath: ["news", "id"]})
+    @grpc(
+      method: "news.NewsService.GetMultipleNews"
+      body: "{{args.news}}"
+      batch: {batchKey: "id", extractionPath: ["news", "id"]}
+    )
 }
 
 type News {

--- a/examples/grpc.graphql
+++ b/examples/grpc.graphql
@@ -10,7 +10,7 @@ type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(method: "news.NewsService.GetNews", body: "{{.args.news}}")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{.args.news}}", batchKey: ["news", "id"])
+    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{.args.news}}", batch: {batchKey: "id", extractionPath: ["news", "id"]})
 }
 
 type News {

--- a/examples/grpc.graphql
+++ b/examples/grpc.graphql
@@ -10,7 +10,11 @@ type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(method: "news.NewsService.GetNews", body: "{{.args.news}}")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(method: "news.NewsService.GetMultipleNews", body: "{{.args.news}}", batch: {batchKey: "id", extractionPath: ["news", "id"]})
+    @grpc(
+      method: "news.NewsService.GetMultipleNews"
+      body: "{{.args.news}}"
+      batch: {batchKey: "id", extractionPath: ["news", "id"]}
+    )
 }
 
 type News {

--- a/examples/jsonplaceholder_batch.graphql
+++ b/examples/jsonplaceholder_batch.graphql
@@ -22,5 +22,5 @@ type Post {
   userId: Int!
   title: String!
   body: String!
-  user: User @http(path: "/users", query: [{key: "id", value: "{{.value.userId}}"}], batchKey: ["id"])
+  user: User @http(path: "/users", query: [{key: "id", value: "{{.value.userId}}"}],  batch: {batchKey: "id", extractionPath: ["id"]})
 }

--- a/examples/jsonplaceholder_batch.graphql
+++ b/examples/jsonplaceholder_batch.graphql
@@ -22,5 +22,10 @@ type Post {
   userId: Int!
   title: String!
   body: String!
-  user: User @http(path: "/users", query: [{key: "id", value: "{{.value.userId}}"}],  batch: {batchKey: "id", extractionPath: ["id"]})
+  user: User
+    @http(
+      path: "/users"
+      query: [{key: "id", value: "{{.value.userId}}"}]
+      batch: {batchKey: "id", extractionPath: ["id"]}
+    )
 }

--- a/examples/jsonplaceholder_batch.json
+++ b/examples/jsonplaceholder_batch.json
@@ -39,7 +39,10 @@
                 "value": "{{value.userId}}"
               }
             ],
-            "batchKey": ["id"]
+            "batch": {
+              "batchKey": "id",
+              "extractionPath": ["id"]
+            }
           }
         },
         "userId": {

--- a/examples/jsonplaceholder_batch.yml
+++ b/examples/jsonplaceholder_batch.yml
@@ -28,8 +28,10 @@ types:
           query:
             - key: id
               value: "{{value.userId}}"
-          batchKey:
-            - id
+          batch:
+            batchKey: id
+            extractionPath:
+              - id
       userId:
         type: Int
         required: true

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -103,7 +103,7 @@ directive @grpc(
   The key path in the response which should be used to group multiple requests. For 
   instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
-  batchKey: [String!]
+  batch: GroupBy
   """
   This refers to the arguments of your gRPC call. You can pass it as a static object 
   or use Mustache template for dynamic parameters. These parameters will be added in 
@@ -140,7 +140,7 @@ directive @http(
   The `batchKey` parameter groups multiple data requests into a single call. For more 
   details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
-  batchKey: [String!]
+  batch: GroupBy
   """
   The body of the API call. It's used for methods like POST or PUT that send data to 
   the server. You can pass it as a static object or use a Mustache template to substitute 
@@ -543,6 +543,15 @@ input KeyValue {
   value: String!
 }
 
+"""
+The `groupBy` parameter groups multiple data requests into a single call. For more 
+details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+"""
+input GroupBy {
+  batchKey: String!
+  extractionPath: [String!]
+}
+
 input Schema {
   Obj: JSON
   Arr: Schema
@@ -748,7 +757,7 @@ input Grpc {
   The key path in the response which should be used to group multiple requests. For 
   instance `["news","id"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
-  batchKey: [String!]
+  batch: GroupBy
   """
   This refers to the arguments of your gRPC call. You can pass it as a static object 
   or use Mustache template for dynamic parameters. These parameters will be added in 
@@ -785,7 +794,7 @@ input Http {
   The `batchKey` parameter groups multiple data requests into a single call. For more 
   details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
-  batchKey: [String!]
+  batch: GroupBy
   """
   The body of the API call. It's used for methods like POST or PUT that send data to 
   the server. You can pass it as a static object or use a Mustache template to substitute 

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -544,8 +544,8 @@ input KeyValue {
 }
 
 """
-The `groupBy` parameter groups multiple data requests into a single call. For more 
-details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+The `groupBy` parameter allows you to groups multiple data requests into a single 
+call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
 """
 input GroupBy {
   batchKey: String!

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -137,8 +137,8 @@ directive @http(
   """
   baseURL: String
   """
-  The `batchKey` parameter groups multiple data requests into a single call. For more 
-  details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+  The `batch` parameter allows you to groups multiple data requests into a single call. 
+  For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
   batch: GroupBy
   """
@@ -791,8 +791,8 @@ input Http {
   """
   baseURL: String
   """
-  The `batchKey` parameter groups multiple data requests into a single call. For more 
-  details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+  The `batch` parameter allows you to groups multiple data requests into a single call. 
+  For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
   """
   batch: GroupBy
   """

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -587,7 +587,7 @@
       "additionalProperties": false
     },
     "GroupBy": {
-      "description": "The `groupBy` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
+      "description": "The `groupBy` parameter allows you to groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
       "type": "object",
       "properties": {
         "batchKey": {

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -706,7 +706,7 @@
           ]
         },
         "batch": {
-          "description": "The `batchKey` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
+          "description": "The `batch` parameter allows you to groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
           "anyOf": [
             {
               "$ref": "#/definitions/GroupBy"

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -586,6 +586,21 @@
       },
       "additionalProperties": false
     },
+    "GroupBy": {
+      "description": "The `groupBy` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
+      "type": "object",
+      "properties": {
+        "batchKey": {
+          "type": "string"
+        },
+        "extractionPath": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "Grpc": {
       "description": "The @grpc operator indicates that a field or node is backed by a gRPC API.\n\nFor instance, if you add the @grpc operator to the `users` field of the Query type with a service argument of `NewsService` and method argument of `GetAllNews`, it signifies that the `users` field is backed by a gRPC API. The `service` argument specifies the name of the gRPC service. The `method` argument specifies the name of the gRPC method. In this scenario, the GraphQL server will make a gRPC request to the gRPC endpoint specified when the `users` field is queried.",
       "type": "object",
@@ -600,12 +615,16 @@
             "null"
           ]
         },
-        "batchKey": {
+        "batch": {
           "description": "The key path in the response which should be used to group multiple requests. For instance `[\"news\",\"id\"]`. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GroupBy"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "body": {
           "description": "This refers to the arguments of your gRPC call. You can pass it as a static object or use Mustache template for dynamic parameters. These parameters will be added in the body in `protobuf` format."
@@ -686,12 +705,16 @@
             "null"
           ]
         },
-        "batchKey": {
+        "batch": {
           "description": "The `batchKey` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GroupBy"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "body": {
           "description": "The body of the API call. It's used for methods like POST or PUT that send data to the server. You can pass it as a static object or use a Mustache template to substitute variables from the GraphQL variables.",

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -555,7 +555,7 @@ pub struct Http {
     pub encoding: Encoding,
 
     #[serde(rename = "batch", default, skip_serializing_if = "is_default")]
-    /// The `batchKey` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+    /// The `batch` parameter allows you to groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
     pub group_by: Option<GroupBy>,
 
     #[serde(default, skip_serializing_if = "is_default")]

--- a/src/core/config/group_by.rs
+++ b/src/core/config/group_by.rs
@@ -3,25 +3,28 @@ use serde::{Deserialize, Serialize};
 use crate::core::is_default;
 #[derive(Clone, Debug, Eq, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
 /// The `groupBy` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+#[serde(rename_all = "camelCase")]
 pub struct GroupBy {
     #[serde(default, skip_serializing_if = "is_default")]
-    path: Vec<String>,
+    batch_key: String,
+    #[serde(default, skip_serializing_if = "is_default")]
+    extraction_path: Vec<String>,
 }
 
 impl GroupBy {
-    pub fn new(path: Vec<String>) -> Self {
-        Self { path }
+    pub fn new(batch_key: String, extraction_path: Vec<String>) -> Self {
+        Self { batch_key, extraction_path }
     }
 
     pub fn path(&self) -> Vec<String> {
-        if self.path.is_empty() {
+        if self.extraction_path.is_empty() {
             return vec![String::from(ID)];
         }
-        self.path.clone()
+        self.extraction_path.clone()
     }
 
     pub fn key(&self) -> &str {
-        self.path.last().map(|a| a.as_str()).unwrap_or(ID)
+        self.batch_key.as_str()
     }
 }
 
@@ -29,6 +32,9 @@ const ID: &str = "id";
 
 impl Default for GroupBy {
     fn default() -> Self {
-        Self { path: vec![ID.to_string()] }
+        Self {
+            batch_key: ID.to_string(),
+            extraction_path: vec![ID.to_string()],
+        }
     }
 }

--- a/src/core/config/group_by.rs
+++ b/src/core/config/group_by.rs
@@ -2,11 +2,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::is_default;
 #[derive(Clone, Debug, Eq, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
-/// The `groupBy` parameter groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
+/// The `groupBy` parameter allows you to groups multiple data requests into a single call. For more details please refer out [n + 1 guide](https://tailcall.run/docs/guides/n+1#solving-using-batching).
 #[serde(rename_all = "camelCase")]
 pub struct GroupBy {
+    // batch_key is used to form the batched endpoint and is equivalent to a query parameter.
     #[serde(default, skip_serializing_if = "is_default")]
     batch_key: String,
+    // extraction_path is the path to the JSON object in the batched API response.
+    // It helps in extracting the required data from the nested structure of the response.
     #[serde(default, skip_serializing_if = "is_default")]
     extraction_path: Vec<String>,
 }

--- a/src/core/config/n_plus_one.rs
+++ b/src/core/config/n_plus_one.rs
@@ -56,6 +56,7 @@ pub fn n_plus_one(config: &Config) -> Vec<Vec<(String, String)>> {
 #[cfg(test)]
 mod tests {
 
+    use crate::core::config::group_by::GroupBy;
     use crate::core::config::{Config, Field, Http, Type};
 
     #[test]
@@ -116,7 +117,7 @@ mod tests {
                     Field::default()
                         .type_of("F2".to_string())
                         .into_list()
-                        .http(Http { group_by: vec!["id".into()], ..Default::default() }),
+                        .http(Http { group_by: Some(GroupBy::default()), ..Default::default() }),
                 )]),
             ),
             (

--- a/src/core/generator/from_proto.rs
+++ b/src/core/generator/from_proto.rs
@@ -369,7 +369,7 @@ impl Context {
                 cfg_field.grpc = Some(Grpc {
                     base_url: None,
                     body,
-                    group_by: vec![],
+                    group_by: None,
                     headers: vec![],
                     method: field_name.id(),
                 });

--- a/src/core/http/data_loader.rs
+++ b/src/core/http/data_loader.rs
@@ -78,7 +78,7 @@ impl Loader<DataLoaderRequest> for HttpDataLoader {
                 let url = request.url();
                 let pairs: Vec<_> = url
                     .query_pairs()
-                    .filter(|(key, _)| group_by.path().contains(&key.to_string()))
+                    .filter(|(key, _)| group_by.key().contains(&key.to_string()))
                     .collect();
                 first_url.query_pairs_mut().extend_pairs(pairs);
             }

--- a/tests/core/snapshots/batching-default.md_merged.snap
+++ b/tests/core/snapshots/batching-default.md_merged.snap
@@ -14,7 +14,7 @@ type Post {
   title: String
   user: User
     @http(
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
     )

--- a/tests/core/snapshots/batching-group-by-default.md_merged.snap
+++ b/tests/core/snapshots/batching-group-by-default.md_merged.snap
@@ -18,7 +18,7 @@ type Post {
   title: String
   user: User
     @http(
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
     )

--- a/tests/core/snapshots/batching-group-by-optional-key.md_merged.snap
+++ b/tests/core/snapshots/batching-group-by-optional-key.md_merged.snap
@@ -18,7 +18,7 @@ type Post {
   title: String
   user: User
     @http(
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
     )

--- a/tests/core/snapshots/batching-group-by.md_merged.snap
+++ b/tests/core/snapshots/batching-group-by.md_merged.snap
@@ -18,7 +18,7 @@ type Post {
   title: String
   user: User
     @http(
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
     )

--- a/tests/core/snapshots/different-batch-key-and-extraction-path.md_0.snap
+++ b/tests/core/snapshots/different-batch-key-and-extraction-path.md_0.snap
@@ -1,0 +1,45 @@
+---
+source: tests/core/spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "foo": {
+        "transactions": [
+          {
+            "id": "7964963e-06e8-46a7-b228-04fc08fd020f",
+            "bank_account_id": "441ff0f9-c00d-45cc-8bbf-5a8fffa01798",
+            "BankAccounts": [
+              {
+                "bic": "bic1",
+                "iban": "iban1",
+                "id": "441ff0f9-c00d-45cc-8bbf-5a8fffa01798"
+              },
+              {
+                "bic": "bic3",
+                "iban": "iban2",
+                "id": "441ff0f9-c00d-45cc-8bbf-5a8fffa01798"
+              }
+            ]
+          },
+          {
+            "id": "140b5e4d-b9c0-40f7-97ec-313c9bda2b00",
+            "bank_account_id": "ea2efff5-6d7c-4cf3-bada-8447e139a864",
+            "BankAccounts": [
+              {
+                "bic": "bic3",
+                "iban": "iban3",
+                "id": "ea2efff5-6d7c-4cf3-bada-8447e139a864"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/core/snapshots/different-batch-key-and-extraction-path.md_client.snap
+++ b/tests/core/snapshots/different-batch-key-and-extraction-path.md_client.snap
@@ -1,0 +1,62 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+---
+type BankAccount {
+  bic: String
+  iban: String
+  id: ID
+}
+
+scalar Bytes
+
+scalar Date
+
+scalar Email
+
+scalar Empty
+
+type Foo {
+  transactions: [Transaction]
+}
+
+scalar Int128
+
+scalar Int16
+
+scalar Int32
+
+scalar Int64
+
+scalar Int8
+
+scalar JSON
+
+scalar PhoneNumber
+
+type Query {
+  foo: Foo
+}
+
+type Transaction {
+  BankAccounts: [BankAccount]
+  bank_account_id: String
+  id: ID
+  slug: String
+}
+
+scalar UInt128
+
+scalar UInt16
+
+scalar UInt32
+
+scalar UInt64
+
+scalar UInt8
+
+scalar Url
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/different-batch-key-and-extraction-path.md_merged.snap
+++ b/tests/core/snapshots/different-batch-key-and-extraction-path.md_merged.snap
@@ -1,0 +1,35 @@
+---
+source: tests/core/spec.rs
+expression: formatter
+---
+schema
+  @server(port: 8000)
+  @upstream(baseURL: "http://jsonplaceholder.typicode.com", batch: {delay: 1, headers: [], maxSize: 1000}) {
+  query: Query
+}
+
+type BankAccount {
+  bic: String
+  iban: String
+  id: ID
+}
+
+type Foo {
+  transactions: [Transaction]
+}
+
+type Query {
+  foo: Foo @http(path: "/transactions")
+}
+
+type Transaction {
+  BankAccounts: [BankAccount]
+    @http(
+      batch: {batchKey: "bank_account_ids[]", extractionPath: ["bank_accounts", "id"]}
+      path: "/v1/bank_accounts"
+      query: [{key: "bank_account_ids[]", value: "{{.value.bank_account_id}}"}]
+    )
+  bank_account_id: String
+  id: ID
+  slug: String
+}

--- a/tests/core/snapshots/grpc-batch.md_merged.snap
+++ b/tests/core/snapshots/grpc-batch.md_merged.snap
@@ -33,7 +33,7 @@ type Query {
     @grpc(
       baseURL: "http://localhost:50051"
       body: "{{.args.news}}"
-      batchKey: ["news", "id"]
+      batch: {batchKey: "id", extractionPath: ["news", "id"]}
       method: "news.NewsService.GetMultipleNews"
     )
 }

--- a/tests/core/snapshots/n-plus-one-list.md_merged.snap
+++ b/tests/core/snapshots/n-plus-one-list.md_merged.snap
@@ -7,13 +7,23 @@ schema @server @upstream(baseURL: "http://example.com", batch: {delay: 1, header
 }
 
 type Bar {
-  foo: [Foo] @http(batchKey: ["id"], path: "/foos", query: [{key: "id", value: "{{.value.fooId}}"}])
+  foo: [Foo]
+    @http(
+      batch: {batchKey: "id", extractionPath: ["id"]}
+      path: "/foos"
+      query: [{key: "id", value: "{{.value.fooId}}"}]
+    )
   fooId: Int!
   id: Int!
 }
 
 type Foo {
-  bar: Bar @http(batchKey: ["fooId"], path: "/bars", query: [{key: "fooId", value: "{{.value.id}}"}])
+  bar: Bar
+    @http(
+      batch: {batchKey: "fooId", extractionPath: ["fooId"]}
+      path: "/bars"
+      query: [{key: "fooId", value: "{{.value.id}}"}]
+    )
   id: Int!
   name: String!
 }

--- a/tests/core/snapshots/n-plus-one.md_merged.snap
+++ b/tests/core/snapshots/n-plus-one.md_merged.snap
@@ -7,13 +7,23 @@ schema @server @upstream(baseURL: "http://example.com", batch: {delay: 1, header
 }
 
 type Bar {
-  foo: [Foo] @http(batchKey: ["id"], path: "/foos", query: [{key: "id", value: "{{.value.fooId}}"}])
+  foo: [Foo]
+    @http(
+      batch: {batchKey: "id", extractionPath: ["id"]}
+      path: "/foos"
+      query: [{key: "id", value: "{{.value.fooId}}"}]
+    )
   fooId: Int!
   id: Int!
 }
 
 type Foo {
-  bar: Bar @http(batchKey: ["fooId"], path: "/bars", query: [{key: "fooId", value: "{{.value.id}}"}])
+  bar: Bar
+    @http(
+      batch: {batchKey: "fooId", extractionPath: ["fooId"]}
+      path: "/bars"
+      query: [{key: "fooId", value: "{{.value.id}}"}]
+    )
   id: Int!
   name: String!
 }

--- a/tests/core/snapshots/request-to-upstream-batching.md_merged.snap
+++ b/tests/core/snapshots/request-to-upstream-batching.md_merged.snap
@@ -10,7 +10,7 @@ type Query {
   user(id: Int!): User
     @http(
       baseURL: "http://jsonplaceholder.typicode.com"
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
       path: "/users"
       query: [{key: "id", value: "{{.args.id}}"}]
     )

--- a/tests/core/snapshots/test-batching-group-by.md_merged.snap
+++ b/tests/core/snapshots/test-batching-group-by.md_merged.snap
@@ -10,7 +10,12 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @http(batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{.value.userId}}"}])
+  user: User
+    @http(
+      batch: {batchKey: "id", extractionPath: ["id"]}
+      path: "/users"
+      query: [{key: "id", value: "{{.value.userId}}"}]
+    )
   userId: Int!
 }
 

--- a/tests/core/snapshots/test-grpc.md_merged.snap
+++ b/tests/core/snapshots/test-grpc.md_merged.snap
@@ -31,5 +31,9 @@ type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(body: "{{.args.news}}", method: "news.NewsService.GetNews")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(body: "{{.args.news}}", batchKey: ["news", "id"], method: "news.NewsService.GetMultipleNews")
+    @grpc(
+      body: "{{.args.news}}"
+      batch: {batchKey: "id", extractionPath: ["news", "id"]}
+      method: "news.NewsService.GetMultipleNews"
+    )
 }

--- a/tests/core/snapshots/upstream-batching.md_merged.snap
+++ b/tests/core/snapshots/upstream-batching.md_merged.snap
@@ -10,7 +10,7 @@ type Query {
   user(id: Int): User
     @http(
       baseURL: "http://jsonplaceholder.typicode.com"
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
       path: "/users"
       query: [{key: "id", value: "{{.args.id}}"}]
     )

--- a/tests/execution/batching-default.md
+++ b/tests/execution/batching-default.md
@@ -18,7 +18,7 @@ type Post {
     @http(
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
     )
 }
 

--- a/tests/execution/batching-group-by-default.md
+++ b/tests/execution/batching-group-by-default.md
@@ -18,7 +18,7 @@ type Post {
   userId: Int!
   user: User
     @http(
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
     )

--- a/tests/execution/batching-group-by-optional-key.md
+++ b/tests/execution/batching-group-by-optional-key.md
@@ -20,7 +20,7 @@ type Post {
     @http(
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
     )
 }
 

--- a/tests/execution/batching-group-by.md
+++ b/tests/execution/batching-group-by.md
@@ -20,7 +20,7 @@ type Post {
     @http(
       path: "/users"
       query: [{key: "id", value: "{{.value.userId}}"}, {key: "foo", value: "bar"}]
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
     )
 }
 

--- a/tests/execution/different-batch-key-and-extraction-path.md
+++ b/tests/execution/different-batch-key-and-extraction-path.md
@@ -1,9 +1,7 @@
 # different batch key and extraction path
 
 ```graphql @config
-schema
-  @server(port: 8000)
-  @upstream(baseURL: "http://jsonplaceholder.typicode.com", batch: {maxSize: 1000, delay: 1}) {
+schema @server(port: 8000) @upstream(baseURL: "http://jsonplaceholder.typicode.com", batch: {maxSize: 1000, delay: 1}) {
   query: Query
 }
 
@@ -23,10 +21,7 @@ type Transaction {
     @http(
       path: "/v1/bank_accounts"
       query: [{key: "bank_account_ids[]", value: "{{.value.bank_account_id}}"}]
-      batch: {
-        batchKey: "bank_account_ids[]",
-        extractionPath: ["bank_accounts","id"]
-      }
+      batch: {batchKey: "bank_account_ids[]", extractionPath: ["bank_accounts", "id"]}
     )
 }
 
@@ -82,7 +77,6 @@ type BankAccount {
         total_pages: 2
         total_count: 4
         per_page: 2
-
 ```
 
 ```yml @test

--- a/tests/execution/different-batch-key-and-extraction-path.md
+++ b/tests/execution/different-batch-key-and-extraction-path.md
@@ -53,6 +53,7 @@ type BankAccount {
         total_pages: 2
         total_count: 4
         per_page: 2
+  expectedHits: 1
 
 - request:
     method: GET
@@ -77,6 +78,8 @@ type BankAccount {
         total_pages: 2
         total_count: 4
         per_page: 2
+  expectedHits: 1
+  
 ```
 
 ```yml @test

--- a/tests/execution/different-batch-key-and-extraction-path.md
+++ b/tests/execution/different-batch-key-and-extraction-path.md
@@ -79,7 +79,6 @@ type BankAccount {
         total_count: 4
         per_page: 2
   expectedHits: 1
-  
 ```
 
 ```yml @test

--- a/tests/execution/different-batch-key-and-extraction-path.md
+++ b/tests/execution/different-batch-key-and-extraction-path.md
@@ -1,0 +1,106 @@
+# different batch key and extraction path
+
+```graphql @config
+schema
+  @server(port: 8000)
+  @upstream(baseURL: "http://jsonplaceholder.typicode.com", batch: {maxSize: 1000, delay: 1}) {
+  query: Query
+}
+
+type Query {
+  foo: Foo @http(path: "/transactions")
+}
+
+type Foo {
+  transactions: [Transaction]
+}
+
+type Transaction {
+  id: ID
+  slug: String
+  bank_account_id: String
+  BankAccounts: [BankAccount]
+    @http(
+      path: "/v1/bank_accounts"
+      query: [{key: "bank_account_ids[]", value: "{{.value.bank_account_id}}"}]
+      batch: {
+        batchKey: "bank_account_ids[]",
+        extractionPath: ["bank_accounts","id"]
+      }
+    )
+}
+
+type BankAccount {
+  id: ID
+  bic: String
+  iban: String
+}
+```
+
+```yml @mock
+- request:
+    method: GET
+    url: http://jsonplaceholder.typicode.com/transactions
+  response:
+    status: 200
+    body:
+      transactions:
+        - id: "7964963e-06e8-46a7-b228-04fc08fd020f"
+          slug: "slug-tx-1"
+          bank_account_id: "441ff0f9-c00d-45cc-8bbf-5a8fffa01798"
+        - id: "140b5e4d-b9c0-40f7-97ec-313c9bda2b00"
+          slug: "slug-tx-2"
+          bank_account_id: "ea2efff5-6d7c-4cf3-bada-8447e139a864"
+      meta:
+        current_page: 1
+        next_page: 2
+        prev_page: null
+        total_pages: 2
+        total_count: 4
+        per_page: 2
+
+- request:
+    method: GET
+    url: http://jsonplaceholder.typicode.com/v1/bank_accounts?bank_account_ids[]=441ff0f9-c00d-45cc-8bbf-5a8fffa01798&bank_account_ids%5B%5D=ea2efff5-6d7c-4cf3-bada-8447e139a864
+  response:
+    status: 200
+    body:
+      bank_accounts:
+        - id: "441ff0f9-c00d-45cc-8bbf-5a8fffa01798"
+          iban: "iban1"
+          bic: "bic1"
+        - id: "441ff0f9-c00d-45cc-8bbf-5a8fffa01798"
+          iban: "iban2"
+          bic: "bic3"
+        - id: "ea2efff5-6d7c-4cf3-bada-8447e139a864"
+          iban: "iban3"
+          bic: "bic3"
+      meta:
+        current_page: 1
+        next_page: 2
+        prev_page: null
+        total_pages: 2
+        total_count: 4
+        per_page: 2
+
+```
+
+```yml @test
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: |-
+      {
+        foo {
+          transactions {
+            id,
+            bank_account_id,
+            BankAccounts {
+              bic
+              iban
+              id
+            }
+          }
+        }
+      }
+```

--- a/tests/execution/grpc-batch.md
+++ b/tests/execution/grpc-batch.md
@@ -51,7 +51,7 @@ type Query {
       method: "news.NewsService.GetMultipleNews"
       baseURL: "http://localhost:50051"
       body: "{{.args.news}}"
-      batchKey: ["news", "id"]
+      batch: {batchKey: "id", extractionPath: ["news", "id"]}
     )
 }
 input NewsInput {

--- a/tests/execution/n-plus-one-list.md
+++ b/tests/execution/n-plus-one-list.md
@@ -13,13 +13,23 @@ type Query {
 type Foo {
   id: Int!
   name: String!
-  bar: Bar @http(path: "/bars", query: [{key: "fooId", value: "{{.value.id}}"}], batchKey: ["fooId"])
+  bar: Bar
+    @http(
+      path: "/bars"
+      query: [{key: "fooId", value: "{{.value.id}}"}]
+      batch: {batchKey: "fooId", extractionPath: ["fooId"]}
+    )
 }
 
 type Bar {
   id: Int!
   fooId: Int!
-  foo: [Foo] @http(path: "/foos", query: [{key: "id", value: "{{.value.fooId}}"}], batchKey: ["id"])
+  foo: [Foo]
+    @http(
+      path: "/foos"
+      query: [{key: "id", value: "{{.value.fooId}}"}]
+      batch: {batchKey: "id", extractionPath: ["id"]}
+    )
 }
 ```
 

--- a/tests/execution/n-plus-one.md
+++ b/tests/execution/n-plus-one.md
@@ -13,13 +13,23 @@ type Query {
 type Foo {
   id: Int!
   name: String!
-  bar: Bar @http(path: "/bars", query: [{key: "fooId", value: "{{.value.id}}"}], batchKey: ["fooId"])
+  bar: Bar
+    @http(
+      path: "/bars"
+      query: [{key: "fooId", value: "{{.value.id}}"}]
+      batch: {batchKey: "fooId", extractionPath: ["fooId"]}
+    )
 }
 
 type Bar {
   id: Int!
   fooId: Int!
-  foo: [Foo] @http(path: "/foos", query: [{key: "id", value: "{{.value.fooId}}"}], batchKey: ["id"])
+  foo: [Foo]
+    @http(
+      path: "/foos"
+      query: [{key: "id", value: "{{.value.fooId}}"}]
+      batch: {batchKey: "id", extractionPath: ["id"]}
+    )
 }
 ```
 

--- a/tests/execution/request-to-upstream-batching.md
+++ b/tests/execution/request-to-upstream-batching.md
@@ -35,7 +35,10 @@
               }
             ],
             "baseURL": "http://jsonplaceholder.typicode.com",
-            "batchKey": ["id"]
+            "batch": {
+              "batchKey": "id",
+              "extractionPath": ["id"]
+            }
           },
           "cache": null
         }

--- a/tests/execution/test-batch-operator-post.md
+++ b/tests/execution/test-batch-operator-post.md
@@ -15,6 +15,6 @@ type User {
 }
 
 type Query {
-  user: User @http(path: "/posts/1", method: "POST", batchKey: ["id"])
+  user: User @http(path: "/posts/1", method: "POST", batch: {batchKey: "id", extractionPath: ["id"]})
 }
 ```

--- a/tests/execution/test-batching-group-by.md
+++ b/tests/execution/test-batching-group-by.md
@@ -13,7 +13,12 @@ type Post {
   body: String
   id: Int
   title: String
-  user: User @http(batchKey: ["id"], path: "/users", query: [{key: "id", value: "{{.value.userId}}"}])
+  user: User
+    @http(
+      batch: {batchKey: "id", extractionPath: ["id"]}
+      path: "/users"
+      query: [{key: "id", value: "{{.value.userId}}"}]
+    )
   userId: Int!
 }
 

--- a/tests/execution/test-groupby-without-batching.md
+++ b/tests/execution/test-groupby-without-batching.md
@@ -15,6 +15,7 @@ type User {
 }
 
 type Query {
-  user(id: Int!): User @http(path: "/users", query: [{key: "id", value: "{{.args.id}}"}], batchKey: ["id"])
+  user(id: Int!): User
+    @http(path: "/users", query: [{key: "id", value: "{{.args.id}}"}], batch: {batchKey: "id", extractionPath: ["id"]})
 }
 ```

--- a/tests/execution/test-grpc-group-by.md
+++ b/tests/execution/test-grpc-group-by.md
@@ -54,7 +54,7 @@ type Query {
       method: "news.NewsService.GetMultipleNews"
       baseURL: "http://localhost:50051"
       body: "{{.args.news}}"
-      batchKey: ["id"]
+      batch: {batchKey: "id", extractionPath: ["id"]}
     )
 }
 input NewsInput {

--- a/tests/execution/test-grpc.md
+++ b/tests/execution/test-grpc.md
@@ -70,6 +70,10 @@ type Query {
   news: NewsData! @grpc(method: "news.NewsService.GetAllNews")
   newsById(news: NewsInput!): News! @grpc(body: "{{.args.news}}", method: "news.NewsService.GetNews")
   newsByIdBatch(news: NewsInput!): News!
-    @grpc(body: "{{.args.news}}", batchKey: ["news", "id"], method: "news.NewsService.GetMultipleNews")
+    @grpc(
+      body: "{{.args.news}}"
+      batch: {batchKey: "id", extractionPath: ["news", "id"]}
+      method: "news.NewsService.GetMultipleNews"
+    )
 }
 ```

--- a/tests/execution/upstream-batching.md
+++ b/tests/execution/upstream-batching.md
@@ -32,7 +32,10 @@
               }
             ],
             "baseURL": "http://jsonplaceholder.typicode.com",
-            "batchKey": ["id"]
+            "batch": {
+              "batchKey": "id",
+              "extractionPath": ["id"]
+            }
           },
           "cache": null
         }


### PR DESCRIPTION
**Summary:**  
problem: when we specify the batchKey: ["a","b"] we essentially expect the path to target and assume the last value to be the query param key.
eg.
in the discussion example, `batchKey: ["bank_accounts", "id"]` , tells the server `id` will be used for the extraction of json item from batched endpoint's response and `id` will be used form a batched end point which isn't the case when extraction property name is different than the name used to form batched endpoint. so we need more information in order to solve this problem.


proposed solution: 
```graphql
      batch: {batchKey: "bank_account_ids[]", extractionPath: ["bank_accounts", "id"]}
```
 here we tell form the endpoint with batchKey and use extraction path for extract the json object from batched endpoint.
i.e when creating batched endpoint use `bank_account_ids[]` and in the batched endpoint response go to `bank_accounts.id` to figure out merging.


**Issue Reference(s):**  
Fixes #2489
/claim #2489


**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
