### PR TITLE
refactor: simplify json_like trait

### DIFF
--- a/src/core/ir/discriminator.rs
+++ b/src/core/ir/discriminator.rs
@@ -23,7 +23,6 @@ const TYPENAME_FIELD: &str = "__typename";
 impl<'json, T> TypedValue<'json> for T
 where
     T: JsonLike<'json>,
-    T::JsonObject<'json>: JsonObjectLike<'json, Value = T>,
 {
     type Error = anyhow::Error;
 

--- a/src/core/jit/common/jp.rs
+++ b/src/core/jit/common/jp.rs
@@ -83,14 +83,7 @@ impl<'a, Value: JsonLike<'a> + Deserialize<'a> + Clone + 'a> TestData<Value> {
     }
 }
 
-impl<
-        'a,
-        Value: Deserialize<'a>
-            + Clone
-            + 'a
-            + JsonLike<'a, JsonObject<'a>: JsonObjectLike<'a, Value = Value>>,
-    > JP<Value>
-{
+impl<'a, Value: Deserialize<'a> + Clone + 'a + JsonLike<'a>> JP<Value> {
     const CONFIG: &'static str = include_str!("../fixtures/jsonplaceholder-mutation.graphql");
 
     fn plan(query: &str, variables: &Variables<async_graphql::Value>) -> OperationPlan<Value> {

--- a/src/core/jit/exec.rs
+++ b/src/core/jit/exec.rs
@@ -25,8 +25,7 @@ pub struct Executor<IRExec, Input> {
 
 impl<Input, Output, Exec> Executor<Exec, Input>
 where
-    Output:
-        for<'b> JsonLike<'b, JsonObject<'b>: JsonObjectLike<'b, Value = Output>> + Debug + Clone,
+    Output: for<'b> JsonLike<'b> + Debug + Clone,
     Input: Clone + Debug,
     Exec: IRExecutor<Input = Input, Output = Output, Error = jit::Error>,
 {

--- a/src/core/jit/synth/synth.rs
+++ b/src/core/jit/synth/synth.rs
@@ -26,7 +26,6 @@ impl<Value> Synth<Value> {
 impl<'a, Value> Synth<Value>
 where
     Value: JsonLike<'a> + Clone + std::fmt::Debug,
-    Value::JsonObject<'a>: JsonObjectLike<'a, Value = Value>,
 {
     #[inline(always)]
     fn include<T>(&self, field: &Field<T, Value>) -> bool {

--- a/src/core/json/borrow.rs
+++ b/src/core/json/borrow.rs
@@ -12,7 +12,7 @@ impl<'ctx> JsonObjectLike<'ctx> for ObjectAsVec<'ctx> {
         ObjectAsVec::default()
     }
 
-    fn get_key(&'ctx self, key: &str) -> Option<&Value> {
+    fn get_key(&self, key: &str) -> Option<&Self::Value> {
         self.get(key)
     }
 
@@ -22,13 +22,13 @@ impl<'ctx> JsonObjectLike<'ctx> for ObjectAsVec<'ctx> {
 }
 
 impl<'ctx> JsonLike<'ctx> for Value<'ctx> {
-    type JsonObject<'obj> = ObjectAsVec<'obj>;
+    type JsonObject = ObjectAsVec<'ctx>;
 
     fn null() -> Self {
         Value::Null
     }
 
-    fn object(obj: Self::JsonObject<'ctx>) -> Self {
+    fn object(obj: Self::JsonObject) -> Self {
         Value::Object(obj)
     }
 
@@ -54,18 +54,18 @@ impl<'ctx> JsonLike<'ctx> for Value<'ctx> {
         }
     }
 
-    fn as_object(&self) -> Option<&Self::JsonObject<'_>> {
+    fn as_object(&self) -> Option<&Self::JsonObject> {
         self.as_object()
     }
 
-    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject<'ctx>> {
+    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject> {
         match self {
             Value::Object(obj) => Some(obj),
             _ => None,
         }
     }
 
-    fn into_object(self) -> Option<Self::JsonObject<'ctx>> {
+    fn into_object(self) -> Option<Self::JsonObject> {
         match self {
             Value::Object(obj) => Some(obj),
             _ => None,

--- a/src/core/json/graphql.rs
+++ b/src/core/json/graphql.rs
@@ -14,7 +14,7 @@ impl<'obj, Value: JsonLike<'obj> + Clone> JsonObjectLike<'obj> for IndexMap<Name
         IndexMap::new()
     }
 
-    fn get_key(&'obj self, key: &str) -> Option<&Self::Value> {
+    fn get_key(&self, key: &str) -> Option<&Self::Value> {
         self.get(key)
     }
 
@@ -24,7 +24,7 @@ impl<'obj, Value: JsonLike<'obj> + Clone> JsonObjectLike<'obj> for IndexMap<Name
 }
 
 impl<'json> JsonLike<'json> for ConstValue {
-    type JsonObject<'obj> = IndexMap<Name, ConstValue>;
+    type JsonObject = IndexMap<Name, ConstValue>;
 
     fn as_array(&self) -> Option<&Vec<Self>> {
         match self {
@@ -110,28 +110,28 @@ impl<'json> JsonLike<'json> for ConstValue {
         Default::default()
     }
 
-    fn as_object(&self) -> Option<&Self::JsonObject<'_>> {
+    fn as_object(&self) -> Option<&Self::JsonObject> {
         match self {
             ConstValue::Object(map) => Some(map),
             _ => None,
         }
     }
 
-    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject<'_>> {
+    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject> {
         match self {
             ConstValue::Object(map) => Some(map),
             _ => None,
         }
     }
 
-    fn into_object(self) -> Option<Self::JsonObject<'json>> {
+    fn into_object(self) -> Option<Self::JsonObject> {
         match self {
             ConstValue::Object(map) => Some(map),
             _ => None,
         }
     }
 
-    fn object(obj: Self::JsonObject<'json>) -> Self {
+    fn object(obj: Self::JsonObject) -> Self {
         ConstValue::Object(obj)
     }
 

--- a/src/core/json/json_like.rs
+++ b/src/core/json/json_like.rs
@@ -6,35 +6,20 @@ impl<T> JsonLikeOwned for T where T: for<'json> JsonLike<'json> {}
 
 /// A trait for objects that can be used as JSON values
 pub trait JsonLike<'json>: Sized {
-    type JsonObject<'obj>: JsonObjectLike<
-        'obj,
-        // generally we want to specify `Self` instead of generic here
-        // and `Self` is used anyway through JsonObjectLike for
-        // current implementations.
-        // But `Self` means the very specific type with some specific lifetime
-        // which doesn't work in case we want to return self type but with different
-        // lifetime. Currently, it affects only `as_object` fn because `serde_json_borrow`
-        // returns smaller lifetime for Value in its `as_object` fn that either forces to
-        // use `&'json self` in the fn (that leads to error "variable does not live long enough")
-        // or generic like this.
-        // TODO: perhaps it could be fixed on `serde_json_borrow` side if we return `Value<'ctx>`
-        // instead of `Value<'_>` in its functions like `as_object`. In that case we can specify
-        // `Self` here and simplify usages of this trait
-        Value: JsonLike<'obj>,
-    >;
+    type JsonObject: JsonObjectLike<'json, Value = Self>;
 
     // Constructors
     fn null() -> Self;
-    fn object(obj: Self::JsonObject<'json>) -> Self;
+    fn object(obj: Self::JsonObject) -> Self;
     fn array(arr: Vec<Self>) -> Self;
     fn string(s: Cow<'json, str>) -> Self;
 
     // Operators
     fn as_array(&self) -> Option<&Vec<Self>>;
     fn into_array(self) -> Option<Vec<Self>>;
-    fn as_object(&self) -> Option<&Self::JsonObject<'_>>;
-    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject<'json>>;
-    fn into_object(self) -> Option<Self::JsonObject<'json>>;
+    fn as_object(&self) -> Option<&Self::JsonObject>;
+    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject>;
+    fn into_object(self) -> Option<Self::JsonObject>;
     fn as_str(&self) -> Option<&str>;
     fn as_i64(&self) -> Option<i64>;
     fn as_u64(&self) -> Option<u64>;
@@ -50,7 +35,7 @@ pub trait JsonLike<'json>: Sized {
 pub trait JsonObjectLike<'obj>: Sized {
     type Value;
     fn new() -> Self;
-    fn get_key(&'obj self, key: &str) -> Option<&Self::Value>;
+    fn get_key(&self, key: &str) -> Option<&Self::Value>;
     fn insert_key(&mut self, key: &'obj str, value: Self::Value);
 }
 

--- a/src/core/json/serde.rs
+++ b/src/core/json/serde.rs
@@ -10,7 +10,7 @@ impl<'obj> JsonObjectLike<'obj> for serde_json::Map<String, serde_json::Value> {
         serde_json::Map::new()
     }
 
-    fn get_key(&'obj self, key: &str) -> Option<&serde_json::Value> {
+    fn get_key(&self, key: &str) -> Option<&serde_json::Value> {
         self.get(key)
     }
 
@@ -20,7 +20,7 @@ impl<'obj> JsonObjectLike<'obj> for serde_json::Map<String, serde_json::Value> {
 }
 
 impl<'json> JsonLike<'json> for serde_json::Value {
-    type JsonObject<'obj> = serde_json::Map<String, serde_json::Value>;
+    type JsonObject = serde_json::Map<String, serde_json::Value>;
 
     fn as_array(&self) -> Option<&Vec<Self>> {
         self.as_array()
@@ -89,15 +89,15 @@ impl<'json> JsonLike<'json> for serde_json::Value {
         Self::Null
     }
 
-    fn as_object(&self) -> Option<&Self::JsonObject<'_>> {
+    fn as_object(&self) -> Option<&Self::JsonObject> {
         self.as_object()
     }
 
-    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject<'_>> {
+    fn as_object_mut(&mut self) -> Option<&mut Self::JsonObject> {
         self.as_object_mut()
     }
 
-    fn into_object(self) -> Option<Self::JsonObject<'json>> {
+    fn into_object(self) -> Option<Self::JsonObject> {
         if let Self::Object(obj) = self {
             Some(obj)
         } else {
@@ -105,7 +105,7 @@ impl<'json> JsonLike<'json> for serde_json::Value {
         }
     }
 
-    fn object(obj: Self::JsonObject<'json>) -> Self {
+    fn object(obj: Self::JsonObject) -> Self {
         serde_json::Value::Object(obj)
     }
 

--- a/src/core/scalar.rs
+++ b/src/core/scalar.rs
@@ -75,14 +75,14 @@ pub enum Scalar {
     Bytes,
 }
 
-fn eval_str<'a, Value: JsonLike<'a> + 'a, F: Fn(&str) -> bool>(val: &'a Value, fxn: F) -> bool {
+fn eval_str<'a, Value: JsonLike<'a>, F: Fn(&str) -> bool>(val: &'a Value, fxn: F) -> bool {
     val.as_str().map_or(false, fxn)
 }
 
 fn eval_signed<
     'a,
     Num,
-    Value: JsonLike<'a> + 'a,
+    Value: JsonLike<'a>,
     F: Fn(i64) -> Result<Num, std::num::TryFromIntError>,
 >(
     val: &'a Value,
@@ -94,7 +94,7 @@ fn eval_signed<
 fn eval_unsigned<
     'a,
     Num,
-    Value: JsonLike<'a> + 'a,
+    Value: JsonLike<'a>,
     F: Fn(u64) -> Result<Num, std::num::TryFromIntError>,
 >(
     val: &'a Value,
@@ -114,7 +114,7 @@ impl Scalar {
         }
     }
 
-    pub fn validate<'a, Value: JsonLike<'a> + 'a>(&self, value: &'a Value) -> bool {
+    pub fn validate<'a, Value: JsonLike<'a>>(&self, value: &'a Value) -> bool {
         match self {
             Scalar::JSON => true,
             Scalar::Empty => true,


### PR DESCRIPTION
**Summary:**  
Simplify JsonLike associated type constraints according to `TODO` in the code. This is doable after serde_json_borrow update https://github.com/PSeitz/serde_json_borrow/pull/19

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
