### PR TITLE
chore: migrate to serde_yaml_ng instead of serde_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,10 +5072,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.6.0",
  "itoa",
@@ -5518,7 +5518,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_qs",
  "serde_urlencoded",
- "serde_yaml",
+ "serde_yaml_ng",
  "stripmargin",
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ thiserror = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 serde_qs = "0.13"
-serde_yaml = "0.9.34"
+serde_yaml_ng = "0.10.0"
 serde_urlencoded = "0.7.1"
 url = { workspace = true }
 indexmap = { workspace = true }

--- a/src/cli/generator/generator.rs
+++ b/src/cli/generator/generator.rs
@@ -87,7 +87,7 @@ impl Generator {
 
         let config: Config = match source {
             ConfigSource::Json => serde_json::from_str(&config_content)?,
-            ConfigSource::Yml => serde_yaml::from_str(&config_content)?,
+            ConfigSource::Yml => serde_yaml_ng::from_str(&config_content)?,
         };
 
         config.into_resolved(config_path)

--- a/src/cli/tc/init.rs
+++ b/src/cli/tc/init.rs
@@ -55,10 +55,10 @@ pub(super) async fn init_command(runtime: TargetRuntime, folder_path: &str) -> R
     Ok(())
 }
 
-fn default_graphqlrc() -> serde_yaml::Value {
-    serde_yaml::Value::Mapping(serde_yaml::mapping::Mapping::from_iter([(
+fn default_graphqlrc() -> serde_yaml_ng::Value {
+    serde_yaml_ng::Value::Mapping(serde_yaml_ng::mapping::Mapping::from_iter([(
         "schema".into(),
-        serde_yaml::Value::Sequence(vec!["./.tailcallrc.graphql".into(), "./*.graphql".into()]),
+        serde_yaml_ng::Value::Sequence(vec!["./.tailcallrc.graphql".into(), "./*.graphql".into()]),
     )]))
 }
 
@@ -72,13 +72,13 @@ async fn confirm_and_write_yml(
 
     match runtime.file.read(yml_file_path.as_ref()).await {
         Ok(yml_content) => {
-            let graphqlrc: serde_yaml::Value = serde_yaml::from_str(&yml_content)?;
+            let graphqlrc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yml_content)?;
             final_graphqlrc = graphqlrc.merge_right(final_graphqlrc);
-            let content = serde_yaml::to_string(&final_graphqlrc)?;
+            let content = serde_yaml_ng::to_string(&final_graphqlrc)?;
             confirm_and_write(runtime.clone(), &yml_file_path, content.as_bytes()).await
         }
         Err(_) => {
-            let content = serde_yaml::to_string(&final_graphqlrc)?;
+            let content = serde_yaml_ng::to_string(&final_graphqlrc)?;
             runtime.file.write(&yml_file_path, content.as_bytes()).await
         }
     }

--- a/src/core/blueprint/operators/resolver.rs
+++ b/src/core/blueprint/operators/resolver.rs
@@ -21,13 +21,9 @@ pub fn compile_resolver(
     let CompileResolver { config_module, field, operation_type, object_name } = inputs;
 
     match resolver {
-        Resolver::Http(http) => compile_http(
-            config_module,
-            http,
-            // inner resolver should resolve only single instance of type, not a list
-            field,
-        )
-        .trace(config::Http::trace_name().as_str()),
+        Resolver::Http(http) => {
+            compile_http(config_module, http, field).trace(config::Http::trace_name().as_str())
+        }
         Resolver::Grpc(grpc) => compile_grpc(super::CompileGrpc {
             config_module,
             operation_type,

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -387,7 +387,7 @@ impl Config {
     }
 
     pub fn to_yaml(&self) -> Result<String> {
-        Ok(serde_yaml::to_string(self)?)
+        Ok(serde_yaml_ng::to_string(self)?)
     }
 
     pub fn to_json(&self, pretty: bool) -> Result<String> {
@@ -428,7 +428,7 @@ impl Config {
     }
 
     pub fn from_yaml(yaml: &str) -> Result<Self> {
-        Ok(serde_yaml::from_str(yaml)?)
+        Ok(serde_yaml_ng::from_str(yaml)?)
     }
 
     pub fn from_sdl(sdl: &str) -> Valid<Self, String> {

--- a/src/core/merge_right.rs
+++ b/src/core/merge_right.rs
@@ -128,9 +128,9 @@ impl MergeRight for async_graphql_value::ConstValue {
     }
 }
 
-impl MergeRight for serde_yaml::Value {
+impl MergeRight for serde_yaml_ng::Value {
     fn merge_right(self, other: Self) -> Self {
-        use serde_yaml::Value;
+        use serde_yaml_ng::Value;
 
         match (self, other) {
             (Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_), other) => other,

--- a/tests/cli/parser.rs
+++ b/tests/cli/parser.rs
@@ -106,7 +106,7 @@ impl ExecutionSpec {
                             "env" => {
                                 let vars: HashMap<String, String> = match source {
                                     Source::Json => Ok(serde_json::from_str(&content)?),
-                                    Source::Yml => Ok(serde_yaml::from_str(&content)?),
+                                    Source::Yml => Ok(serde_yaml_ng::from_str(&content)?),
                                     _ => Err(anyhow!("Unexpected language in env block in {:?} (only JSON and YAML are supported)", path)),
                                 }?;
 

--- a/tests/core/parse.rs
+++ b/tests/core/parse.rs
@@ -179,7 +179,7 @@ impl ExecutionSpec {
                                     if mock.is_none() {
                                         mock = match source {
                                             Source::Json => Ok(serde_json::from_str(&content)?),
-                                            Source::Yml => Ok(serde_yaml::from_str(&content)?),
+                                            Source::Yml => Ok(serde_yaml_ng::from_str(&content)?),
                                             _ => Err(anyhow!("Unexpected language in mock block in {:?} (only JSON and YAML are supported)", path)),
                                         }?;
                                     } else {
@@ -190,7 +190,7 @@ impl ExecutionSpec {
                                     if env.is_none() {
                                         env = match source {
                                             Source::Json => Ok(serde_json::from_str(&content)?),
-                                            Source::Yml => Ok(serde_yaml::from_str(&content)?),
+                                            Source::Yml => Ok(serde_yaml_ng::from_str(&content)?),
                                             _ => Err(anyhow!("Unexpected language in env block in {:?} (only JSON and YAML are supported)", path)),
                                         }?;
                                     } else {
@@ -201,7 +201,7 @@ impl ExecutionSpec {
                                     if test.is_none() {
                                         test = match source {
                                             Source::Json => Ok(serde_json::from_str(&content)?),
-                                            Source::Yml => Ok(serde_yaml::from_str(&content)?),
+                                            Source::Yml => Ok(serde_yaml_ng::from_str(&content)?),
                                             _ => Err(anyhow!("Unexpected language in test block in {:?} (only JSON and YAML are supported)", path)),
                                         }?;
                                     } else {


### PR DESCRIPTION
[serde_yaml](https://github.com/dtolnay/serde-yaml) is deprecated and not maintained anymore. The [serde_yaml_ng](https://github.com/acatton/serde-yaml-ng) is the fork of the original repo

**Issue Reference(s):**  
Fixes #... _(Replace "..." with the issue number)_

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
