### PR TITLE
feat(link): add `proto_paths` support

### DIFF
--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -269,6 +269,16 @@
         "meta": {
           "description": "Additional metadata pertaining to the linked resource."
         },
+        "proto_paths": {
+          "description": "The proto paths to be used when resolving dependencies. Only valid when [`Link::type_of`] is [`LinkType::Protobuf`]",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "src": {
           "description": "The source of the link. It can be a URL or a path to a file. If a path is provided, it is relative to the file that imports the link.",
           "type": "string"

--- a/src/core/config/directives/link.rs
+++ b/src/core/config/directives/link.rs
@@ -93,4 +93,9 @@ pub struct Link {
     /// Additional metadata pertaining to the linked resource.
     #[serde(default, skip_serializing_if = "is_default")]
     pub meta: Option<serde_json::Value>,
+    ///
+    /// The proto paths to be used when resolving dependencies.
+    /// Only valid when [`Link::type_of`] is [`LinkType::Protobuf`]
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub proto_paths: Option<Vec<String>>,
 }

--- a/src/core/config/reader.rs
+++ b/src/core/config/reader.rs
@@ -79,7 +79,13 @@ impl ConfigReader {
                     });
                 }
                 LinkType::Protobuf => {
-                    let meta = self.proto_reader.read(path, None).await?;
+                    let proto_paths = link.proto_paths.as_ref().map(|paths| {
+                        paths
+                            .iter()
+                            .map(|p| Self::resolve_path(p, parent_dir))
+                            .collect::<Vec<_>>()
+                    });
+                    let meta = self.proto_reader.read(path, proto_paths.as_deref()).await?;
                     extensions.add_proto(meta);
                 }
                 LinkType::Script => {

--- a/src/core/generator/generator.rs
+++ b/src/core/generator/generator.rs
@@ -99,6 +99,7 @@ impl Generator {
             type_of: LinkType::Protobuf,
             headers: None,
             meta: None,
+            proto_paths: None,
         });
         Ok(config)
     }

--- a/src/core/grpc/data_loader_request.rs
+++ b/src/core/grpc/data_loader_request.rs
@@ -74,6 +74,7 @@ mod tests {
             type_of: LinkType::Protobuf,
             headers: None,
             meta: None,
+            proto_paths: None,
         }]);
         let method = GrpcMethod {
             package: "greetings".to_string(),

--- a/src/core/grpc/request_template.rs
+++ b/src/core/grpc/request_template.rs
@@ -160,6 +160,7 @@ mod tests {
             type_of: LinkType::Protobuf,
             headers: None,
             meta: None,
+            proto_paths: None,
         }]);
         let method = GrpcMethod {
             package: id.to_string(),


### PR DESCRIPTION
**Summary:**  
Previously, this [pr[3206]](https://github.com/tailcallhq/tailcall/pull/3206) only processed the `proto_paths` during gen, but when using `tailcall start`, there will still be path problems, so it is necessary to save the` proto_paths` information on the link to ensure that the path can be processed correctly during `tailcall start`.

Config:
```json
{
  "inputs": [
    {
      "proto": {
        "src": "news.proto",
        "url": "http://localhost:50051",
        "protoPaths": ["tailcall-fixtures/fixtures/protobuf"]
      }
    }
  ],

  ...
}
```

Output:
```graphql
schema
  @server
  @upstream
  @link(
    src: "news.proto"
    # new attr
    proto_paths: ["tailcall-fixtures/fixtures/protobuf"]
    type: Protobuf
  ) {
  query: Query
}
...
```

**Issue Reference(s):**  
None

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
