### PR TITLE
fix: remove custom scalars from blueprint

### DIFF
--- a/src/core/blueprint/into_schema.rs
+++ b/src/core/blueprint/into_schema.rs
@@ -4,13 +4,11 @@ use async_graphql::dynamic::{self, FieldFuture, FieldValue, SchemaBuilder, TypeR
 use async_graphql::ErrorExtensions;
 use async_graphql_value::ConstValue;
 use futures_util::TryFutureExt;
-use strum::IntoEnumIterator;
 use tracing::Instrument;
 
 use crate::core::blueprint::{Blueprint, Definition};
 use crate::core::http::RequestContext;
 use crate::core::ir::{EvalContext, ResolverContext, TypedValue};
-use crate::core::scalar;
 
 /// We set the default value for an `InputValue` by reading it from the
 /// blueprint and assigning it to the provided `InputValue` during the
@@ -198,13 +196,6 @@ impl From<&Blueprint> for SchemaBuilder {
         let query = blueprint.query();
         let mutation = blueprint.mutation();
         let mut schema = dynamic::Schema::build(query.as_str(), mutation.as_deref(), None);
-
-        for scalar in scalar::Scalar::iter() {
-            let k = scalar.name();
-            schema = schema.register(dynamic::Type::Scalar(
-                dynamic::Scalar::new(k.clone()).validator(move |val| scalar.validate(val)),
-            ));
-        }
 
         for def in blueprint.definitions.iter() {
             schema = schema.register(to_type(def));

--- a/tests/core/snapshots/add-field-index-list.md_client.snap
+++ b/tests/core/snapshots/add-field-index-list.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   username: String
   users: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   name: String

--- a/tests/core/snapshots/add-field-many-list.md_client.snap
+++ b/tests/core/snapshots/add-field-many-list.md_client.snap
@@ -8,30 +8,6 @@ type A {
   d: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   u: U
 }
@@ -43,18 +19,6 @@ type U {
   d: String
   e: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/add-field-many.md_client.snap
+++ b/tests/core/snapshots/add-field-many.md_client.snap
@@ -2,16 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   a: String
   b: String
@@ -20,35 +10,9 @@ type Foo {
   x: X
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: Foo
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type X {
   a: String

--- a/tests/core/snapshots/add-field-modify.md_client.snap
+++ b/tests/core/snapshots/add-field-modify.md_client.snap
@@ -8,45 +8,9 @@ type Address {
   zipcode: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   address: Address

--- a/tests/core/snapshots/add-field-with-composition.md_client.snap
+++ b/tests/core/snapshots/add-field-with-composition.md_client.snap
@@ -7,52 +7,16 @@ type Address {
   street: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Geo {
   lat: String
   lng: String
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Query {
   lat: String
   lng: String
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   address: Address

--- a/tests/core/snapshots/add-field-with-modify.md_client.snap
+++ b/tests/core/snapshots/add-field-with-modify.md_client.snap
@@ -2,48 +2,12 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   person1: User
   person2: User
   user1: String
   user2: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   name: String

--- a/tests/core/snapshots/add-field.md_client.snap
+++ b/tests/core/snapshots/add-field.md_client.snap
@@ -6,49 +6,13 @@ type Address {
   geo: Geo
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Geo {
   lat: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   address: Address

--- a/tests/core/snapshots/apollo-federation-entities-batch.md_client.snap
+++ b/tests/core/snapshots/apollo-federation-entities-batch.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int!
   title: String!
@@ -42,18 +18,6 @@ type Query {
   _service: _Service!
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/apollo-federation-entities.md_client.snap
+++ b/tests/core/snapshots/apollo-federation-entities.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int!
   title: String!
@@ -42,18 +18,6 @@ type Query {
   _service: _Service!
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/apollo-tracing.md_client.snap
+++ b/tests/core/snapshots/apollo-tracing.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hello: String!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/async-cache-disabled.md_client.snap
+++ b/tests/core/snapshots/async-cache-disabled.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/async-cache-enable-multiple-resolvers.md_client.snap
+++ b/tests/core/snapshots/async-cache-enable-multiple-resolvers.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int!
@@ -38,18 +14,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/async-cache-enabled.md_client.snap
+++ b/tests/core/snapshots/async-cache-enabled.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/async-cache-global.md_client.snap
+++ b/tests/core/snapshots/async-cache-global.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -36,18 +12,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/async-cache-inflight-request.md_client.snap
+++ b/tests/core/snapshots/async-cache-inflight-request.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/auth-basic.md_client.snap
+++ b/tests/core/snapshots/auth-basic.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   protectedType: ProtectedType
 }
@@ -32,8 +10,6 @@ type Nested {
   name: String!
   protected: String!
 }
-
-scalar PhoneNumber
 
 type ProtectedType {
   name: String!
@@ -46,18 +22,6 @@ type Query {
   protectedType: ProtectedType
   scalar: String!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/auth-jwt.md_client.snap
+++ b/tests/core/snapshots/auth-jwt.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   protectedType: ProtectedType
 }
@@ -32,8 +10,6 @@ type Nested {
   name: String!
   protected: String!
 }
-
-scalar PhoneNumber
 
 type ProtectedType {
   name: String!
@@ -46,18 +22,6 @@ type Query {
   protectedType: ProtectedType
   scalar: String!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/auth.md_client.snap
+++ b/tests/core/snapshots/auth.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   data: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/batching-default.md_client.snap
+++ b/tests/core/snapshots/batching-default.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/batching-disabled.md_client.snap
+++ b/tests/core/snapshots/batching-disabled.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/batching-group-by-default.md_client.snap
+++ b/tests/core/snapshots/batching-group-by-default.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/batching-group-by-optional-key.md_client.snap
+++ b/tests/core/snapshots/batching-group-by-optional-key.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/batching-group-by.md_client.snap
+++ b/tests/core/snapshots/batching-group-by.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/batching-post.md_client.snap
+++ b/tests/core/snapshots/batching-post.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/batching.md_client.snap
+++ b/tests/core/snapshots/batching.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/cache-control.md_client.snap
+++ b/tests/core/snapshots/cache-control.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/caching-collision.md_client.snap
+++ b/tests/core/snapshots/caching-collision.md_client.snap
@@ -7,49 +7,13 @@ type Bar {
   id: String!
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   id: Int!
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bars: [Bar]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/caching.md_client.snap
+++ b/tests/core/snapshots/caching.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   fieldCache: Type
   fieldCacheList: [Type]
@@ -41,18 +17,6 @@ type TypeCache {
   b: Type
   list: [Type]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/call-graphql-datasource.md_client.snap
+++ b/tests/core/snapshots/call-graphql-datasource.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String!
   id: Int!
@@ -38,18 +14,6 @@ type Query {
   posts: [Post]
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   email: String!

--- a/tests/core/snapshots/call-mutation.md_client.snap
+++ b/tests/core/snapshots/call-mutation.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   attachPostToFirstUser(postId: Int!): User
   attachPostToUser(userId: Int!, postId: Int!): User
@@ -32,8 +10,6 @@ type Mutation {
   insertPostToFirstUser(input: PostInputWithoutUserId): Post
   insertPostToUser(input: PostInputWithoutUserId!, userId: Int!): Post
 }
-
-scalar PhoneNumber
 
 type Post {
   body: String
@@ -58,18 +34,6 @@ type Query {
   firstUser: User
   postFromUser(userId: Int!): Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/call-operator.md_client.snap
+++ b/tests/core/snapshots/call-operator.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -34,8 +12,6 @@ type News {
 type NewsData {
   news: [News]
 }
-
-scalar PhoneNumber
 
 type Post {
   body: String
@@ -68,18 +44,6 @@ type Query {
   userPosts(id: ID!): [Post]
   userWithPosts: UserWithPosts
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   email: String!

--- a/tests/core/snapshots/cors-allow-cred-false.md_client.snap
+++ b/tests/core/snapshots/cors-allow-cred-false.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   val: Int
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/cors-allow-cred-true.md_client.snap
+++ b/tests/core/snapshots/cors-allow-cred-true.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   val: Int
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/cors-allow-cred-vary.md_client.snap
+++ b/tests/core/snapshots/cors-allow-cred-vary.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   val: Int
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/custom-headers.md_client.snap
+++ b/tests/core/snapshots/custom-headers.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   greet: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/dedupe_batch_query_execution.md_client.snap
+++ b/tests/core/snapshots/dedupe_batch_query_execution.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -36,18 +12,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/default-value-arg.md_client.snap
+++ b/tests/core/snapshots/default-value-arg.md_client.snap
@@ -2,49 +2,13 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 input Input {
   id: Int!
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bar(input: Input = {id: 1}): Int
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/default-value-config.md_client.snap
+++ b/tests/core/snapshots/default-value-config.md_client.snap
@@ -2,50 +2,14 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 input Input {
   id: Int = 1
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Query {
   bar(input: Input = {id: 3}): Int
   foo(input: Input!): Int
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/enum-args.md_client.snap
+++ b/tests/core/snapshots/enum-args.md_client.snap
@@ -2,51 +2,15 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 enum COLOR {
   BLUE
   GREEN
   RED
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   color(item: COLOR): COLOR
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/env-value.md_client.snap
+++ b/tests/core/snapshots/env-value.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -38,18 +14,6 @@ type Query {
   post2: Post
   post3: Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/experimental-headers.md_client.snap
+++ b/tests/core/snapshots/experimental-headers.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   users: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/federation-subgraph-force-disabled.md_client.snap
+++ b/tests/core/snapshots/federation-subgraph-force-disabled.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/federation-subgraph-force-enabled.md_client.snap
+++ b/tests/core/snapshots/federation-subgraph-force-enabled.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   """
   Apollo federation Query._service resolver
@@ -33,18 +9,6 @@ type Query {
   _service: _Service!
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/federation-subgraph-no-entities.md_client.snap
+++ b/tests/core/snapshots/federation-subgraph-no-entities.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/graphql-conformance-001.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-001.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   city: String

--- a/tests/core/snapshots/graphql-conformance-003.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-003.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: ID!

--- a/tests/core/snapshots/graphql-conformance-010.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-010.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Location {
   lat: Int!
   lon: Int!
@@ -34,8 +12,6 @@ input LocationInput {
   lon: Int!
 }
 
-scalar PhoneNumber
-
 type Point {
   id: ID!
   location: Location
@@ -45,18 +21,6 @@ type Point {
 type Query {
   nearby(location: LocationInput): Point
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/graphql-conformance-014.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-014.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   city: String

--- a/tests/core/snapshots/graphql-conformance-015.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-015.md_client.snap
@@ -2,49 +2,13 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 input Foo {
   bar: String! = "BUZZ"
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   featuredVideo(video: VideoSize! = {width: 1600, height: 900}): String!

--- a/tests/core/snapshots/graphql-conformance-http-001.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-001.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   city: String

--- a/tests/core/snapshots/graphql-conformance-http-002.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-002.md_client.snap
@@ -8,45 +8,9 @@ type BirthDay {
   year: Int
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   birthday: BirthDay!

--- a/tests/core/snapshots/graphql-conformance-http-003.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-003.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: ID!

--- a/tests/core/snapshots/graphql-conformance-http-004.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-004.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: ID!

--- a/tests/core/snapshots/graphql-conformance-http-005.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-005.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   dob: String!

--- a/tests/core/snapshots/graphql-conformance-http-006.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-006.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   friends(first: Int): [User!]!

--- a/tests/core/snapshots/graphql-conformance-http-010.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-010.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Location {
   lat: Int!
   lon: Int!
@@ -34,8 +12,6 @@ input LocationInput {
   lon: Int!
 }
 
-scalar PhoneNumber
-
 type Point {
   id: ID!
   location: Location
@@ -45,18 +21,6 @@ type Point {
 type Query {
   nearby(location: LocationInput): Point
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/graphql-conformance-http-012.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-012.md_client.snap
@@ -2,34 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Person {
   age: Int
   name: String
 }
-
-scalar PhoneNumber
 
 type Photo {
   height: Int
@@ -48,18 +24,6 @@ type Query {
 }
 
 union SearchResult = Person | Photo
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/graphql-conformance-http-014.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-014.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   city: String

--- a/tests/core/snapshots/graphql-conformance-http-015.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-http-015.md_client.snap
@@ -2,49 +2,13 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 input Foo {
   bar: String! = "BUZZ"
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: ID!): User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   featuredVideo(video: VideoSize! = {width: 1600, height: 900}): String!

--- a/tests/core/snapshots/graphql-conformance-nested-lists-fragment.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-nested-lists-fragment.md_client.snap
@@ -7,47 +7,11 @@ type Admin {
   region: String!
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   users: [[Role!]!]!
 }
 
 union Role = Admin | User
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   accountRef: String!

--- a/tests/core/snapshots/graphql-conformance-nested-lists-http.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-nested-lists-http.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   addUsers(userNames: [[String!]!]!): Boolean
   userGroups: [[User!]!]!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   accountRef: String!

--- a/tests/core/snapshots/graphql-conformance-nested-lists.md_client.snap
+++ b/tests/core/snapshots/graphql-conformance-nested-lists.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   addUsers(userNames: [[String!]!]!): Boolean
   userGroups: [[User!]!]!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   accountRef: String!

--- a/tests/core/snapshots/graphql-dataloader-batch-request.md_client.snap
+++ b/tests/core/snapshots/graphql-dataloader-batch-request.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int
   title: String
@@ -36,18 +12,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/graphql-dataloader-no-batch-request.md_client.snap
+++ b/tests/core/snapshots/graphql-dataloader-no-batch-request.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int
   title: String
@@ -36,18 +12,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/graphql-datasource-errors.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-errors.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/graphql-datasource-mutation.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-mutation.md_client.snap
@@ -2,49 +2,13 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   createUser(user: UserInput!): User
 }
 
-scalar PhoneNumber
-
 type Query {
   users: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/graphql-datasource-no-args.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-no-args.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   users_list: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/graphql-datasource-query-directives.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-query-directives.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/graphql-datasource-with-args.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-with-args.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int
   user: User
@@ -35,18 +11,6 @@ type Query {
   post(id: Int): Post
   user(id: Int): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/graphql-datasource-with-empty-enum.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-with-empty-enum.md_client.snap
@@ -2,34 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 enum EnumType {
   INFORMATION
   WARNING
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Post {
   severity: WithOptEnum!
@@ -38,18 +14,6 @@ type Post {
 type Query {
   post: Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type WithOptEnum {
   type: EnumType

--- a/tests/core/snapshots/graphql-datasource-with-mandatory-enum.md_client.snap
+++ b/tests/core/snapshots/graphql-datasource-with-mandatory-enum.md_client.snap
@@ -2,34 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 enum EnumType {
   INFORMATION
   WARNING
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Post {
   severity: WithMandatoryEnum!
@@ -38,18 +14,6 @@ type Post {
 type Query {
   post: Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type WithMandatoryEnum {
   type: EnumType!

--- a/tests/core/snapshots/graphql-nested-datasource.md_client.snap
+++ b/tests/core/snapshots/graphql-nested-datasource.md_client.snap
@@ -15,50 +15,14 @@ type B {
   y: String!
 }
 
-scalar Bytes
-
 type C {
   id: Int!
   x: String!
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   a: [A]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/grpc-batch.md_client.snap
+++ b/tests/core/snapshots/grpc-batch.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -42,24 +20,10 @@ input NewsInput {
   title: String
 }
 
-scalar PhoneNumber
-
 type Query {
   news: NewsData!
   newsById(news: NewsInput!): News!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/grpc-error.md_client.snap
+++ b/tests/core/snapshots/grpc-error.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -42,24 +20,10 @@ input NewsInput {
   title: String
 }
 
-scalar PhoneNumber
-
 type Query {
   news: NewsData!
   newsById(news: NewsInput!): News!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/grpc-json.md_client.snap
+++ b/tests/core/snapshots/grpc-json.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -35,25 +13,11 @@ input NewsInput {
   id: Int
 }
 
-scalar PhoneNumber
-
 type Query {
   newsById: News!
   newsByIdMustache(news: NewsInput!): News!
   newsByIdMustacheAndJson(news: NewsInput!): News!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/grpc-oneof.md_client.snap
+++ b/tests/core/snapshots/grpc-oneof.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   oneof__OneOfService__GetOneOfVar0(request: oneof__Request__Var0__Var!): oneof__Response!
   oneof__OneOfService__GetOneOfVar1(request: oneof__Request__Var0__Var0!): oneof__Response!
@@ -37,18 +13,6 @@ type Query {
   oneof__OneOfService__GetOneOfVar7(request: oneof__Request__Var__Var0!): oneof__Response!
   oneof__OneOfService__GetOneOfVar8(request: oneof__Request__Var__Var1!): oneof__Response!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type oneof__Command {
   command: String

--- a/tests/core/snapshots/grpc-override-url-from-upstream.md_client.snap
+++ b/tests/core/snapshots/grpc-override-url-from-upstream.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -42,24 +20,10 @@ input NewsInput {
   title: String
 }
 
-scalar PhoneNumber
-
 type Query {
   news: NewsData!
   newsById(news: NewsInput!): News!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/grpc-proto-with-same-package.md_client.snap
+++ b/tests/core/snapshots/grpc-proto-with-same-package.md_client.snap
@@ -6,50 +6,14 @@ type Bar {
   bar: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   foo: String
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Query {
   bar: Bar!
   foo: Foo!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/grpc-reflection.md_client.snap
+++ b/tests/core/snapshots/grpc-reflection.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -36,8 +14,6 @@ type NewsData {
   news: [News]
 }
 
-scalar PhoneNumber
-
 type Query {
   news: NewsData!
 }
@@ -47,18 +23,6 @@ enum Status {
   DRAFT
   PUBLISHED
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/grpc-url-from-upstream.md_client.snap
+++ b/tests/core/snapshots/grpc-url-from-upstream.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -42,24 +20,10 @@ input NewsInput {
   title: String
 }
 
-scalar PhoneNumber
-
 type Query {
   news: NewsData!
   newsById(news: NewsInput!): News!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/http-select.md_client.snap
+++ b/tests/core/snapshots/http-select.md_client.snap
@@ -2,51 +2,15 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type Company {
   catchPhrase: String!
   name: String!
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   userCompany(id: Int!): Company
   userDetails(id: Int!): UserDetails
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type UserDetails {
   city: String!

--- a/tests/core/snapshots/https.md_client.snap
+++ b/tests/core/snapshots/https.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   firstUser: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/inline-field.md_client.snap
+++ b/tests/core/snapshots/inline-field.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   address: String

--- a/tests/core/snapshots/inline-index-list.md_client.snap
+++ b/tests/core/snapshots/inline-index-list.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   username: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/inline-many-list.md_client.snap
+++ b/tests/core/snapshots/inline-many-list.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   u: U
 }
@@ -36,18 +12,6 @@ type U {
   d: String
   e: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/inline-many.md_client.snap
+++ b/tests/core/snapshots/inline-many.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   city: String

--- a/tests/core/snapshots/io-cache.md_client.snap
+++ b/tests/core/snapshots/io-cache.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String!
   id: Int!
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/jit-enum-array.md_client.snap
+++ b/tests/core/snapshots/jit-enum-array.md_client.snap
@@ -2,15 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type DTA {
   departments: [Department]
 }
-
-scalar Date
-
-scalar DateTime
 
 enum Department {
   BLUE
@@ -18,39 +12,9 @@ enum Department {
   MARKETING
 }
 
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   color: DTA
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/js-directive.md_client.snap
+++ b/tests/core/snapshots/js-directive.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hello: User!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/jsonplaceholder-call-post.md_client.snap
+++ b/tests/core/snapshots/jsonplaceholder-call-post.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int!
   title: String!
@@ -38,18 +14,6 @@ type Query {
   user(id: Int!): User
   users: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/modified-field.md_client.snap
+++ b/tests/core/snapshots/modified-field.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   fullname: String

--- a/tests/core/snapshots/mutation-put.md_client.snap
+++ b/tests/core/snapshots/mutation-put.md_client.snap
@@ -2,33 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   insertPost(input: PostInput!): Post
 }
-
-scalar PhoneNumber
 
 type Post {
   body: String
@@ -47,18 +23,6 @@ input PostInput {
 type Query {
   firstUser: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/mutation.md_client.snap
+++ b/tests/core/snapshots/mutation.md_client.snap
@@ -2,33 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   insertPost(input: PostInput): Post
 }
-
-scalar PhoneNumber
 
 type Post {
   body: String
@@ -46,18 +22,6 @@ input PostInput {
 type Query {
   firstUser: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/n-plus-one-list.md_client.snap
+++ b/tests/core/snapshots/n-plus-one-list.md_client.snap
@@ -8,52 +8,16 @@ type Bar {
   id: Int!
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   bar: Bar
   id: Int!
   name: String!
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bars: [Bar]
   foos: [Foo]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/n-plus-one.md_client.snap
+++ b/tests/core/snapshots/n-plus-one.md_client.snap
@@ -8,52 +8,16 @@ type Bar {
   id: Int!
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   bar: Bar
   id: Int!
   name: String!
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bars: [Bar]
   foos: [Foo]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/nested-objects.md_client.snap
+++ b/tests/core/snapshots/nested-objects.md_client.snap
@@ -7,50 +7,14 @@ type Address {
   street: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Geo {
   lat: String
   lng: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   address: Address

--- a/tests/core/snapshots/nested-recursive-types.md_client.snap
+++ b/tests/core/snapshots/nested-recursive-types.md_client.snap
@@ -2,8 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type Connection {
   nested: NestedUser
   type: String
@@ -13,26 +11,6 @@ input ConnectionInput {
   nested: NestedUserInput
   type: String
 }
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
 
 type Mutation {
   createUser(user: UserInput): User
@@ -46,23 +24,9 @@ input NestedUserInput {
   user: UserInput
 }
 
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   connections: [Connection]

--- a/tests/core/snapshots/nesting-level3.md_client.snap
+++ b/tests/core/snapshots/nesting-level3.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -41,18 +17,6 @@ type Query {
 type Todo {
   completed: Boolean
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   email: String!

--- a/tests/core/snapshots/nullable-arg-query.md_client.snap
+++ b/tests/core/snapshots/nullable-arg-query.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   users(id: ID): [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: ID!

--- a/tests/core/snapshots/omit-index-list.md_client.snap
+++ b/tests/core/snapshots/omit-index-list.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   username: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/omit-many.md_client.snap
+++ b/tests/core/snapshots/omit-many.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   complements: [String]

--- a/tests/core/snapshots/omit-resolved-by-parent.md_client.snap
+++ b/tests/core/snapshots/omit-resolved-by-parent.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   address: String

--- a/tests/core/snapshots/recursive-types-json.md_client.snap
+++ b/tests/core/snapshots/recursive-types-json.md_client.snap
@@ -2,8 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type Connection {
   type: String
   user: User
@@ -14,47 +12,13 @@ input ConnectionInput {
   user: UserInput
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   createUser(user: UserInput): User
 }
 
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   connections: [Connection]

--- a/tests/core/snapshots/recursive-types.md_client.snap
+++ b/tests/core/snapshots/recursive-types.md_client.snap
@@ -2,8 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type Connection {
   type: String
   user: User
@@ -14,47 +12,13 @@ input ConnectionInput {
   user: UserInput
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   createUser(user: UserInput): User
 }
 
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   connections: [Connection]

--- a/tests/core/snapshots/ref-other-nested.md_client.snap
+++ b/tests/core/snapshots/ref-other-nested.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   firstUser: User1
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/ref-other.md_client.snap
+++ b/tests/core/snapshots/ref-other.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   firstUser: User1
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/related-fields-recursive.md_client.snap
+++ b/tests/core/snapshots/related-fields-recursive.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type NodeA {
   name: String
   nodeB: NodeB
@@ -34,23 +12,9 @@ type NodeB {
   nodeA: NodeA
 }
 
-scalar PhoneNumber
-
 type Query {
   queryNodeA: [NodeA]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/rename-field.md_client.snap
+++ b/tests/core/snapshots/rename-field.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user1: User
   user2: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   name: String

--- a/tests/core/snapshots/request-to-upstream-batching.md_client.snap
+++ b/tests/core/snapshots/request-to-upstream-batching.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/resolve-with-headers.md_client.snap
+++ b/tests/core/snapshots/resolve-with-headers.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String!
   id: ID!
@@ -36,18 +12,6 @@ type Post {
 type Query {
   post1: Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/resolve-with-vars.md_client.snap
+++ b/tests/core/snapshots/resolve-with-vars.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/resolved-by-parent.md_client.snap
+++ b/tests/core/snapshots/resolved-by-parent.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   address: String

--- a/tests/core/snapshots/rest-api-error.md_client.snap
+++ b/tests/core/snapshots/rest-api-error.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/rest-api-post.md_client.snap
+++ b/tests/core/snapshots/rest-api-post.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/rest-api.md_client.snap
+++ b/tests/core/snapshots/rest-api.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/routes-param-on-server-directive.md_client.snap
+++ b/tests/core/snapshots/routes-param-on-server-directive.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   users: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   name: String

--- a/tests/core/snapshots/showcase.md_client.snap
+++ b/tests/core/snapshots/showcase.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   not_user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   not_id: Int

--- a/tests/core/snapshots/simple-graphql.md_client.snap
+++ b/tests/core/snapshots/simple-graphql.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/simple-query.md_client.snap
+++ b/tests/core/snapshots/simple-query.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   firstUser: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-add-field-list.md_client.snap
+++ b/tests/core/snapshots/test-add-field-list.md_client.snap
@@ -10,50 +10,14 @@ type B {
   c: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   a: A
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Query {
   b: B
   foo: [Foo]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-add-field.md_client.snap
+++ b/tests/core/snapshots/test-add-field.md_client.snap
@@ -10,50 +10,14 @@ type B {
   c: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   a: A
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Query {
   b: B
   foo: Foo
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-add-link-to-empty-config.md_client.snap
+++ b/tests/core/snapshots/test-add-link-to-empty-config.md_client.snap
@@ -2,51 +2,15 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 enum Foo {
   BAR
   BAZ
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: Foo
   hello: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-alias-on-enum.md_client.snap
+++ b/tests/core/snapshots/test-alias-on-enum.md_client.snap
@@ -2,15 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type DTA {
   departments: [Department]
 }
-
-scalar Date
-
-scalar DateTime
 
 enum Department {
   ENGINEERING
@@ -18,39 +12,9 @@ enum Department {
   MARKETING
 }
 
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   color: DTA
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-batching-group-by.md_client.snap
+++ b/tests/core/snapshots/test-batching-group-by.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -37,18 +13,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-cache.md_client.snap
+++ b/tests/core/snapshots/test-cache.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-custom-scalar.md_client.snap
+++ b/tests/core/snapshots/test-custom-scalar.md_client.snap
@@ -2,47 +2,11 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 scalar Json
-
-scalar PhoneNumber
 
 type Query {
   foo: [Json]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-custom-types.md_client.snap
+++ b/tests/core/snapshots/test-custom-types.md_client.snap
@@ -2,33 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mut {
   insertPost(input: PostInput): Post
 }
-
-scalar PhoneNumber
 
 type Post {
   body: String
@@ -46,18 +22,6 @@ input PostInput {
 type Que {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Que

--- a/tests/core/snapshots/test-dbl-usage-many.md_client.snap
+++ b/tests/core/snapshots/test-dbl-usage-many.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: ID!
   title: String!
@@ -40,18 +16,6 @@ type Query {
   post(input: PostInput!): Post
   user(input: UserInput!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: ID!

--- a/tests/core/snapshots/test-description-many.md_client.snap
+++ b/tests/core/snapshots/test-description-many.md_client.snap
@@ -9,48 +9,12 @@ type Bar {
   baz: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   """
   This is test
   """
   foo: Bar
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-enable-jit.md_client.snap
+++ b/tests/core/snapshots/test-enable-jit.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int!
   title: String!
@@ -36,18 +12,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/test-enum-aliases.md_client.snap
+++ b/tests/core/snapshots/test-enum-aliases.md_client.snap
@@ -2,50 +2,14 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 enum Foo {
   BAR
   BAZ
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: Foo
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-enum-default.md_client.snap
+++ b/tests/core/snapshots/test-enum-default.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   foo: Status
   id: Int
@@ -32,8 +10,6 @@ type News {
 type NewsData {
   news: [News]
 }
-
-scalar PhoneNumber
 
 type Query {
   news: NewsData!
@@ -44,18 +20,6 @@ enum Status {
   NOT_DEFINED
   PUBLISHED
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-enum-description.md_client.snap
+++ b/tests/core/snapshots/test-enum-description.md_client.snap
@@ -2,16 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 """
 Description of enum Foo
 """
@@ -20,35 +10,9 @@ enum Foo {
   BAZ
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo(val: String!): Foo
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-enum.md_client.snap
+++ b/tests/core/snapshots/test-enum.md_client.snap
@@ -2,50 +2,14 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 enum Foo {
   BAR
   BAZ
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo(val: String!): Foo
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-expr-scalar-as-string.md_client.snap
+++ b/tests/core/snapshots/test-expr-scalar-as-string.md_client.snap
@@ -2,16 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Entry {
   arr: String
   bool: String
@@ -21,18 +11,6 @@ type Entry {
   str: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Nested {
   arr: String
   bool: String
@@ -41,23 +19,9 @@ type Nested {
   str: String
 }
 
-scalar PhoneNumber
-
 type Query {
   entry: Entry
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-expr-with-mustache.md_client.snap
+++ b/tests/core/snapshots/test-expr-with-mustache.md_client.snap
@@ -15,49 +15,13 @@ type BC {
   g: Boolean
 }
 
-scalar Bytes
-
 type D {
   e: Int
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   a: A
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-expr.md_client.snap
+++ b/tests/core/snapshots/test-expr.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hello: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-graphqlsource.md_client.snap
+++ b/tests/core/snapshots/test-graphqlsource.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int!
   user: User
@@ -35,18 +11,6 @@ type Post {
 type Query {
   post(id: Int!): Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-grpc.md_client.snap
+++ b/tests/core/snapshots/test-grpc.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   body: String
   id: Int
@@ -42,25 +20,11 @@ input NewsInput {
   title: String
 }
 
-scalar PhoneNumber
-
 type Query {
   news: NewsData!
   newsById(news: NewsInput!): News!
   newsByIdBatch(news: NewsInput!): News!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-http-baseurl.md_client.snap
+++ b/tests/core/snapshots/test-http-baseurl.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bar: String
   foo: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-http-batchKey.md_client.snap
+++ b/tests/core/snapshots/test-http-batchKey.md_client.snap
@@ -7,16 +7,6 @@ type Bar {
   id: ID!
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   barId: String!
   bars: [Bar!]!
@@ -28,35 +18,9 @@ type FooResponse {
   foos: [Foo!]!
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foos: FooResponse
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-http-headers.md_client.snap
+++ b/tests/core/snapshots/test-http-headers.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-http-tmpl.md_client.snap
+++ b/tests/core/snapshots/test-http-tmpl.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int
   user: User
@@ -35,18 +11,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-http-with-mustache-expr.md_client.snap
+++ b/tests/core/snapshots/test-http-with-mustache-expr.md_client.snap
@@ -12,49 +12,13 @@ type BC {
   f: Boolean
 }
 
-scalar Bytes
-
 type D {
   e: Int
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   a: A
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-http.md_client.snap
+++ b/tests/core/snapshots/test-http.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-inline-list.md_client.snap
+++ b/tests/core/snapshots/test-inline-list.md_client.snap
@@ -6,45 +6,9 @@ type B {
   c: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: B
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-inline.md_client.snap
+++ b/tests/core/snapshots/test-inline.md_client.snap
@@ -6,45 +6,9 @@ type B {
   c: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: B
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-input-documentation.md_client.snap
+++ b/tests/core/snapshots/test-input-documentation.md_client.snap
@@ -2,16 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 """
 Test input documentation
 """
@@ -22,23 +12,9 @@ input Foo {
   id: Int
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Mutation {
   testDocumentation(input: Foo!): Post
 }
-
-scalar PhoneNumber
 
 type Post {
   body: String
@@ -52,18 +28,6 @@ type Query {
   foo: String
   postFromFoo(id: Int!): Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-input-out.md_client.snap
+++ b/tests/core/snapshots/test-input-out.md_client.snap
@@ -2,54 +2,18 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 input Filter {
   a: Int
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
 
 type MyType {
   id: String!
   name: String
 }
 
-scalar PhoneNumber
-
 type Query {
   queryTest(filter: Filter): [MyType]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-input-with-arg-out.md_client.snap
+++ b/tests/core/snapshots/test-input-with-arg-out.md_client.snap
@@ -2,39 +2,15 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
 input IntFilter {
   i: Int
 }
-
-scalar JSON
 
 type MyType {
   id: String!
   name(sf: StringFilter): String
   num(if: IntFilter): Int
 }
-
-scalar PhoneNumber
 
 type Query {
   queryTest(filter: StringFilter): [MyType]
@@ -43,18 +19,6 @@ type Query {
 input StringFilter {
   s: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-interface-from-json.md_client.snap
+++ b/tests/core/snapshots/test-interface-from-json.md_client.snap
@@ -7,49 +7,13 @@ type B implements IA {
   b: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 interface IA {
   a: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bar: B
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-interface-result.md_client.snap
+++ b/tests/core/snapshots/test-interface-result.md_client.snap
@@ -7,49 +7,13 @@ type B implements IA {
   b: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 interface IA {
   a: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bar: IA
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-interface.md_client.snap
+++ b/tests/core/snapshots/test-interface.md_client.snap
@@ -7,49 +7,13 @@ type B implements IA {
   b: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 interface IA {
   a: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bar: B
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-js-multi-onRequest-handlers.md_client.snap
+++ b/tests/core/snapshots/test-js-multi-onRequest-handlers.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bar: String
   foo: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-js-request-response-2.md_client.snap
+++ b/tests/core/snapshots/test-js-request-response-2.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hello: String
   hi: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-js-request-response.md_client.snap
+++ b/tests/core/snapshots/test-js-request-response.md_client.snap
@@ -2,46 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hello: String
   hi: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-link-support.md_client.snap
+++ b/tests/core/snapshots/test-link-support.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type News {
   id: Int
 }
@@ -32,23 +10,9 @@ input NewsInput {
   id: Int
 }
 
-scalar PhoneNumber
-
 type Query {
   newsById(news: NewsInput!): News!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-list-args.md_client.snap
+++ b/tests/core/snapshots/test-list-args.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   f1(q: [Int!]!): T1
 }
@@ -33,18 +9,6 @@ type Query {
 type T1 {
   numbers: [Int]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-merge-right-with-link-config.md_client.snap
+++ b/tests/core/snapshots/test-merge-right-with-link-config.md_client.snap
@@ -2,49 +2,13 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   bar: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: Foo
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-merge-server-sdl.md_client.snap
+++ b/tests/core/snapshots/test-merge-server-sdl.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-modify.md_client.snap
+++ b/tests/core/snapshots/test-modify.md_client.snap
@@ -2,49 +2,13 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 input Foo {
   bar: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   data(input: Foo): String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-multi-interface.md_client.snap
+++ b/tests/core/snapshots/test-multi-interface.md_client.snap
@@ -7,16 +7,6 @@ type B implements IA & IB {
   b: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 interface IA {
   a: String
 }
@@ -25,35 +15,9 @@ interface IB {
   b: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bar: B
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-multiple-config-types.md_client.snap
+++ b/tests/core/snapshots/test-multiple-config-types.md_client.snap
@@ -2,55 +2,19 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 input Input {
   id: Int
   name: String
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
 
 type Output {
   id: Int
   name: String
 }
 
-scalar PhoneNumber
-
 type Query {
   bar(input: Input): Output
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-nested-input.md_client.snap
+++ b/tests/core/snapshots/test-nested-input.md_client.snap
@@ -10,8 +10,6 @@ input B {
   c: C
 }
 
-scalar Bytes
-
 input C {
   d: D
 }
@@ -20,43 +18,9 @@ input D {
   e: Int
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   a(a: A!): X
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type X {
   a: String

--- a/tests/core/snapshots/test-nested-link.md_client.snap
+++ b/tests/core/snapshots/test-nested-link.md_client.snap
@@ -2,34 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 enum Foo {
   BAR
   BAZ
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Post {
   id: Int!
@@ -41,18 +17,6 @@ type Query {
   foo: Foo
   post(id: Int!): Post
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-nested-value.md_client.snap
+++ b/tests/core/snapshots/test-nested-value.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int
   user: User!
@@ -34,18 +10,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int!

--- a/tests/core/snapshots/test-null-in-array.md_client.snap
+++ b/tests/core/snapshots/test-null-in-array.md_client.snap
@@ -2,50 +2,14 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type Company {
   id: ID
   name: String
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hi(id: ID!): [Company]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-null-in-object.md_client.snap
+++ b/tests/core/snapshots/test-null-in-object.md_client.snap
@@ -2,50 +2,14 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
 type Company {
   id: ID
   name: String
 }
 
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hi(id: ID!): Company
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-omit-list.md_client.snap
+++ b/tests/core/snapshots/test-omit-list.md_client.snap
@@ -6,45 +6,9 @@ type B {
   c: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: B
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-omit.md_client.snap
+++ b/tests/core/snapshots/test-omit.md_client.snap
@@ -6,45 +6,9 @@ type B {
   c: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: B
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-optional-key-skip-empty.md_client.snap
+++ b/tests/core/snapshots/test-optional-key-skip-empty.md_client.snap
@@ -6,51 +6,15 @@ type Bar {
   id: Int
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   bar: Bar
   id: Int!
   tag: String
 }
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foos: [Foo]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-params-as-body.md_client.snap
+++ b/tests/core/snapshots/test-params-as-body.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   firstUser(id: Int, name: String): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-query-documentation.md_client.snap
+++ b/tests/core/snapshots/test-query-documentation.md_client.snap
@@ -2,48 +2,12 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   """
   This is test
   """
   foo: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-query.md_client.snap
+++ b/tests/core/snapshots/test-query.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-ref-other.md_client.snap
+++ b/tests/core/snapshots/test-ref-other.md_client.snap
@@ -2,33 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type InPost {
   get: [Post]
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Post {
   id: Int!
@@ -38,18 +14,6 @@ type Post {
 type Query {
   posts: InPost
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-required-fields.md_client.snap
+++ b/tests/core/snapshots/test-required-fields.md_client.snap
@@ -2,34 +2,10 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   bar: String!
   id: Int!
 }
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
 
 type Query {
   basicFieldMissing: Foo!
@@ -55,18 +31,6 @@ type Query {
   relaxedMissing: Foo
   relaxedPresent: Foo
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-scalars-builtin.md_client.snap
+++ b/tests/core/snapshots/test-scalars-builtin.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   bool(x: Boolean!): Boolean!
   float(x: Float!): Float!
@@ -33,18 +9,6 @@ type Query {
   int(x: Int!): Int!
   string(x: String!): String!
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-server-vars.md_client.snap
+++ b/tests/core/snapshots/test-server-vars.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   foo: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-set-cookie-headers.md_client.snap
+++ b/tests/core/snapshots/test-set-cookie-headers.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   email: String!

--- a/tests/core/snapshots/test-static-value.md_client.snap
+++ b/tests/core/snapshots/test-static-value.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   firstUser: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/test-union-ambiguous.md_client.snap
+++ b/tests/core/snapshots/test-union-ambiguous.md_client.snap
@@ -11,40 +11,16 @@ type Baz {
   baz: String
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   foo: String
 }
 
 union FooBarBaz = Bar | Baz | Foo
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Nested {
   bar: FooBarBaz
   foo: FooBarBaz
 }
-
-scalar PhoneNumber
 
 type Query {
   arr: [FooBarBaz]
@@ -55,18 +31,6 @@ type Query {
   unknown: FooBarBaz
   wrong: FooBarBaz
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-union.md_client.snap
+++ b/tests/core/snapshots/test-union.md_client.snap
@@ -6,40 +6,16 @@ type Bar {
   bar: String!
 }
 
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
 type Foo {
   foo: String!
 }
 
 union FooBar = Bar | Foo
 
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 type Nested {
   bar: FooBar
   foo: FooBar
 }
-
-scalar PhoneNumber
 
 type Query {
   arr: [FooBar]
@@ -48,18 +24,6 @@ type Query {
   nested: Nested
   unknown: FooBar
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-upstream-headers.md_client.snap
+++ b/tests/core/snapshots/test-upstream-headers.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   id: Int
 }
@@ -33,18 +9,6 @@ type Post {
 type Query {
   posts: [Post]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/test-upstream.md_client.snap
+++ b/tests/core/snapshots/test-upstream.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   hello: String
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/upstream-batching.md_client.snap
+++ b/tests/core/snapshots/upstream-batching.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/upstream-fail-request.md_client.snap
+++ b/tests/core/snapshots/upstream-fail-request.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/with-args-url.md_client.snap
+++ b/tests/core/snapshots/with-args-url.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   id: Int

--- a/tests/core/snapshots/with-args.md_client.snap
+++ b/tests/core/snapshots/with-args.md_client.snap
@@ -2,45 +2,9 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   user(id: Int!): [User]
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   name: String

--- a/tests/core/snapshots/with-nesting.md_client.snap
+++ b/tests/core/snapshots/with-nesting.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Post {
   body: String
   id: Int
@@ -36,18 +12,6 @@ type Post {
 type Query {
   user: User
 }
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 type User {
   email: String!

--- a/tests/core/snapshots/yaml-nested-unions.md_client.snap
+++ b/tests/core/snapshots/yaml-nested-unions.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   testVar0(u: T1Input!): U
   testVar1(u: T2Input!): U
@@ -77,18 +53,6 @@ input T5Input {
 }
 
 union U = T1 | T2 | T3 | T4 | T5
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/yaml-union-in-type.md_client.snap
+++ b/tests/core/snapshots/yaml-union-in-type.md_client.snap
@@ -2,28 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
 input NNU__nu0 {
   new: Boolean
   nu: NU__u0
@@ -56,8 +34,6 @@ input NU__u2 {
   test: String
   u: T3Input
 }
-
-scalar PhoneNumber
 
 type Query {
   testVar0Var0(nu: NU__u0!, nnu: NNU__nu0): U
@@ -98,18 +74,6 @@ input T3Input {
 }
 
 union U = T1 | T2 | T3
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query

--- a/tests/core/snapshots/yaml-union.md_client.snap
+++ b/tests/core/snapshots/yaml-union.md_client.snap
@@ -2,30 +2,6 @@
 source: tests/core/spec.rs
 expression: formatted
 ---
-scalar Bytes
-
-scalar Date
-
-scalar DateTime
-
-scalar Email
-
-scalar Empty
-
-scalar Int128
-
-scalar Int16
-
-scalar Int32
-
-scalar Int64
-
-scalar Int8
-
-scalar JSON
-
-scalar PhoneNumber
-
 type Query {
   testVar0(u: T1Input!): U
   testVar1(u: T2Input!): U
@@ -59,18 +35,6 @@ input T3Input {
 }
 
 union U = T1 | T2 | T3
-
-scalar UInt128
-
-scalar UInt16
-
-scalar UInt32
-
-scalar UInt64
-
-scalar UInt8
-
-scalar Url
 
 schema {
   query: Query


### PR DESCRIPTION
**Summary:**  
Remove force insertion of custom scalars when converting blueprint to schema. 

**Issue Reference(s):**  
Fixes https://github.com/tailcallhq/tailcall/issues/2985

**Build & Testing:**

- [X] I ran `cargo test` successfully.
- [X] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [X] I have added relevant unit & integration tests.
- [X] I have updated the [documentation] accordingly.
- [X] I have performed a self-review of my code.
- [X] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
