### PR TITLE
fix(2777): use option_env for trackers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,8 @@ jobs:
       pull-requests: write
     env:
       GITHUB_TOKEN: ${{secrets.GITHUBTOKEN}}
+      GA_API_SECRET: ${{secrets.GA_API_SECRET}}
+      GA_MEASUREMENT_ID: ${{secrets.GA_MEASUREMENT_ID}}
       APP_VERSION: ${{ needs.draft_release.outputs.create_release_name }}
 
     steps:

--- a/tailcall-tracker/src/tracker.rs
+++ b/tailcall-tracker/src/tracker.rs
@@ -4,8 +4,16 @@ use super::Result;
 use crate::check_tracking::check_tracking;
 use crate::event::Event;
 
-const API_SECRET: &str = "GVaEzXFeRkCI9YBIylbEjQ";
-const MEASUREMENT_ID: &str = "G-JEP3QDWT0G";
+const API_SECRET: &str = match option_env!("API_SECRET") {
+    Some(val) => val,
+    None => "dev",
+};
+
+const MEASUREMENT_ID: &str = match option_env!("MEASUREMENT_ID") {
+    Some(val) => val,
+    None => "dev",
+};
+
 const BASE_URL: &str = "https://www.google-analytics.com";
 
 ///

--- a/tailcall-tracker/src/tracker.rs
+++ b/tailcall-tracker/src/tracker.rs
@@ -4,12 +4,12 @@ use super::Result;
 use crate::check_tracking::check_tracking;
 use crate::event::Event;
 
-const API_SECRET: &str = match option_env!("API_SECRET") {
+const API_SECRET: &str = match option_env!("GA_API_SECRET") {
     Some(val) => val,
     None => "dev",
 };
 
-const MEASUREMENT_ID: &str = match option_env!("MEASUREMENT_ID") {
+const MEASUREMENT_ID: &str = match option_env!("GA_MEASUREMENT_ID") {
     Some(val) => val,
     None => "dev",
 };


### PR DESCRIPTION

**Issue Reference(s):**  
Fixes #2777

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.


/claim #2777