### PR TITLE
feat(gen): support proto_paths for gen graphql through proto file

### DIFF
--- a/src/cli/generator/generator.rs
+++ b/src/cli/generator/generator.rs
@@ -135,9 +135,11 @@ impl Generator {
                         headers: headers.into_btree_map(),
                     });
                 }
-                Source::Proto { src, url, connect_rpc } => {
+                Source::Proto { src, url, proto_paths, connect_rpc } => {
                     let path = src.0;
-                    let mut metadata = proto_reader.read(&path).await?;
+                    let proto_paths =
+                        proto_paths.map(|paths| paths.into_iter().map(|l| l.0).collect::<Vec<_>>());
+                    let mut metadata = proto_reader.read(&path, proto_paths.as_deref()).await?;
                     if let Some(relative_path_to_proto) = to_relative_path(output_dir, &path) {
                         metadata.path = relative_path_to_proto;
                     }

--- a/src/core/config/reader.rs
+++ b/src/core/config/reader.rs
@@ -87,7 +87,7 @@ impl ConfigReader {
                     }
                 }
                 LinkType::Protobuf => {
-                    let meta = self.proto_reader.read(path).await?;
+                    let meta = self.proto_reader.read(path, None).await?;
                     extensions.add_proto(meta);
                 }
                 LinkType::Script => {

--- a/tailcall-fixtures/fixtures/protobuf/news_proto_paths.proto
+++ b/tailcall-fixtures/fixtures/protobuf/news_proto_paths.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package news;
+
+import "protobuf/news_dto.proto";
+import "google/protobuf/empty.proto";
+
+service NewsService {
+  rpc GetAllNews(google.protobuf.Empty) returns (NewsList) {}
+  rpc GetNews(NewsId) returns (News) {}
+  rpc GetMultipleNews(MultipleNewsId) returns (NewsList) {}
+  rpc DeleteNews(NewsId) returns (google.protobuf.Empty) {}
+  rpc EditNews(News) returns (News) {}
+  rpc AddNews(News) returns (News) {}
+}

--- a/tests/cli/fixtures/generator/gen_proto_with_proto_paths_config.md
+++ b/tests/cli/fixtures/generator/gen_proto_with_proto_paths_config.md
@@ -1,0 +1,33 @@
+```json @config
+{
+  "inputs": [
+    {
+      "curl": {
+        "src": "http://jsonplaceholder.typicode.com/users",
+        "fieldName": "users"
+      }
+    },
+    {
+      "proto": {
+        "src": "tailcall-fixtures/fixtures/protobuf/news_proto_paths.proto",
+        "url": "http://localhost:50051",
+        "protoPaths": [
+          "tailcall-fixtures/fixtures/"
+        ]
+      }
+    }
+  ],
+  "preset": {
+    "mergeType": 1.0,
+    "inferTypeNames": true,
+    "treeShake": true
+  },
+  "output": {
+    "path": "./output.graphql",
+    "format": "graphQL"
+  },
+  "schema": {
+    "query": "Query"
+  }
+}
+```

--- a/tests/cli/fixtures/generator/gen_proto_with_proto_paths_config.md
+++ b/tests/cli/fixtures/generator/gen_proto_with_proto_paths_config.md
@@ -11,9 +11,7 @@
       "proto": {
         "src": "tailcall-fixtures/fixtures/protobuf/news_proto_paths.proto",
         "url": "http://localhost:50051",
-        "protoPaths": [
-          "tailcall-fixtures/fixtures/"
-        ]
+        "protoPaths": ["tailcall-fixtures/fixtures/"]
       }
     }
   ],

--- a/tests/cli/snapshots/cli_spec__test__generator_spec__tests__cli__fixtures__generator__gen_proto_with_proto_paths_config.md.snap
+++ b/tests/cli/snapshots/cli_spec__test__generator_spec__tests__cli__fixtures__generator__gen_proto_with_proto_paths_config.md.snap
@@ -1,0 +1,81 @@
+---
+source: tests/cli/gen.rs
+expression: config.to_sdl()
+---
+schema @server @upstream {
+  query: Query
+}
+
+input GEN__news__MultipleNewsId {
+  ids: [Id]
+}
+
+input GEN__news__NewsInput {
+  body: String
+  id: Int
+  postImage: String
+  status: Status
+  title: String
+}
+
+input Id {
+  id: Int
+}
+
+enum Status {
+  DELETED
+  DRAFT
+  PUBLISHED
+}
+
+type Address {
+  city: String
+  geo: Geo
+  street: String
+  suite: String
+  zipcode: String
+}
+
+type Company {
+  bs: String
+  catchPhrase: String
+  name: String
+}
+
+type GEN__news__NewsList {
+  news: [News]
+}
+
+type Geo {
+  lat: String
+  lng: String
+}
+
+type News {
+  body: String
+  id: Int
+  postImage: String
+  status: Status
+  title: String
+}
+
+type Query {
+  GEN__news__NewsService__AddNews(news: GEN__news__NewsInput!): News @grpc(url: "http://localhost:50051", body: "{{.args.news}}", method: "news.NewsService.AddNews")
+  GEN__news__NewsService__DeleteNews(newsId: Id!): Empty @grpc(url: "http://localhost:50051", body: "{{.args.newsId}}", method: "news.NewsService.DeleteNews")
+  GEN__news__NewsService__EditNews(news: GEN__news__NewsInput!): News @grpc(url: "http://localhost:50051", body: "{{.args.news}}", method: "news.NewsService.EditNews")
+  GEN__news__NewsService__GetAllNews: GEN__news__NewsList @grpc(url: "http://localhost:50051", method: "news.NewsService.GetAllNews")
+  GEN__news__NewsService__GetMultipleNews(multipleNewsId: GEN__news__MultipleNewsId!): GEN__news__NewsList @grpc(url: "http://localhost:50051", body: "{{.args.multipleNewsId}}", method: "news.NewsService.GetMultipleNews")
+  GEN__news__NewsService__GetNews(newsId: Id!): News @grpc(url: "http://localhost:50051", body: "{{.args.newsId}}", method: "news.NewsService.GetNews")
+  users: [User] @http(url: "http://jsonplaceholder.typicode.com/users")
+}
+
+type User {
+  address: Address
+  company: Company
+  email: String
+  id: Int
+  name: String
+  phone: String
+  username: String
+  website: String
+}


### PR DESCRIPTION
**Summary:**  

Currently, when using the `tailcall gen` command to process proto files, the import path is fixed to a relative path, but in the [protobuf import syntax](https://protobuf.dev/programming-guides/proto3/#importing), you can specify the path to find the dependency using the `-I/--proto_path` flag. So, most proto projects are currently organized in this way, and I think we also need to support it.

```jsonc
{
  "inputs": [
    {
      "proto": {
        "src": "./proto/apps/mian.proto",
        "url": "http://localhost:8080",
        // new params
        "protoPaths": ["./proto/apps"]
      }
    }
  ],
  "preset": {
    "mergeType": 1.0
  },
  "output": {
    "path": "./output/main.graphql",
    "format": "graphQL"
  },
  "schema": {
    "query": "Query"
  }
}
```

**Issue Reference(s):**  

None

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
