### PR TITLE
chore: upgrade derive_more to v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,12 +1019,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -1357,19 +1351,6 @@ checksum = "870368c3fb35b8031abb378861d4460f573b92238ec2152c927a21f77e3e0127"
 dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.86",
 ]
 
 [[package]]
@@ -1822,7 +1803,7 @@ version = "0.1.7-wip"
 source = "git+https://github.com/laststylebender14/rust-genai.git?rev=63a542ce20132503c520f4e07108e0d768f243c3#63a542ce20132503c520f4e07108e0d768f243c3"
 dependencies = [
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "eventsource-stream",
  "futures",
  "reqwest 0.12.7",
@@ -4682,7 +4663,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c602d3f35d1a5725235ef874b9a9e24232534e34fe610d53657e24c6c37572d"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "fnv",
  "ident_case",
  "indexmap 2.6.0",
@@ -5461,13 +5442,13 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
- "convert_case 0.6.0",
+ "convert_case",
  "criterion",
  "ctrlc",
  "dashmap",
  "datatest-stable",
  "derive-getters",
- "derive_more 0.99.18",
+ "derive_more",
  "derive_setters",
  "dotenvy",
  "exitcode",
@@ -5620,8 +5601,8 @@ dependencies = [
 name = "tailcall-fixtures"
 version = "0.1.0"
 dependencies = [
- "convert_case 0.6.0",
- "derive_more 0.99.18",
+ "convert_case",
+ "derive_more",
  "indenter",
 ]
 
@@ -5673,8 +5654,8 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "convert_case 0.6.0",
- "derive_more 0.99.18",
+ "convert_case",
+ "derive_more",
  "http 0.2.12",
  "lazy_static",
  "machineid-rs",
@@ -5721,7 +5702,7 @@ dependencies = [
 name = "tailcall-upstream-grpc"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.18",
+ "derive_more",
  "headers",
  "http 0.2.12",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1.40"
 lazy_static = "1.4.0"
 serde_json = { version = "1.0.116", features = ["preserve_order"] }
 serde = { version = "1.0.200", features = ["derive"] }
-derive_more = "1.0.0"
+derive_more = { version = "1.0.0", features = ["display", "debug", "from"]}
 thiserror = "1.0.59"
 url = { version = "2.5.0", features = ["serde"] }
 convert_case = "0.6.0"
@@ -170,7 +170,7 @@ path-clean = "=1.0.1"
 pathdiff = "0.2.1"
 num = "0.4.3"
 indenter = "0.3.3"
-derive_more = { version = "1.0.0", workspace = true, features = ["display", "debug", "from"] }
+derive_more = { workspace = true }
 strum = "0.26.2"
 tailcall-valid = { workspace = true }
 dashmap = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1.40"
 lazy_static = "1.4.0"
 serde_json = { version = "1.0.116", features = ["preserve_order"] }
 serde = { version = "1.0.200", features = ["derive"] }
-derive_more = "0.99.18"
+derive_more = "1.0.0"
 thiserror = "1.0.59"
 url = { version = "2.5.0", features = ["serde"] }
 convert_case = "0.6.0"
@@ -170,7 +170,7 @@ path-clean = "=1.0.1"
 pathdiff = "0.2.1"
 num = "0.4.3"
 indenter = "0.3.3"
-derive_more = { workspace = true }
+derive_more = { version = "1.0.0", workspace = true, features = ["display", "debug", "from"] }
 strum = "0.26.2"
 tailcall-valid = { workspace = true }
 dashmap = "6.1.0"

--- a/src/core/cache/error.rs
+++ b/src/core/cache/error.rs
@@ -1,14 +1,14 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use derive_more::{DebugCustom, From};
+use derive_more::{Debug, From};
 
-#[derive(From, DebugCustom, Clone)]
+#[derive(From, Debug, Clone)]
 pub enum Error {
-    #[debug(fmt = "Serde Json Error: {}", _0)]
+    #[debug("Serde Json Error: {}", _0)]
     SerdeJson(Arc<serde_json::Error>),
 
-    #[debug(fmt = "Kv Error: {}", _0)]
+    #[debug("Kv Error: {}", _0)]
     #[from(ignore)]
     Kv(String),
 }

--- a/src/core/rest/error.rs
+++ b/src/core/rest/error.rs
@@ -3,11 +3,11 @@ use std::str::ParseBoolError;
 
 use async_graphql::parser::types::{Directive, Type};
 use async_graphql::{Name, ServerError};
-use derive_more::{DebugCustom, From};
+use derive_more::{Debug, From};
 use serde_json;
 use tailcall_valid::ValidationError;
 
-#[derive(From, thiserror::Error, DebugCustom)]
+#[derive(From, thiserror::Error, Debug)]
 pub enum Error {
     #[error("Unexpected Named Type: {}", 0.to_string())]
     UnexpectedNamedType(Name),
@@ -19,7 +19,7 @@ pub enum Error {
     SerdeJson(serde_json::Error),
 
     #[error("{msg}: {directive:?}")]
-    #[debug(fmt = "{msg}: {directive:?}")]
+    #[debug("{msg}: {directive:?}")]
     Missing { msg: String, directive: Directive },
 
     #[error("Undefined query param: {}", _0)]
@@ -35,7 +35,7 @@ pub enum Error {
     ParseBoolean(ParseBoolError),
 
     #[error("Undefined param : {key} in {input}")]
-    #[debug(fmt = "Undefined param : {key} in {input}")]
+    #[debug("Undefined param : {key} in {input}")]
     UndefinedParam { key: String, input: String },
 
     #[error("Validation Error : {}", _0)]

--- a/src/core/worker/error.rs
+++ b/src/core/worker/error.rs
@@ -1,62 +1,62 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use derive_more::{DebugCustom, From};
+use derive_more::{Debug, From};
 use tokio::task::JoinError;
 
-#[derive(From, DebugCustom, Clone)]
+#[derive(From, Debug, Clone)]
 pub enum Error {
-    #[debug(fmt = "Failed to initialize worker")]
+    #[debug("Failed to initialize worker")]
     InitializationFailed,
 
-    #[debug(fmt = "Worker communication error")]
+    #[debug("Worker communication error")]
     Communication,
 
-    #[debug(fmt = "Serde Json Error: {}", _0)]
+    #[debug("Serde Json Error: {}", _0)]
     SerdeJson(Arc<serde_json::Error>),
 
-    #[debug(fmt = "Request Clone Failed")]
+    #[debug("Request Clone Failed")]
     RequestCloneFailed,
 
-    #[debug(fmt = "Hyper Header To Str Error: {}", _0)]
+    #[debug("Hyper Header To Str Error: {}", _0)]
     HyperHeaderStr(Arc<http::header::ToStrError>),
 
-    #[debug(fmt = "JS Runtime Stopped Error")]
+    #[debug("JS Runtime Stopped Error")]
     JsRuntimeStopped,
 
-    #[debug(fmt = "CLI Error : {}", _0)]
+    #[debug("CLI Error : {}", _0)]
     CLI(String),
 
-    #[debug(fmt = "Join Error : {}", _0)]
+    #[debug("Join Error : {}", _0)]
     Join(Arc<JoinError>),
 
-    #[debug(fmt = "Runtime not initialized")]
+    #[debug("Runtime not initialized")]
     RuntimeNotInitialized,
 
-    #[debug(fmt = "{} is not a function", _0)]
+    #[debug("{} is not a function", _0)]
     #[from(ignore)]
     InvalidFunction(String),
 
-    #[debug(fmt = "Rquickjs Error: {}", _0)]
+    #[debug("Rquickjs Error: {}", _0)]
     #[from(ignore)]
     Rquickjs(String),
 
-    #[debug(fmt = "Deserialize Failed: {}", _0)]
+    #[debug("Deserialize Failed: {}", _0)]
     #[from(ignore)]
     DeserializeFailed(String),
 
-    #[debug(fmt = "globalThis not initialized: {}", _0)]
+    #[debug("globalThis not initialized: {}", _0)]
     #[from(ignore)]
     GlobalThisNotInitialised(String),
 
     #[debug(
-        fmt = "Error: {}\nUnable to parse value from js function: {} maybe because it's not returning a string?",
+        "Error: {}\nUnable to parse value from js function: {} maybe because it's not returning a string?",
         _0,
         _1
     )]
     FunctionValueParseError(String, String),
 
-    #[debug(fmt = "Error : {}", _0)]
+    #[debug("Error : {}", _0)]
     Anyhow(Arc<anyhow::Error>),
 }
 

--- a/tailcall-fixtures/error.rs
+++ b/tailcall-fixtures/error.rs
@@ -1,16 +1,16 @@
 use std::fmt::Display;
 
-use derive_more::{DebugCustom, From};
+use derive_more::{Debug, From};
 
-#[derive(From, DebugCustom)]
+#[derive(From, Debug)]
 pub enum Error {
-    #[debug(fmt = "Std Fmt Error: {}", _0)]
+    #[debug("Std Fmt Error: {}", _0)]
     StdFmt(std::fmt::Error),
 
-    #[debug(fmt = "Std IO Error: {}", _0)]
+    #[debug("Std IO Error: {}", _0)]
     IO(std::io::Error),
 
-    #[debug(fmt = "Failed to resolve filename: {}", _0)]
+    #[debug("Failed to resolve filename: {}", _0)]
     FilenameNotResolved(String),
 }
 

--- a/tailcall-tracker/src/error.rs
+++ b/tailcall-tracker/src/error.rs
@@ -1,27 +1,27 @@
-use derive_more::{DebugCustom, From};
+use derive_more::{Debug, From};
 use reqwest::header::InvalidHeaderValue;
 
-#[derive(From, DebugCustom)]
+#[derive(From, Debug)]
 pub enum Error {
-    #[debug(fmt = "Reqwest Error: {}", _0)]
+    #[debug("Reqwest Error: {}", _0)]
     Reqwest(reqwest::Error),
 
-    #[debug(fmt = "Invalid Header Value: {}", _0)]
+    #[debug("Invalid Header Value: {}", _0)]
     InvalidHeaderValue(InvalidHeaderValue),
 
-    #[debug(fmt = "Serde JSON Error: {}", _0)]
+    #[debug("Serde JSON Error: {}", _0)]
     SerdeJson(serde_json::Error),
 
-    #[debug(fmt = "Url Parser Error: {}", _0)]
+    #[debug("Url Parser Error: {}", _0)]
     UrlParser(url::ParseError),
 
-    #[debug(fmt = "PostHog Error: {}", _0)]
+    #[debug("PostHog Error: {}", _0)]
     PostHog(posthog_rs::Error),
 
-    #[debug(fmt = "Tokio Join Error: {}", _0)]
+    #[debug("Tokio Join Error: {}", _0)]
     TokioJoin(tokio::task::JoinError),
 
-    #[debug(fmt = "IO Error: {}", _0)]
+    #[debug("IO Error: {}", _0)]
     IO(std::io::Error),
 }
 


### PR DESCRIPTION
**Summary:**  
- Upgrade `derive_more` to `1.0.0`

**Issue Reference(s):**  
Fixes #3148
/claim #3148

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
