### PR TITLE
fix(scalar): DateTime is not a pre defined scalar of GraphQL

### DIFF
--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -317,6 +317,10 @@
       "title": "Date",
       "description": "Field whose value conforms to the standard date format as specified in RFC 3339 (https://datatracker.ietf.org/doc/html/rfc3339)."
     },
+    "DateTime": {
+      "title": "DateTime",
+      "description": "Field whose value conforms to the standard datetime format as specified in RFC 3339 (https://datatracker.ietf.org/doc/html/rfc3339\")."
+    },
     "Email": {
       "title": "Email",
       "description": "Field whose value conforms to the standard internet email address format as specified in HTML Spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address."

--- a/src/core/scalar.rs
+++ b/src/core/scalar.rs
@@ -31,6 +31,9 @@ pub enum Scalar {
     /// Field whose value conforms to the standard date format as specified in RFC 3339 (https://datatracker.ietf.org/doc/html/rfc3339).
     #[gen_doc(ty = "String")]
     Date,
+    /// Field whose value conforms to the standard datetime format as specified in RFC 3339 (https://datatracker.ietf.org/doc/html/rfc3339").
+    #[gen_doc(ty = "String")]
+    DateTime,
     /// Field whose value conforms to the standard URL format as specified in RFC 3986 (https://datatracker.ietf.org/doc/html/rfc3986).
     #[gen_doc(ty = "String")]
     Url,
@@ -119,7 +122,8 @@ impl Scalar {
                 async_graphql::validators::email(&s.to_string()).is_ok()
             }),
             Scalar::PhoneNumber => eval_str(value, |s| phonenumber::parse(None, s).is_ok()),
-            Scalar::Date => eval_str(value, |s| chrono::DateTime::parse_from_rfc3339(s).is_ok()),
+            Scalar::Date => eval_str(value, |s| chrono::Date::parse_from_rfc3339(s).is_ok()),
+            Scalar::DateTime => eval_str(value, |s| chrono::DateTime::parse_from_rfc3339(s).is_ok()),
             Scalar::Url => eval_str(value, |s| url::Url::parse(s).is_ok()),
             Scalar::Bytes => value.as_str().is_some(),
 

--- a/src/core/scalar.rs
+++ b/src/core/scalar.rs
@@ -122,7 +122,7 @@ impl Scalar {
                 async_graphql::validators::email(&s.to_string()).is_ok()
             }),
             Scalar::PhoneNumber => eval_str(value, |s| phonenumber::parse(None, s).is_ok()),
-            Scalar::Date => eval_str(value, |s| chrono::Date::parse_from_rfc3339(s).is_ok()),
+            Scalar::Date => eval_str(value, |s| chrono::DateTime::parse_from_rfc3339(s).is_ok()),
             Scalar::DateTime => eval_str(value, |s| chrono::DateTime::parse_from_rfc3339(s).is_ok()),
             Scalar::Url => eval_str(value, |s| url::Url::parse(s).is_ok()),
             Scalar::Bytes => value.as_str().is_some(),

--- a/src/core/scalar.rs
+++ b/src/core/scalar.rs
@@ -123,7 +123,9 @@ impl Scalar {
             }),
             Scalar::PhoneNumber => eval_str(value, |s| phonenumber::parse(None, s).is_ok()),
             Scalar::Date => eval_str(value, |s| chrono::DateTime::parse_from_rfc3339(s).is_ok()),
-            Scalar::DateTime => eval_str(value, |s| chrono::DateTime::parse_from_rfc3339(s).is_ok()),
+            Scalar::DateTime => {
+                eval_str(value, |s| chrono::DateTime::parse_from_rfc3339(s).is_ok())
+            }
             Scalar::Url => eval_str(value, |s| url::Url::parse(s).is_ok()),
             Scalar::Bytes => value.as_str().is_some(),
 

--- a/src/core/scalar.rs
+++ b/src/core/scalar.rs
@@ -8,7 +8,7 @@ use tailcall_macros::{gen_doc, Doc};
 
 use crate::core::json::JsonLike;
 
-const PREDEFINED_SCALARS: &[&str] = &["Boolean", "Float", "ID", "Int", "String", "DateTime"];
+const PREDEFINED_SCALARS: &[&str] = &["Boolean", "Float", "ID", "Int", "String"];
 
 lazy_static! {
     static ref CUSTOM_SCALARS: HashMap<String, Scalar> =

--- a/tests/core/snapshots/add-field-index-list.md_client.snap
+++ b/tests/core/snapshots/add-field-index-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/add-field-many-list.md_client.snap
+++ b/tests/core/snapshots/add-field-many-list.md_client.snap
@@ -12,6 +12,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/add-field-many.md_client.snap
+++ b/tests/core/snapshots/add-field-many.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/add-field-modify.md_client.snap
+++ b/tests/core/snapshots/add-field-modify.md_client.snap
@@ -12,6 +12,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/add-field-with-composition.md_client.snap
+++ b/tests/core/snapshots/add-field-with-composition.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/add-field-with-modify.md_client.snap
+++ b/tests/core/snapshots/add-field-with-modify.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/add-field.md_client.snap
+++ b/tests/core/snapshots/add-field.md_client.snap
@@ -10,6 +10,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/apollo-tracing.md_client.snap
+++ b/tests/core/snapshots/apollo-tracing.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/async-cache-disabled.md_client.snap
+++ b/tests/core/snapshots/async-cache-disabled.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/async-cache-enable-multiple-resolvers.md_client.snap
+++ b/tests/core/snapshots/async-cache-enable-multiple-resolvers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/async-cache-enabled.md_client.snap
+++ b/tests/core/snapshots/async-cache-enabled.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/async-cache-global.md_client.snap
+++ b/tests/core/snapshots/async-cache-global.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/async-cache-inflight-request.md_client.snap
+++ b/tests/core/snapshots/async-cache-inflight-request.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/auth-basic.md_client.snap
+++ b/tests/core/snapshots/auth-basic.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/auth-jwt.md_client.snap
+++ b/tests/core/snapshots/auth-jwt.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/auth.md_client.snap
+++ b/tests/core/snapshots/auth.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/batching-default.md_client.snap
+++ b/tests/core/snapshots/batching-default.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/batching-disabled.md_client.snap
+++ b/tests/core/snapshots/batching-disabled.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/batching-group-by-default.md_client.snap
+++ b/tests/core/snapshots/batching-group-by-default.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/batching-group-by-optional-key.md_client.snap
+++ b/tests/core/snapshots/batching-group-by-optional-key.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/batching-group-by.md_client.snap
+++ b/tests/core/snapshots/batching-group-by.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/batching-post.md_client.snap
+++ b/tests/core/snapshots/batching-post.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/batching.md_client.snap
+++ b/tests/core/snapshots/batching.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/cache-control.md_client.snap
+++ b/tests/core/snapshots/cache-control.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/caching-collision.md_client.snap
+++ b/tests/core/snapshots/caching-collision.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/caching.md_client.snap
+++ b/tests/core/snapshots/caching.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/call-graphql-datasource.md_client.snap
+++ b/tests/core/snapshots/call-graphql-datasource.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/call-multiple-steps-piping.md_client.snap
+++ b/tests/core/snapshots/call-multiple-steps-piping.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/call-mutation.md_client.snap
+++ b/tests/core/snapshots/call-mutation.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/call-operator.md_client.snap
+++ b/tests/core/snapshots/call-operator.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/cors-allow-cred-false.md_client.snap
+++ b/tests/core/snapshots/cors-allow-cred-false.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/cors-allow-cred-true.md_client.snap
+++ b/tests/core/snapshots/cors-allow-cred-true.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/cors-allow-cred-vary.md_client.snap
+++ b/tests/core/snapshots/cors-allow-cred-vary.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/custom-headers.md_client.snap
+++ b/tests/core/snapshots/custom-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/dedupe_batch_query_execution.md_client.snap
+++ b/tests/core/snapshots/dedupe_batch_query_execution.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/default-value-arg.md_client.snap
+++ b/tests/core/snapshots/default-value-arg.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/default-value-config.md_client.snap
+++ b/tests/core/snapshots/default-value-config.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/env-value.md_client.snap
+++ b/tests/core/snapshots/env-value.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/experimental-headers.md_client.snap
+++ b/tests/core/snapshots/experimental-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-dataloader-batch-request.md_client.snap
+++ b/tests/core/snapshots/graphql-dataloader-batch-request.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-dataloader-no-batch-request.md_client.snap
+++ b/tests/core/snapshots/graphql-dataloader-no-batch-request.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-datasource-errors.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-errors.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-datasource-mutation.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-mutation.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-datasource-no-args.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-no-args.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-datasource-query-directives.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-query-directives.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-datasource-with-args.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-with-args.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-datasource-with-empty-enum.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-with-empty-enum.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-datasource-with-mandatory-enum.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-with-mandatory-enum.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/graphql-nested-datasource.md_client.snap
+++ b/tests/core/snapshots/graphql-nested-datasource.md_client.snap
@@ -24,6 +24,8 @@ type C {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-batch.md_client.snap
+++ b/tests/core/snapshots/grpc-batch.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-error.md_client.snap
+++ b/tests/core/snapshots/grpc-error.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-json.md_client.snap
+++ b/tests/core/snapshots/grpc-json.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-map.md_client.snap
+++ b/tests/core/snapshots/grpc-map.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-oneof.md_client.snap
+++ b/tests/core/snapshots/grpc-oneof.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-override-url-from-upstream.md_client.snap
+++ b/tests/core/snapshots/grpc-override-url-from-upstream.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-proto-with-same-package.md_client.snap
+++ b/tests/core/snapshots/grpc-proto-with-same-package.md_client.snap
@@ -10,6 +10,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-reflection.md_client.snap
+++ b/tests/core/snapshots/grpc-reflection.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-simple.md_client.snap
+++ b/tests/core/snapshots/grpc-simple.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/grpc-url-from-upstream.md_client.snap
+++ b/tests/core/snapshots/grpc-url-from-upstream.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/https.md_client.snap
+++ b/tests/core/snapshots/https.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/inline-field.md_client.snap
+++ b/tests/core/snapshots/inline-field.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/inline-index-list.md_client.snap
+++ b/tests/core/snapshots/inline-index-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/inline-many-list.md_client.snap
+++ b/tests/core/snapshots/inline-many-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/inline-many.md_client.snap
+++ b/tests/core/snapshots/inline-many.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/io-cache.md_client.snap
+++ b/tests/core/snapshots/io-cache.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/js-directive.md_client.snap
+++ b/tests/core/snapshots/js-directive.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/jsonplaceholder-call-post.md_client.snap
+++ b/tests/core/snapshots/jsonplaceholder-call-post.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/modified-field.md_client.snap
+++ b/tests/core/snapshots/modified-field.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/mutation-put.md_client.snap
+++ b/tests/core/snapshots/mutation-put.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/mutation.md_client.snap
+++ b/tests/core/snapshots/mutation.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/n-plus-one-list.md_client.snap
+++ b/tests/core/snapshots/n-plus-one-list.md_client.snap
@@ -12,6 +12,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/n-plus-one.md_client.snap
+++ b/tests/core/snapshots/n-plus-one.md_client.snap
@@ -12,6 +12,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/nested-objects.md_client.snap
+++ b/tests/core/snapshots/nested-objects.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/nested-recursive-types.md_client.snap
+++ b/tests/core/snapshots/nested-recursive-types.md_client.snap
@@ -16,6 +16,8 @@ input ConnectionInput {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/nesting-level3.md_client.snap
+++ b/tests/core/snapshots/nesting-level3.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/nullable-arg-query.md_client.snap
+++ b/tests/core/snapshots/nullable-arg-query.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/omit-index-list.md_client.snap
+++ b/tests/core/snapshots/omit-index-list.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/omit-many.md_client.snap
+++ b/tests/core/snapshots/omit-many.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/omit-resolved-by-parent.md_client.snap
+++ b/tests/core/snapshots/omit-resolved-by-parent.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/predefined-scalar.md_error.snap
+++ b/tests/core/snapshots/predefined-scalar.md_error.snap
@@ -25,6 +25,13 @@ expression: errors
     "description": null
   },
   {
+    "message": "Scalar type DateTime is predefined",
+    "trace": [
+      "DateTime"
+    ],
+    "description": null
+  },
+  {
     "message": "Scalar type Email is predefined",
     "trace": [
       "Email"

--- a/tests/core/snapshots/predefined-scalar.md_error.snap
+++ b/tests/core/snapshots/predefined-scalar.md_error.snap
@@ -25,13 +25,6 @@ expression: errors
     "description": null
   },
   {
-    "message": "Scalar type DateTime is predefined",
-    "trace": [
-      "DateTime"
-    ],
-    "description": null
-  },
-  {
     "message": "Scalar type Email is predefined",
     "trace": [
       "Email"

--- a/tests/core/snapshots/recursive-types-json.md_client.snap
+++ b/tests/core/snapshots/recursive-types-json.md_client.snap
@@ -16,6 +16,8 @@ input ConnectionInput {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/recursive-types.md_client.snap
+++ b/tests/core/snapshots/recursive-types.md_client.snap
@@ -16,6 +16,8 @@ input ConnectionInput {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/ref-other-nested.md_client.snap
+++ b/tests/core/snapshots/ref-other-nested.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/ref-other.md_client.snap
+++ b/tests/core/snapshots/ref-other.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/related-fields-recursive.md_client.snap
+++ b/tests/core/snapshots/related-fields-recursive.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/rename-field.md_client.snap
+++ b/tests/core/snapshots/rename-field.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/request-to-upstream-batching.md_client.snap
+++ b/tests/core/snapshots/request-to-upstream-batching.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/resolve-with-headers.md_client.snap
+++ b/tests/core/snapshots/resolve-with-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/resolve-with-vars.md_client.snap
+++ b/tests/core/snapshots/resolve-with-vars.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/resolved-by-parent.md_client.snap
+++ b/tests/core/snapshots/resolved-by-parent.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/rest-api-error.md_client.snap
+++ b/tests/core/snapshots/rest-api-error.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/rest-api-post.md_client.snap
+++ b/tests/core/snapshots/rest-api-post.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/rest-api.md_client.snap
+++ b/tests/core/snapshots/rest-api.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/showcase.md_client.snap
+++ b/tests/core/snapshots/showcase.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/simple-graphql.md_client.snap
+++ b/tests/core/snapshots/simple-graphql.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/simple-query.md_client.snap
+++ b/tests/core/snapshots/simple-query.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-add-field-list.md_client.snap
+++ b/tests/core/snapshots/test-add-field-list.md_client.snap
@@ -14,6 +14,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-add-field.md_client.snap
+++ b/tests/core/snapshots/test-add-field.md_client.snap
@@ -14,6 +14,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-add-link-to-empty-config.md_client.snap
+++ b/tests/core/snapshots/test-add-link-to-empty-config.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-batching-group-by.md_client.snap
+++ b/tests/core/snapshots/test-batching-group-by.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-cache.md_client.snap
+++ b/tests/core/snapshots/test-cache.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-custom-scalar.md_client.snap
+++ b/tests/core/snapshots/test-custom-scalar.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-custom-types.md_client.snap
+++ b/tests/core/snapshots/test-custom-types.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-dbl-usage-many.md_client.snap
+++ b/tests/core/snapshots/test-dbl-usage-many.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-description-many.md_client.snap
+++ b/tests/core/snapshots/test-description-many.md_client.snap
@@ -13,6 +13,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-enable-jit.md_client.snap
+++ b/tests/core/snapshots/test-enable-jit.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-enum-aliases.md_client.snap
+++ b/tests/core/snapshots/test-enum-aliases.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-enum-default.md_client.snap
+++ b/tests/core/snapshots/test-enum-default.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-enum-description.md_client.snap
+++ b/tests/core/snapshots/test-enum-description.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-enum.md_client.snap
+++ b/tests/core/snapshots/test-enum.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-expr-scalar-as-string.md_client.snap
+++ b/tests/core/snapshots/test-expr-scalar-as-string.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-expr-with-mustache.md_client.snap
+++ b/tests/core/snapshots/test-expr-with-mustache.md_client.snap
@@ -23,6 +23,8 @@ type D {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-expr.md_client.snap
+++ b/tests/core/snapshots/test-expr.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-graphqlsource.md_client.snap
+++ b/tests/core/snapshots/test-graphqlsource.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-grpc.md_client.snap
+++ b/tests/core/snapshots/test-grpc.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-http-baseurl.md_client.snap
+++ b/tests/core/snapshots/test-http-baseurl.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-http-batchKey.md_client.snap
+++ b/tests/core/snapshots/test-http-batchKey.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-http-headers.md_client.snap
+++ b/tests/core/snapshots/test-http-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-http-tmpl.md_client.snap
+++ b/tests/core/snapshots/test-http-tmpl.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-http-with-mustache-expr.md_client.snap
+++ b/tests/core/snapshots/test-http-with-mustache-expr.md_client.snap
@@ -20,6 +20,8 @@ type D {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-http.md_client.snap
+++ b/tests/core/snapshots/test-http.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-inline-list.md_client.snap
+++ b/tests/core/snapshots/test-inline-list.md_client.snap
@@ -10,6 +10,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-inline.md_client.snap
+++ b/tests/core/snapshots/test-inline.md_client.snap
@@ -10,6 +10,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-input-documentation.md_client.snap
+++ b/tests/core/snapshots/test-input-documentation.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-input-out.md_client.snap
+++ b/tests/core/snapshots/test-input-out.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-input-with-arg-out.md_client.snap
+++ b/tests/core/snapshots/test-input-with-arg-out.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-interface-from-json.md_client.snap
+++ b/tests/core/snapshots/test-interface-from-json.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-interface-result.md_client.snap
+++ b/tests/core/snapshots/test-interface-result.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-interface.md_client.snap
+++ b/tests/core/snapshots/test-interface.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-js-multi-onRequest-handlers.md_client.snap
+++ b/tests/core/snapshots/test-js-multi-onRequest-handlers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-js-request-response-2.md_client.snap
+++ b/tests/core/snapshots/test-js-request-response-2.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-js-request-response.md_client.snap
+++ b/tests/core/snapshots/test-js-request-response.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-list-args.md_client.snap
+++ b/tests/core/snapshots/test-list-args.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-merge-right-with-link-config.md_client.snap
+++ b/tests/core/snapshots/test-merge-right-with-link-config.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-merge-server-sdl.md_client.snap
+++ b/tests/core/snapshots/test-merge-server-sdl.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-modify.md_client.snap
+++ b/tests/core/snapshots/test-modify.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-multi-interface.md_client.snap
+++ b/tests/core/snapshots/test-multi-interface.md_client.snap
@@ -11,6 +11,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-multiple-config-types.md_client.snap
+++ b/tests/core/snapshots/test-multiple-config-types.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-nested-input.md_client.snap
+++ b/tests/core/snapshots/test-nested-input.md_client.snap
@@ -22,6 +22,8 @@ input D {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-nested-link.md_client.snap
+++ b/tests/core/snapshots/test-nested-link.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-nested-value.md_client.snap
+++ b/tests/core/snapshots/test-nested-value.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-null-in-array.md_client.snap
+++ b/tests/core/snapshots/test-null-in-array.md_client.snap
@@ -11,6 +11,8 @@ type Company {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-null-in-object.md_client.snap
+++ b/tests/core/snapshots/test-null-in-object.md_client.snap
@@ -11,6 +11,8 @@ type Company {
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-omit-list.md_client.snap
+++ b/tests/core/snapshots/test-omit-list.md_client.snap
@@ -10,6 +10,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-omit.md_client.snap
+++ b/tests/core/snapshots/test-omit.md_client.snap
@@ -10,6 +10,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-params-as-body.md_client.snap
+++ b/tests/core/snapshots/test-params-as-body.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-query-documentation.md_client.snap
+++ b/tests/core/snapshots/test-query-documentation.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-query.md_client.snap
+++ b/tests/core/snapshots/test-query.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-ref-other.md_client.snap
+++ b/tests/core/snapshots/test-ref-other.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-scalars-builtin.md_client.snap
+++ b/tests/core/snapshots/test-scalars-builtin.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-scalars-integers.md_client.snap
+++ b/tests/core/snapshots/test-scalars-integers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-scalars-validation.md_client.snap
+++ b/tests/core/snapshots/test-scalars-validation.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-scalars.md_client.snap
+++ b/tests/core/snapshots/test-scalars.md_client.snap
@@ -8,6 +8,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-server-vars.md_client.snap
+++ b/tests/core/snapshots/test-server-vars.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-set-cookie-headers.md_client.snap
+++ b/tests/core/snapshots/test-set-cookie-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-static-value.md_client.snap
+++ b/tests/core/snapshots/test-static-value.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-tag.md_client.snap
+++ b/tests/core/snapshots/test-tag.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-union-ambiguous.md_client.snap
+++ b/tests/core/snapshots/test-union-ambiguous.md_client.snap
@@ -15,6 +15,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-union.md_client.snap
+++ b/tests/core/snapshots/test-union.md_client.snap
@@ -10,6 +10,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-upstream-headers.md_client.snap
+++ b/tests/core/snapshots/test-upstream-headers.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/test-upstream.md_client.snap
+++ b/tests/core/snapshots/test-upstream.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/upstream-batching.md_client.snap
+++ b/tests/core/snapshots/upstream-batching.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/upstream-fail-request.md_client.snap
+++ b/tests/core/snapshots/upstream-fail-request.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/with-args-url.md_client.snap
+++ b/tests/core/snapshots/with-args-url.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/with-args.md_client.snap
+++ b/tests/core/snapshots/with-args.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/with-nesting.md_client.snap
+++ b/tests/core/snapshots/with-nesting.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/yaml-nested-unions.md_client.snap
+++ b/tests/core/snapshots/yaml-nested-unions.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/yaml-union-in-type.md_client.snap
+++ b/tests/core/snapshots/yaml-union-in-type.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty

--- a/tests/core/snapshots/yaml-union.md_client.snap
+++ b/tests/core/snapshots/yaml-union.md_client.snap
@@ -6,6 +6,8 @@ scalar Bytes
 
 scalar Date
 
+scalar DateTime
+
 scalar Email
 
 scalar Empty


### PR DESCRIPTION
**Summary:**  
`DateTime` is not a pre-defined scalar of GraphQL

For more information, look [here](https://spec.graphql.org/October2021/#sec-Scalars) and [here](https://graphql.org/learn/schema/).

> GraphQL comes with a set of default scalar types out of the box:
> 
>     Int: A signed 32‐bit integer.
>     Float: A signed double-precision floating-point value.
>     String: A UTF‐8 character sequence.
>     Boolean: true or false.
>     ID: The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a String; however, defining it as an ID signifies that it is not intended to be human‐readable.
> https://graphql.org/learn/schema/

**Issue Reference(s):**  
Fixes #2580 

**Build & Testing:**

- [X] I ran `cargo test` successfully.
- [X] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [X] I have added relevant unit & integration tests.
- [X] I have updated the [documentation] accordingly.
- [X] I have performed a self-review of my code.
- [X] PR follows the naming convention of `<type>(<optional scope>): <title>`

**Extra Sources:**
- https://github.com/async-graphql/async-graphql/blob/880dac90f1516bbb590be63965dfcfa4973b4edd/src/types/external/datetime.rs
- https://github.com/async-graphql/async-graphql/tree/880dac90f1516bbb590be63965dfcfa4973b4edd/src/types


[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
