### PR TITLE
fix: query parameter selection when `batchKey` is used

### DIFF
--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -185,9 +185,9 @@ directive @http(
   """
   This represents the query parameters of your API call. You can pass it as a static 
   object or use Mustache template for dynamic parameters. These parameters will be 
-  added to the URL. When `batchKey` is present Tailcall uses the last query parameter 
-  as the key for the groupBy operator. You can overwrite this behavior by specifying 
-  the `key` property.
+  added to the URL. NOTE: Query parameter order is critical for batching in Tailcall. 
+  The first parameter referencing a field in the current value using mustache syntax 
+  is automatically selected as the batching parameter.
   """
   query: [KeyValue]
 ) on FIELD_DEFINITION
@@ -827,9 +827,9 @@ input Http {
   """
   This represents the query parameters of your API call. You can pass it as a static 
   object or use Mustache template for dynamic parameters. These parameters will be 
-  added to the URL. When `batchKey` is present Tailcall uses the last query parameter 
-  as the key for the groupBy operator. You can overwrite this behavior by specifying 
-  the `key` property.
+  added to the URL. NOTE: Query parameter order is critical for batching in Tailcall. 
+  The first parameter referencing a field in the current value using mustache syntax 
+  is automatically selected as the batching parameter.
   """
   query: [KeyValue]
 }

--- a/generated/.tailcallrc.graphql
+++ b/generated/.tailcallrc.graphql
@@ -185,8 +185,9 @@ directive @http(
   """
   This represents the query parameters of your API call. You can pass it as a static 
   object or use Mustache template for dynamic parameters. These parameters will be 
-  added to the URL. When `batchKey` is present Tailcall uses the first query parameter 
-  as the key for the groupBy operator.
+  added to the URL. When `batchKey` is present Tailcall uses the last query parameter 
+  as the key for the groupBy operator. You can overwrite this behavior by specifying 
+  the `key` property.
   """
   query: [KeyValue]
 ) on FIELD_DEFINITION
@@ -826,8 +827,9 @@ input Http {
   """
   This represents the query parameters of your API call. You can pass it as a static 
   object or use Mustache template for dynamic parameters. These parameters will be 
-  added to the URL. When `batchKey` is present Tailcall uses the first query parameter 
-  as the key for the groupBy operator.
+  added to the URL. When `batchKey` is present Tailcall uses the last query parameter 
+  as the key for the groupBy operator. You can overwrite this behavior by specifying 
+  the `key` property.
   """
   query: [KeyValue]
 }

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -732,7 +732,7 @@
           "type": "string"
         },
         "query": {
-          "description": "This represents the query parameters of your API call. You can pass it as a static object or use Mustache template for dynamic parameters. These parameters will be added to the URL. When `batchKey` is present Tailcall uses the last query parameter as the key for the groupBy operator. You can overwrite this behavior by specifying the `key` property.",
+          "description": "This represents the query parameters of your API call. You can pass it as a static object or use Mustache template for dynamic parameters. These parameters will be added to the URL. NOTE: Query parameter order is critical for batching in Tailcall. The first parameter referencing a field in the current value using mustache syntax is automatically selected as the batching parameter.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/KeyValue"

--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -732,7 +732,7 @@
           "type": "string"
         },
         "query": {
-          "description": "This represents the query parameters of your API call. You can pass it as a static object or use Mustache template for dynamic parameters. These parameters will be added to the URL. When `batchKey` is present Tailcall uses the first query parameter as the key for the groupBy operator.",
+          "description": "This represents the query parameters of your API call. You can pass it as a static object or use Mustache template for dynamic parameters. These parameters will be added to the URL. When `batchKey` is present Tailcall uses the last query parameter as the key for the groupBy operator. You can overwrite this behavior by specifying the `key` property.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/KeyValue"

--- a/src/core/blueprint/operators/http.rs
+++ b/src/core/blueprint/operators/http.rs
@@ -6,7 +6,7 @@ use crate::core::http::{HttpFilter, Method, RequestTemplate};
 use crate::core::ir::model::{IO, IR};
 use crate::core::try_fold::TryFold;
 use crate::core::valid::{Valid, ValidationError, Validator};
-use crate::core::{config, helpers};
+use crate::core::{config, helpers, Mustache};
 
 pub fn compile_http(
     config_module: &config::ConfigModule,
@@ -62,7 +62,14 @@ pub fn compile_http(
                 .map(|on_request| HttpFilter { on_request });
 
             if !http.batch_key.is_empty() && http.method == Method::GET {
-                let key = http.query.first().map(|query| query.key.clone());
+                // Find a query parameter that contains a reference to the {{.value}} key
+                let key = http
+                    .query
+                    .iter()
+                    .find_map(|q| match Mustache::parse(&q.value) {
+                        Ok(tmpl) => tmpl.expression_contains("value").then(|| q.key.clone()),
+                        Err(_) => None,
+                    });
                 IR::IO(IO::Http {
                     req_template,
                     group_by: Some(GroupBy::new(http.batch_key.clone(), key)),

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -590,8 +590,9 @@ pub struct Http {
     /// This represents the query parameters of your API call. You can pass it
     /// as a static object or use Mustache template for dynamic parameters.
     /// These parameters will be added to the URL.
-    /// When `batchKey` is present Tailcall uses the first query parameter as
-    /// the key for the groupBy operator.
+    /// When `batchKey` is present Tailcall uses the last query parameter as
+    /// the key for the groupBy operator. You can overwrite this behavior by
+    /// specifying the `key` property.
     pub query: Vec<KeyValue>,
 }
 

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -590,9 +590,9 @@ pub struct Http {
     /// This represents the query parameters of your API call. You can pass it
     /// as a static object or use Mustache template for dynamic parameters.
     /// These parameters will be added to the URL.
-    /// When `batchKey` is present Tailcall uses the last query parameter as
-    /// the key for the groupBy operator. You can overwrite this behavior by
-    /// specifying the `key` property.
+    /// NOTE: Query parameter order is critical for batching in Tailcall. The
+    /// first parameter referencing a field in the current value using mustache
+    /// syntax is automatically selected as the batching parameter.
     pub query: Vec<KeyValue>,
 }
 

--- a/src/core/mustache/model.rs
+++ b/src/core/mustache/model.rs
@@ -42,6 +42,13 @@ impl Mustache {
             })
             .collect()
     }
+
+    /// Checks if the mustache template contains the given expression
+    pub fn expression_contains(&self, expression: &str) -> bool {
+        self.segments()
+            .iter()
+            .any(|seg| matches!(seg, Segment::Expression(parts) if parts.iter().any(|part| part.as_str() == expression)))
+    }
 }
 
 impl Display for Mustache {

--- a/tests/core/snapshots/test-http-batchKey.md_merged.snap
+++ b/tests/core/snapshots/test-http-batchKey.md_merged.snap
@@ -15,7 +15,12 @@ type Bar {
 
 type Foo {
   barId: String!
-  bars: [Bar!]! @http(batchKey: ["bars", "id"], path: "/bar", query: [{key: "barId[]", value: "{{.value.barId}}"}])
+  bars: [Bar!]!
+    @http(
+      batchKey: ["bars", "id"]
+      path: "/bar"
+      query: [{key: "baz", value: "static_value"}, {key: "barId[]", value: "{{.value.barId}}"}]
+    )
   fooName: String!
   id: ID!
 }

--- a/tests/execution/test-http-batchKey.md
+++ b/tests/execution/test-http-batchKey.md
@@ -19,12 +19,7 @@ type Foo {
   id: ID!
   fooName: String!
   barId: String!
-  bars: [Bar!]!
-    @http(
-      path: "/bar"
-      query: [{key: "barId[]", value: "{{.value.barId}}"}]
-      batchKey: ["bars", "id"]
-    )
+  bars: [Bar!]! @http(path: "/bar", query: [{key: "barId[]", value: "{{.value.barId}}"}], batchKey: ["bars", "id"])
 }
 
 type Bar {

--- a/tests/execution/test-http-batchKey.md
+++ b/tests/execution/test-http-batchKey.md
@@ -23,7 +23,6 @@ type Foo {
     @http(
       path: "/bar"
       query: [{key: "barId[]", value: "{{.value.barId}}"}]
-      batchKey: "barId[]"
       batchKey: ["bars", "id"]
     )
 }

--- a/tests/execution/test-http-batchKey.md
+++ b/tests/execution/test-http-batchKey.md
@@ -19,7 +19,16 @@ type Foo {
   id: ID!
   fooName: String!
   barId: String!
-  bars: [Bar!]! @http(path: "/bar", query: [{key: "barId[]", value: "{{.value.barId}}"}], batchKey: ["bars", "id"])
+  bars: [Bar!]!
+    @http(
+      path: "/bar"
+      query: [
+        #
+        {key: "baz", value: "static_value"}
+        {key: "barId[]", value: "{{.value.barId}}"}
+      ]
+      batchKey: ["bars", "id"]
+    )
 }
 
 type Bar {
@@ -47,7 +56,7 @@ type Bar {
       }
 - request:
     method: GET
-    url: http://jsonplaceholder.typicode.com/bar?barId[]=bar_1&barId%5B%5D=bar_2
+    url: http://jsonplaceholder.typicode.com/bar?baz=static_value&barId[]=bar_1&barId%5B%5D=bar_2
   response:
     status: 200
     body:


### PR DESCRIPTION
**Summary:**  
Fix documentation and test correctness to prevent misleading of users.

**Build & Testing:**

- [X] I ran `cargo test` successfully.
- [X] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [X] I have added relevant unit & integration tests.
- [X] I have updated the [documentation] accordingly.
- [X] I have performed a self-review of my code.
- [X] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
