### PR TITLE
perf: strip extra iteration when creating serde_json_borrow::Value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4972,8 +4972,7 @@ dependencies = [
 [[package]]
 name = "serde_json_borrow"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8dc27b181f9294b9cd937ae4375414cd0a77f542a34e063ced1e47ed2ceaa"
+source = "git+https://github.com/meskill/serde_json_borrow?branch=perf/object-vec-initializer#d7f0d39da5e457d57612f4d32501053710c56adc"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ tonic-types = "0.12.1"
 base64 = "0.22.1"
 tailcall-hasher = { path = "tailcall-hasher" }
 # TODO: drop git ref when new version is released
-serde_json_borrow = { version = "0.7.0", default-features = false, git = "https://github.com/meskill/serde_json_borrow", branch = "perf/object-vec-initializer" }
+serde_json_borrow = { version = "0.7.0", default-features = false, git = "https://github.com/PSeitz/serde_json_borrow", rev = "6ad7127e0fb9c31f6fd927e934a21112e9ac0fdb" }
 pluralizer = "0.4.0"
 path-clean = "=1.0.1"
 pathdiff = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,8 @@ tailcall-typedefs-common = { path = "./tailcall-typedefs-common" }
 tonic-types = "0.12.1"
 base64 = "0.22.1"
 tailcall-hasher = { path = "tailcall-hasher" }
-serde_json_borrow = "0.7.0"
+# TODO: drop git ref when new version is released
+serde_json_borrow = { version = "0.7.0", default-features = false, git = "https://github.com/meskill/serde_json_borrow", branch = "perf/object-vec-initializer" }
 pluralizer = "0.4.0"
 path-clean = "=1.0.1"
 pathdiff = "0.2.1"


### PR DESCRIPTION
**Summary:**  
Remove `from_vec` column in the base [pr](https://github.com/tailcallhq/tailcall/pull/3073#issuecomment-2438984363) with reported flamegraph time around 1%

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
