### PR TITLE
fix: add CLI layer to telemetry tracing

### DIFF
--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -28,7 +28,7 @@ use crate::cli::CLIError;
 use crate::core::blueprint::telemetry::{OtlpExporter, Telemetry, TelemetryExporter};
 use crate::core::runtime::TargetRuntime;
 use crate::core::tracing::{
-    default_tracing, default_tracing_tailcall, filter_target, get_log_level, tailcall_filter_target,
+    default_tracing, default_tracing_tailcall, get_log_level, tailcall_filter_target,
 };
 
 static RESOURCE: Lazy<Resource> = Lazy::new(|| {
@@ -222,7 +222,7 @@ pub fn init_opentelemetry(config: Telemetry, runtime: &TargetRuntime) -> anyhow:
 
         let subscriber = tracing_subscriber::registry()
             .with(trace_layer)
-            .with(default_tracing().with_filter(filter_target("tailcall")))
+            .with(default_tracing())
             .with(
                 log_layer.with_filter(dynamic_filter_fn(|_metatada, context| {
                     // ignore logs that are generated inside tracing::Span since they will be logged

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -27,7 +27,9 @@ use super::metrics::init_metrics;
 use crate::cli::CLIError;
 use crate::core::blueprint::telemetry::{OtlpExporter, Telemetry, TelemetryExporter};
 use crate::core::runtime::TargetRuntime;
-use crate::core::tracing::{default_tracing, default_tracing_tailcall, filter_target, get_log_level, tailcall_filter_target};
+use crate::core::tracing::{
+    default_tracing, default_tracing_tailcall, filter_target, get_log_level, tailcall_filter_target,
+};
 
 static RESOURCE: Lazy<Resource> = Lazy::new(|| {
     Resource::default().merge(&Resource::new(vec![

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -27,7 +27,7 @@ use super::metrics::init_metrics;
 use crate::cli::CLIError;
 use crate::core::blueprint::telemetry::{OtlpExporter, Telemetry, TelemetryExporter};
 use crate::core::runtime::TargetRuntime;
-use crate::core::tracing::{default_tracing_tailcall, get_log_level, tailcall_filter_target};
+use crate::core::tracing::{default_tracing, default_tracing_tailcall, filter_target, get_log_level, tailcall_filter_target};
 
 static RESOURCE: Lazy<Resource> = Lazy::new(|| {
     Resource::default().merge(&Resource::new(vec![
@@ -220,6 +220,7 @@ pub fn init_opentelemetry(config: Telemetry, runtime: &TargetRuntime) -> anyhow:
 
         let subscriber = tracing_subscriber::registry()
             .with(trace_layer)
+            .with(default_tracing().with_filter(filter_target("tailcall")))
             .with(
                 log_layer.with_filter(dynamic_filter_fn(|_metatada, context| {
                     // ignore logs that are generated inside tracing::Span since they will be logged


### PR DESCRIPTION
**Summary:**  
- When telemetry is enabled, we configure tracing to send all tracing events to the tracing service. This pull request introduces an additional layer to the tracing setup, allowing us to both log events to the CLI and send them to the tracing service simultaneously.

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
