### PR TITLE
ci: use windows-2019 runner to fix windows builds of rquickjs

### DIFF
--- a/.github/workflows/build_matrix.yml
+++ b/.github/workflows/build_matrix.yml
@@ -77,14 +77,14 @@ jobs:
                 target: x86_64-apple-darwin
 
               - build: win32-x64-msvc
-                os: windows-latest
+                os: windows-2019
                 rust: stable
                 target: x86_64-pc-windows-msvc
                 libc: msvc
                 ext: ".exe"
 
               - build: win32-arm64-msvc
-                os: windows-latest
+                os: windows-2019
                 rust: stable
                 target: aarch64-pc-windows-msvc
                 features: --no-default-features --features cli
@@ -93,7 +93,7 @@ jobs:
                 test: false # TODO: tests are broken without default features
 
               - build: win32-ia32-msvc
-                os: windows-latest
+                os: windows-2019
                 rust: stable
                 target: i686-pc-windows-msvc
                 libc: msvc


### PR DESCRIPTION
**Summary:**  
[Build fails](https://github.com/tailcallhq/tailcall/actions/runs/11868699676/job/33078485494) of rquickjs were caused by the update of github windows runners. For passing runs the Runner Image Version is older. Because of this difference there are still some ci runs that passing and failing depending on the exact runner that pick up the workflow.

![image](https://github.com/user-attachments/assets/29654309-04a2-4286-a645-df9e19d42cc7)

**Another way to fix** this is to update rquickjs by https://github.com/tailcallhq/tailcall/pull/3112 so we can merge any of this prs

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
