### PR TITLE
fix(gen): read from parent_dir, then try cwd

### DIFF
--- a/tailcall-fixtures/fixtures/protobuf/news_root.proto
+++ b/tailcall-fixtures/fixtures/protobuf/news_root.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package news;
+
+import "tailcall-fixtures/fixtures/protobuf/news_dto.proto";
+import "google/protobuf/empty.proto";
+
+service NewsService {
+  rpc GetAllNews(google.protobuf.Empty) returns (NewsList) {}
+  rpc GetNews(NewsId) returns (News) {}
+  rpc GetMultipleNews(MultipleNewsId) returns (NewsList) {}
+  rpc DeleteNews(NewsId) returns (google.protobuf.Empty) {}
+  rpc EditNews(News) returns (News) {}
+  rpc AddNews(News) returns (News) {}
+}

--- a/tests/cli/fixtures/generator/gen_json_proto_root_paths.md
+++ b/tests/cli/fixtures/generator/gen_json_proto_root_paths.md
@@ -1,0 +1,21 @@
+```json @config
+{
+  "inputs": [
+    {
+      "proto": {
+        "src": "tailcall-fixtures/fixtures/protobuf/news_root.proto"
+      }
+    }
+  ],
+  "preset": {
+    "mergeType": 1.0
+  },
+  "output": {
+    "path": "./output.graphql",
+    "format": "graphQL"
+  },
+  "schema": {
+    "query": "Query"
+  }
+}
+```

--- a/tests/cli/snapshots/cli_spec__test__generator_spec__tests__cli__fixtures__generator__gen_json_proto_root_paths.md.snap
+++ b/tests/cli/snapshots/cli_spec__test__generator_spec__tests__cli__fixtures__generator__gen_json_proto_root_paths.md.snap
@@ -1,0 +1,50 @@
+---
+source: tests/cli/gen.rs
+expression: config.to_sdl()
+---
+schema @server @upstream {
+  query: Query
+}
+
+input news__MultipleNewsId @addField(name: "ids", path: ["ids", "id"]) {
+  ids: [news__NewsId]@omit 
+}
+
+input news__NewsId {
+  id: Int
+}
+
+input news__NewsInput {
+  body: String
+  id: Int
+  postImage: String
+  status: news__Status
+  title: String
+}
+
+enum news__Status {
+  DELETED
+  DRAFT
+  PUBLISHED
+}
+
+type Query {
+  news__NewsService__AddNews(news: news__NewsInput!): news__News @grpc(body: "{{.args.news}}", method: "news.NewsService.AddNews")
+  news__NewsService__DeleteNews(newsId: news__NewsId!): Empty @grpc(body: "{{.args.newsId}}", method: "news.NewsService.DeleteNews")
+  news__NewsService__EditNews(news: news__NewsInput!): news__News @grpc(body: "{{.args.news}}", method: "news.NewsService.EditNews")
+  news__NewsService__GetAllNews: news__NewsList @grpc(method: "news.NewsService.GetAllNews")
+  news__NewsService__GetMultipleNews(multipleNewsId: news__MultipleNewsId!): news__NewsList @grpc(body: "{{.args.multipleNewsId}}", method: "news.NewsService.GetMultipleNews")
+  news__NewsService__GetNews(newsId: news__NewsId!): news__News @grpc(body: "{{.args.newsId}}", method: "news.NewsService.GetNews")
+}
+
+type news__News {
+  body: String
+  id: Int
+  postImage: String
+  status: news__Status
+  title: String
+}
+
+type news__NewsList {
+  news: [news__News]
+}


### PR DESCRIPTION
**Summary:**  
In a discussion on Discord, the user `ben` had an issue regarding the generation of tailcall configuration from a proto file. The issue was that they used relative paths from the project root folder, whereas we used relative to the folder of the proto file during the stitching of proto files. To fix this issue, we now do the following: (1) we check for the proto file we want to stitch if it exists in the folder relative to the parent proto file, and if we do not find we (2) try to load the target file for stitching from the path where the CLI command had been run.

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [X] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [X] I have updated the [documentation] accordingly.
- [X] I have performed a self-review of my code.
- [X] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
