### PR TITLE
feat: add reverse proxying capabilities on admin server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ genai = { git = "https://github.com/laststylebender14/rust-genai.git", rev = "63
 
 rustls-pemfile = { version = "1.0.4" }
 schemars = { version = "0.8.17", features = ["derive"] }
-hyper = { version = "0.14.28", features = ["server"], default-features = false }
+hyper = { version = "0.14.28", features = ["full"], default-features = false }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }

--- a/src/cli/server/http_1.rs
+++ b/src/cli/server/http_1.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use hyper::service::{make_service_fn, service_fn};
@@ -41,14 +43,29 @@ pub async fn start_http_1(
             .or(Err(anyhow::anyhow!("Failed to send message")))?;
     }
 
-    let server: std::prelude::v1::Result<(), hyper::Error> =
+    let proxy_server = tokio::spawn(async {
+        let proxy_service = make_service_fn(|_conn| async {
+            Ok::<_, anyhow::Error>(service_fn(super::http_proxy::handle))
+        });
+
+        let addr = SocketAddr::from_str("127.0.0.1:8100").unwrap();
+        let builder = hyper::Server::try_bind(&addr)?;
+
+        builder.serve(proxy_service).await
+    });
+
+    let server = async {
         if sc.blueprint.server.enable_batch_requests {
             builder.serve(make_svc_batch_req).await
         } else {
             builder.serve(make_svc_single_req).await
-        };
+        }
+    };
 
-    let result = server.map_err(Errata::from);
+    let (server_result, proxy_server_result) = tokio::join!(server, proxy_server);
 
-    Ok(result?)
+    proxy_server_result?.map_err(Errata::from)?;
+    let server_result = server_result.map_err(Errata::from);
+
+    Ok(server_result?)
 }

--- a/src/cli/server/http_proxy.rs
+++ b/src/cli/server/http_proxy.rs
@@ -1,0 +1,66 @@
+use hyper::{Body, Method, Request, Response, StatusCode};
+use tokio::net::TcpStream;
+
+pub async fn handle(req: Request<hyper::Body>) -> anyhow::Result<Response<Body>> {
+    tracing::info!("Proxy request: {:?}", req.uri());
+    if Method::CONNECT == req.method() {
+        if let Some(addr) = extract_addr(&req) {
+            tokio::task::spawn(async move {
+                match hyper::upgrade::on(req).await {
+                    Ok(mut upgraded) => {
+                        if let Err(e) = async {
+                            let mut server = TcpStream::connect(addr).await?;
+                            let (from_client, from_server) =
+                                tokio::io::copy_bidirectional(&mut upgraded, &mut server).await?;
+
+                            tracing::info!(
+                                "client wrote {} bytes and received {} bytes",
+                                from_client,
+                                from_server
+                            );
+
+                            Ok::<(), tokio::io::Error>(())
+                        }
+                        .await
+                        {
+                            tracing::error!("server io error: {}", e);
+                        };
+                    }
+                    Err(e) => tracing::error!("upgrade error: {}", e),
+                }
+            });
+
+            Ok(Response::new(Body::empty()))
+        } else {
+            tracing::error!("CONNECT host is not socket addr: {:?}", req.uri());
+            let mut resp = Response::new(Body::from("CONNECT must be to a socket address"));
+            *resp.status_mut() = StatusCode::BAD_REQUEST;
+
+            Ok(resp)
+        }
+    } else {
+        let host = req.uri().host().expect("uri has no host");
+        let port = req.uri().port_u16().unwrap_or(80);
+
+        let stream = TcpStream::connect((host, port)).await.unwrap();
+
+        let (mut sender, conn) = hyper::client::conn::Builder::new()
+            .http1_preserve_header_case(true)
+            .http1_title_case_headers(true)
+            .handshake(stream)
+            .await?;
+
+        tokio::task::spawn(async move {
+            if let Err(err) = conn.await {
+                tracing::error!("Connection failed: {:?}", err);
+            }
+        });
+
+        let resp = sender.send_request(req).await?;
+        Ok(resp)
+    }
+}
+
+fn extract_addr(req: &Request<hyper::Body>) -> Option<String> {
+    req.uri().authority().map(|auth| auth.to_string())
+}

--- a/src/cli/server/mod.rs
+++ b/src/cli/server/mod.rs
@@ -1,5 +1,6 @@
 pub mod http_1;
 pub mod http_2;
+pub mod http_proxy;
 pub mod http_server;
 pub mod playground;
 pub mod server_config;


### PR DESCRIPTION
**Summary:**  
Allows tailcall to proxy HTTP requests

**Issue Reference(s):**  
Fixes #2819 

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
