### PR TITLE
fix(graphql): When query data from remote server tailcall should pass the selection set correctly

### DIFF
--- a/src/core/ir/eval_context.rs
+++ b/src/core/ir/eval_context.rs
@@ -171,9 +171,21 @@ fn format_selection_field(field: &SelectionField, related_fields: &RelatedFields
         }
     }
 
-    if let Some(selection_set) = selection_set {
-        output.push(' ');
-        output.push_str(&selection_set);
+    match selection_set {
+        Some(selection_set) => {
+            output.push(' ');
+            output.push_str(&selection_set);
+        }
+        None => {
+            let selections = field
+                .selection_set()
+                .map(|select| select.name())
+                .collect::<Vec<_>>();
+            if !selections.is_empty() {
+                output.push(' ');
+                output.push_str(&format!("{{ {} }}", selections.join(" ")));
+            }
+        }
     }
 
     output

--- a/tests/core/snapshots/graphql-basic-query.md_0.snap
+++ b/tests/core/snapshots/graphql-basic-query.md_0.snap
@@ -1,0 +1,26 @@
+---
+source: tests/core/spec.rs
+expression: response
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "posts": {
+        "posts": [
+          {
+            "id": "post_1",
+            "title": "title_1"
+          },
+          {
+            "id": "post_2",
+            "title": "title_2"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/core/snapshots/graphql-basic-query.md_client.snap
+++ b/tests/core/snapshots/graphql-basic-query.md_client.snap
@@ -1,0 +1,62 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+---
+scalar Bytes
+
+scalar Date
+
+scalar DateTime
+
+scalar Email
+
+scalar Empty
+
+scalar Int128
+
+scalar Int16
+
+scalar Int32
+
+scalar Int64
+
+scalar Int8
+
+scalar JSON
+
+interface Node {
+  id: ID!
+}
+
+scalar PhoneNumber
+
+type Post implements Node {
+  body: String!
+  id: ID!
+  title: String!
+}
+
+type PostsConnection {
+  posts: [Post]
+  totalCount: Int
+}
+
+type Query {
+  posts: PostsConnection
+}
+
+scalar UInt128
+
+scalar UInt16
+
+scalar UInt32
+
+scalar UInt64
+
+scalar UInt8
+
+scalar Url
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/graphql-basic-query.md_merged.snap
+++ b/tests/core/snapshots/graphql-basic-query.md_merged.snap
@@ -1,0 +1,26 @@
+---
+source: tests/core/spec.rs
+expression: formatter
+---
+schema @server(port: 8000) @upstream(baseURL: "http://upstream/graphql") {
+  query: Query
+}
+
+interface Node {
+  id: ID!
+}
+
+type Post implements Node {
+  body: String!
+  id: ID!
+  title: String!
+}
+
+type PostsConnection {
+  posts: [Post]
+  totalCount: Int
+}
+
+type Query {
+  posts: PostsConnection @graphQL(name: "allPosts")
+}

--- a/tests/execution/graphql-basic-query.md
+++ b/tests/execution/graphql-basic-query.md
@@ -1,0 +1,51 @@
+```graphql @config
+schema @server(port: 8000) @upstream(baseURL: "http://upstream/graphql") {
+  query: Query
+}
+
+type Query {
+  posts: PostsConnection @graphQL(name: "allPosts")
+}
+
+type Post implements Node {
+  id: ID!
+  title: String!
+  body: String!
+}
+
+type PostsConnection {
+  posts: [Post]
+  totalCount: Int
+}
+
+interface Node {
+  id: ID!
+}
+```
+
+```yml @mock
+- request:
+    method: POST
+    url: http://upstream/graphql
+    textBody: '{ "query": "query { allPosts { posts { id title } } }" }'
+  response:
+    status: 200
+    body:
+      data:
+        allPosts:
+          totalCount: 2
+          posts:
+            - id: post_1
+              title: title_1
+              body: body_1
+            - id: post_2
+              title: title_2
+              body: body_2
+```
+
+```yml @test
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: query { posts { posts { id title } } }
+```


### PR DESCRIPTION
**Summary:**  
When querying a remote server, Tailcall should pass the selection set correctly to the remote server.

**Issue Reference(s):**  
Fixes #2579 

**Build & Testing:**

- [X] I ran `cargo test` successfully.
- [X] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [X] I have added relevant unit & integration tests.
- [X] I have updated the [documentation] accordingly.
- [X] I have performed a self-review of my code.
- [X] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
