### PR TITLE
fix: add deny_unknown_fields to nested structs

### DIFF
--- a/src/cli/generator/config.rs
+++ b/src/cli/generator/config.rs
@@ -28,6 +28,7 @@ pub struct Config<Status = UnResolved> {
 
 #[derive(Clone, Deserialize, Serialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PresetConfig {
     pub merge_type: Option<f32>,
     #[serde(rename = "consolidateURL")]
@@ -60,6 +61,7 @@ pub struct Input<Status = UnResolved> {
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub enum Source<Status = UnResolved> {
     #[serde(rename_all = "camelCase")]
     Curl {
@@ -77,6 +79,7 @@ pub enum Source<Status = UnResolved> {
 
 #[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct Output<Status = UnResolved> {
     #[serde(skip_serializing_if = "Location::is_empty")]
     pub path: Location<Status>,
@@ -92,6 +95,7 @@ pub enum Resolved {}
 pub struct UnResolved {}
 
 #[derive(Deserialize, Serialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
 pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,

--- a/src/cli/generator/config.rs
+++ b/src/cli/generator/config.rs
@@ -421,8 +421,21 @@ mod tests {
         let expected_error =
             "unknown field `headerss`, expected one of `src`, `headers`, `fieldName` at line 9 column 13";
         assert_deserialization_error(json, expected_error);
+    
+        let json = r#"
+            {"inputs": [{
+                "curls": {
+                    "src": "https://tailcall.run/graphql",
+                    "headerss": {
+                        "content-type": "application/json"
+                    }
+                }
+            }]}
+        "#;
+        let expected_error = "no variant of enum Source found in flattened data at line 9 column 9";
+        assert_deserialization_error(json, expected_error);
     }
-
+    
     #[test]
     fn test_raise_error_unknown_field_in_preset() {
         let json = r#"

--- a/src/cli/generator/config.rs
+++ b/src/cli/generator/config.rs
@@ -432,7 +432,8 @@ mod tests {
                 }
             }]}
         "#;
-        let expected_error = "no variant of enum Source found in flattened data at line 9 column 13";
+        let expected_error =
+            "no variant of enum Source found in flattened data at line 9 column 13";
         assert_deserialization_error(json, expected_error);
     }
 

--- a/src/cli/generator/config.rs
+++ b/src/cli/generator/config.rs
@@ -432,7 +432,7 @@ mod tests {
                 }
             }]}
         "#;
-        let expected_error = "no variant of enum Source found in flattened data at line 9 column 9";
+        let expected_error = "no variant of enum Source found in flattened data at line 9 column 13";
         assert_deserialization_error(json, expected_error);
     }
 

--- a/src/cli/generator/config.rs
+++ b/src/cli/generator/config.rs
@@ -421,7 +421,7 @@ mod tests {
         let expected_error =
             "unknown field `headerss`, expected one of `src`, `headers`, `fieldName` at line 9 column 13";
         assert_deserialization_error(json, expected_error);
-    
+
         let json = r#"
             {"inputs": [{
                 "curls": {
@@ -435,7 +435,7 @@ mod tests {
         let expected_error = "no variant of enum Source found in flattened data at line 9 column 9";
         assert_deserialization_error(json, expected_error);
     }
-    
+
     #[test]
     fn test_raise_error_unknown_field_in_preset() {
         let json = r#"


### PR DESCRIPTION
**Summary:**  
_Briefly describe the changes made in this PR._

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
