### PR TITLE
test: migrate to runtime config

### DIFF
--- a/generated/.tailcallrc.schema.json
+++ b/generated/.tailcallrc.schema.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "RuntimeConfig",
   "type": "object",
-  "required": [
-    "links"
-  ],
   "properties": {
     "links": {
       "description": "A list of all links in the schema.",
@@ -15,7 +12,6 @@
     },
     "server": {
       "description": "Dictates how the server behaves and helps tune tailcall for all ingress requests. Features such as request batching, SSL, HTTP2 etc. can be configured here.",
-      "default": {},
       "allOf": [
         {
           "$ref": "#/definitions/Server"
@@ -32,7 +28,6 @@
     },
     "upstream": {
       "description": "Dictates how tailcall should handle upstream requests/responses. Tuning upstream can improve performance and reliability for connections.",
-      "default": {},
       "allOf": [
         {
           "$ref": "#/definitions/Upstream"

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -43,17 +43,18 @@ pub struct RuntimeConfig {
     /// Dictates how the server behaves and helps tune tailcall for all ingress
     /// requests. Features such as request batching, SSL, HTTP2 etc. can be
     /// configured here.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub server: Server,
 
     ///
     /// Dictates how tailcall should handle upstream requests/responses.
     /// Tuning upstream can improve performance and reliability for connections.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub upstream: Upstream,
 
     ///
     /// A list of all links in the schema.
+    #[serde(default, skip_serializing_if = "is_default")]
     pub links: Vec<Link>,
 
     /// Enable [opentelemetry](https://opentelemetry.io) support

--- a/src/core/config/transformer/subgraph.rs
+++ b/src/core/config/transformer/subgraph.rs
@@ -59,7 +59,12 @@ impl Transform for Subgraph {
                             let key = Key { fields };
 
                             to_directive(key.to_directive()).map(|directive| {
-                                ty.directives.push(directive);
+                                // Prevent transformer to push the same directive multiple times
+                                if !ty.directives.iter().any(|d| {
+                                    d.name == directive.name && d.arguments == directive.arguments
+                                }) {
+                                    ty.directives.push(directive);
+                                }
                             })
                         }
                         None => Valid::succeed(()),

--- a/tests/core/runtime.rs
+++ b/tests/core/runtime.rs
@@ -10,7 +10,7 @@ use derive_setters::Setters;
 use tailcall::cli::javascript::init_worker_io;
 use tailcall::core::blueprint::Script;
 use tailcall::core::cache::InMemoryCache;
-use tailcall::core::config::Source;
+use tailcall::core::config::RuntimeConfig;
 use tailcall::core::runtime::TargetRuntime;
 use tailcall::core::worker::{Command, Event};
 
@@ -25,7 +25,7 @@ pub struct ExecutionSpec {
     pub name: String,
     pub safe_name: String,
 
-    pub server: Vec<(Source, String)>,
+    pub config: RuntimeConfig,
     pub mock: Option<Vec<Mock>>,
     pub env: Option<HashMap<String, String>>,
     pub test: Option<Vec<APIRequest>>,

--- a/tests/core/snapshots/add-field-index-list.md_merged.snap
+++ b/tests/core/snapshots/add-field-index-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/add-field-many-list.md_merged.snap
+++ b/tests/core/snapshots/add-field-many-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/add-field-many.md_merged.snap
+++ b/tests/core/snapshots/add-field-many.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/add-field-modify.md_merged.snap
+++ b/tests/core/snapshots/add-field-modify.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/add-field-with-composition.md_merged.snap
+++ b/tests/core/snapshots/add-field-with-composition.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/add-field-with-modify.md_merged.snap
+++ b/tests/core/snapshots/add-field-with-modify.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/add-field.md_merged.snap
+++ b/tests/core/snapshots/add-field.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/apollo-federation-entities-batch.md_merged.snap
+++ b/tests/core/snapshots/apollo-federation-entities-batch.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(enableFederation: true, port: 8000) @upstream(batch: {delay: 100, headers: []}, httpCache: 42) {
+schema
+  @server(enableFederation: true, port: 8000)
+  @upstream(batch: {delay: 100, headers: []}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/apollo-federation-entities.md_merged.snap
+++ b/tests/core/snapshots/apollo-federation-entities.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(enableFederation: true, port: 8000)
   @upstream(batch: {delay: 100, headers: []}, httpCache: 42)
-  @link(src: "./posts.graphql", type: Config) {
+  @link(src: "./posts.graphql", type: Config)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/apollo-tracing.md_merged.snap
+++ b/tests/core/snapshots/apollo-tracing.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8000) @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/async-cache-disabled.md_merged.snap
+++ b/tests/core/snapshots/async-cache-disabled.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000, queryValidation: false) @upstream {
+schema @server(port: 8000, queryValidation: false) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/async-cache-enable-multiple-resolvers.md_merged.snap
+++ b/tests/core/snapshots/async-cache-enable-multiple-resolvers.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000, queryValidation: false) @upstream {
+schema @server(port: 8000, queryValidation: false) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/async-cache-enabled.md_merged.snap
+++ b/tests/core/snapshots/async-cache-enabled.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000, queryValidation: false) @upstream {
+schema @server(port: 8000, queryValidation: false) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/async-cache-global.md_merged.snap
+++ b/tests/core/snapshots/async-cache-global.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000, queryValidation: false) @upstream {
+schema @server(port: 8000, queryValidation: false) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/async-cache-inflight-request.md_merged.snap
+++ b/tests/core/snapshots/async-cache-inflight-request.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000, queryValidation: false) @upstream {
+schema @server(port: 8000, queryValidation: false) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/auth-basic.md_merged.snap
+++ b/tests/core/snapshots/auth-basic.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd) {
+schema
+  @server(port: 8000)
+  @upstream
+  @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/auth-jwt.md_merged.snap
+++ b/tests/core/snapshots/auth-jwt.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream @link(id: "jwks", src: "jwks.json", type: Jwks) {
+schema
+  @server(port: 8000)
+  @upstream
+  @link(id: "jwks", src: "jwks.json", type: Jwks)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/auth-multiple-complex.md_merged.snap
+++ b/tests/core/snapshots/auth-multiple-complex.md_merged.snap
@@ -8,7 +8,8 @@ schema
   @upstream
   @link(id: "a", src: ".htpasswd_a", type: Htpasswd)
   @link(id: "b", src: ".htpasswd_b", type: Htpasswd)
-  @link(id: "c", src: ".htpasswd_c", type: Htpasswd) {
+  @link(id: "c", src: ".htpasswd_c", type: Htpasswd)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/auth-multiple.md_merged.snap
+++ b/tests/core/snapshots/auth-multiple.md_merged.snap
@@ -8,7 +8,8 @@ schema
   @upstream
   @link(id: "a", src: ".htpasswd_a", type: Htpasswd)
   @link(id: "b", src: ".htpasswd_b", type: Htpasswd)
-  @link(id: "c", src: ".htpasswd_c", type: Htpasswd) {
+  @link(id: "c", src: ".htpasswd_c", type: Htpasswd)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/auth.md_merged.snap
+++ b/tests/core/snapshots/auth.md_merged.snap
@@ -7,7 +7,8 @@ schema
   @server
   @upstream
   @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd)
-  @link(id: "jwks", src: "jwks.json", type: Jwks) {
+  @link(id: "jwks", src: "jwks.json", type: Jwks)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/auth_order.md_merged.snap
+++ b/tests/core/snapshots/auth_order.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd) {
+schema
+  @server
+  @upstream
+  @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/batching-default.md_merged.snap
+++ b/tests/core/snapshots/batching-default.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 10, headers: []}, httpCache: 42) {
+schema @server @upstream(batch: {delay: 10, headers: []}, httpCache: 42) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/batching-disabled.md_merged.snap
+++ b/tests/core/snapshots/batching-disabled.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 0, headers: [], maxSize: 100}, httpCache: 42) {
+schema
+  @server
+  @upstream(batch: {delay: 0, headers: [], maxSize: 100}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/batching-group-by-default.md_merged.snap
+++ b/tests/core/snapshots/batching-group-by-default.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42) {
+schema
+  @server
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/batching-group-by-optional-key.md_merged.snap
+++ b/tests/core/snapshots/batching-group-by-optional-key.md_merged.snap
@@ -5,7 +5,8 @@ snapshot_kind: text
 ---
 schema
   @server(port: 8000, queryValidation: false)
-  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42) {
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/batching-group-by.md_merged.snap
+++ b/tests/core/snapshots/batching-group-by.md_merged.snap
@@ -5,7 +5,8 @@ snapshot_kind: text
 ---
 schema
   @server(port: 8000, queryValidation: false)
-  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42) {
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/batching-post.md_merged.snap
+++ b/tests/core/snapshots/batching-post.md_merged.snap
@@ -5,7 +5,8 @@ snapshot_kind: text
 ---
 schema
   @server(port: 8000, queryValidation: false)
-  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42) {
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/batching.md_merged.snap
+++ b/tests/core/snapshots/batching.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(batchRequests: true) @upstream {
+schema @server(batchRequests: true) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/body-batching-cases.md_merged.snap
+++ b/tests/core/snapshots/body-batching-cases.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream(batch: {delay: 1, headers: []}, httpCache: 42) {
+schema
+  @server(port: 8000)
+  @upstream(batch: {delay: 1, headers: []}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/body-batching.md_merged.snap
+++ b/tests/core/snapshots/body-batching.md_merged.snap
@@ -5,7 +5,8 @@ snapshot_kind: text
 ---
 schema
   @server(port: 8000, queryValidation: false)
-  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42) {
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/cache-control.md_merged.snap
+++ b/tests/core/snapshots/cache-control.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(headers: {cacheControl: true}) @upstream {
+schema @server(headers: {cacheControl: true}) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/caching-collision.md_merged.snap
+++ b/tests/core/snapshots/caching-collision.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/caching.md_merged.snap
+++ b/tests/core/snapshots/caching.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/call-graphql-datasource.md_merged.snap
+++ b/tests/core/snapshots/call-graphql-datasource.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8000) @upstream(httpCache: 42) {
+schema @server(hostname: "0.0.0.0", port: 8000) @upstream(httpCache: 42) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/call-multiple-steps-piping.md_merged.snap
+++ b/tests/core/snapshots/call-multiple-steps-piping.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/call-mutation.md_merged.snap
+++ b/tests/core/snapshots/call-mutation.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/call-operator.md_merged.snap
+++ b/tests/core/snapshots/call-operator.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(hostname: "0.0.0.0", port: 8000)
   @upstream(httpCache: 42)
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/cors-allow-cred-false.md_merged.snap
+++ b/tests/core/snapshots/cors-allow-cred-false.md_merged.snap
@@ -16,7 +16,8 @@ schema
       }
     }
   )
-  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000})
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/cors-allow-cred-true.md_merged.snap
+++ b/tests/core/snapshots/cors-allow-cred-true.md_merged.snap
@@ -16,7 +16,8 @@ schema
       }
     }
   )
-  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000})
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/cors-allow-cred-vary.md_merged.snap
+++ b/tests/core/snapshots/cors-allow-cred-vary.md_merged.snap
@@ -16,7 +16,8 @@ schema
       }
     }
   )
-  @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000})
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/custom-headers.md_merged.snap
+++ b/tests/core/snapshots/custom-headers.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(headers: {custom: [{key: "x-id", value: "1"}, {key: "x-name", value: "John Doe"}]}) @upstream {
+schema
+  @server(headers: {custom: [{key: "x-id", value: "1"}, {key: "x-name", value: "John Doe"}]})
+  @upstream
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/custom-scalars.md_merged.snap
+++ b/tests/core/snapshots/custom-scalars.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/dedupe_batch_query_execution.md_merged.snap
+++ b/tests/core/snapshots/dedupe_batch_query_execution.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000, queryValidation: false) @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/default-value-arg.md_merged.snap
+++ b/tests/core/snapshots/default-value-arg.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/default-value-config.md_merged.snap
+++ b/tests/core/snapshots/default-value-config.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/enum-args.md_merged.snap
+++ b/tests/core/snapshots/enum-args.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/env-value.md_merged.snap
+++ b/tests/core/snapshots/env-value.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/experimental-headers.md_merged.snap
+++ b/tests/core/snapshots/experimental-headers.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(headers: {experimental: ["X-experimental", "x-tailcall"]}) @upstream {
+schema
+  @server(headers: {experimental: ["X-experimental", "x-tailcall"]})
+  @upstream
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/federation-subgraph-force-disabled.md_merged.snap
+++ b/tests/core/snapshots/federation-subgraph-force-disabled.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(enableFederation: false, port: 8000) @upstream(batch: {delay: 100, headers: []}, httpCache: 42) {
+schema
+  @server(enableFederation: false, port: 8000)
+  @upstream(batch: {delay: 100, headers: []}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/federation-subgraph-force-enabled.md_merged.snap
+++ b/tests/core/snapshots/federation-subgraph-force-enabled.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(enableFederation: true, port: 8000) @upstream(batch: {delay: 100, headers: []}, httpCache: 42) {
+schema
+  @server(enableFederation: true, port: 8000)
+  @upstream(batch: {delay: 100, headers: []}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/federation-subgraph-no-entities.md_merged.snap
+++ b/tests/core/snapshots/federation-subgraph-no-entities.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream(batch: {delay: 100, headers: []}, httpCache: 42) {
+schema
+  @server(port: 8000)
+  @upstream(batch: {delay: 100, headers: []}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-001.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-001.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-003.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-003.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-010.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-010.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-013.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-013.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-014.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-014.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-015.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-015.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-018.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-018.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-001.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-001.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-002.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-002.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-003.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-003.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-004.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-004.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-005.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-005.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-006.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-006.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-007.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-007.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-008.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-008.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-010.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-010.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-012.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-012.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-013.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-013.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-014.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-014.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-015.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-015.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-http-017.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-http-017.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-nested-lists-fragment.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-nested-lists-fragment.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-nested-lists-http.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-nested-lists-http.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-conformance-nested-lists.md_merged.snap
+++ b/tests/core/snapshots/graphql-conformance-nested-lists.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-dataloader-batch-request.md_merged.snap
+++ b/tests/core/snapshots/graphql-dataloader-batch-request.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: []}) {
+schema @server @upstream(batch: {delay: 1, headers: []}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-dataloader-no-batch-request.md_merged.snap
+++ b/tests/core/snapshots/graphql-dataloader-no-batch-request.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: []}) {
+schema @server @upstream(batch: {delay: 1, headers: []}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-datasource-errors.md_merged.snap
+++ b/tests/core/snapshots/graphql-datasource-errors.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-datasource-mutation.md_merged.snap
+++ b/tests/core/snapshots/graphql-datasource-mutation.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/graphql-datasource-no-args.md_merged.snap
+++ b/tests/core/snapshots/graphql-datasource-no-args.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-datasource-query-directives.md_merged.snap
+++ b/tests/core/snapshots/graphql-datasource-query-directives.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-datasource-with-args.md_merged.snap
+++ b/tests/core/snapshots/graphql-datasource-with-args.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-datasource-with-empty-enum.md_merged.snap
+++ b/tests/core/snapshots/graphql-datasource-with-empty-enum.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-datasource-with-mandatory-enum.md_merged.snap
+++ b/tests/core/snapshots/graphql-datasource-with-mandatory-enum.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-nested-datasource.md_merged.snap
+++ b/tests/core/snapshots/graphql-nested-datasource.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/graphql-nested.md_merged.snap
+++ b/tests/core/snapshots/graphql-nested.md_merged.snap
@@ -1,8 +1,9 @@
 ---
 source: tests/core/spec.rs
 expression: formatter
+snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8000) @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-batch.md_merged.snap
+++ b/tests/core/snapshots/grpc-batch.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: []}, httpCache: 42)
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-error.md_merged.snap
+++ b/tests/core/snapshots/grpc-error.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: []}, httpCache: 42)
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-json.md_merged.snap
+++ b/tests/core/snapshots/grpc-json.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream @link(id: "news", src: "news.proto", type: Protobuf) {
+schema
+  @server(port: 8000)
+  @upstream
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-map.md_merged.snap
+++ b/tests/core/snapshots/grpc-map.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: []}, httpCache: 42)
-  @link(src: "map.proto", type: Protobuf) {
+  @link(src: "map.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-proto-with-same-package.md_merged.snap
+++ b/tests/core/snapshots/grpc-proto-with-same-package.md_merged.snap
@@ -3,7 +3,12 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream @link(src: "foo.proto", type: Protobuf) @link(src: "bar.proto", type: Protobuf) {
+schema
+  @server(port: 8000)
+  @upstream
+  @link(src: "foo.proto", type: Protobuf)
+  @link(src: "bar.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-reflection.md_merged.snap
+++ b/tests/core/snapshots/grpc-reflection.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream(httpCache: 42) @link(src: "http://localhost:50051", type: Grpc) {
+schema
+  @server(port: 8000)
+  @upstream(httpCache: 42)
+  @link(src: "http://localhost:50051", type: Grpc)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-simple.md_merged.snap
+++ b/tests/core/snapshots/grpc-simple.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: []}, httpCache: 42)
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/grpc-url-from-upstream.md_merged.snap
+++ b/tests/core/snapshots/grpc-url-from-upstream.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: []}, httpCache: 42)
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/http-select.md_merged.snap
+++ b/tests/core/snapshots/http-select.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/inline-field.md_merged.snap
+++ b/tests/core/snapshots/inline-field.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/inline-index-list.md_merged.snap
+++ b/tests/core/snapshots/inline-index-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/inline-many-list.md_merged.snap
+++ b/tests/core/snapshots/inline-many-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/inline-many.md_merged.snap
+++ b/tests/core/snapshots/inline-many.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/introspection-query-with-disabled-introspection.md_merged.snap
+++ b/tests/core/snapshots/introspection-query-with-disabled-introspection.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", introspection: false, port: 8001, queryValidation: false) @upstream(httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", introspection: false, port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/io-cache.md_merged.snap
+++ b/tests/core/snapshots/io-cache.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8000) @upstream(httpCache: 42) {
+schema @server(hostname: "0.0.0.0", port: 8000) @upstream(httpCache: 42) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/jit-enum-array.md_merged.snap
+++ b/tests/core/snapshots/jit-enum-array.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/js-directive.md_merged.snap
+++ b/tests/core/snapshots/js-directive.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(src: "test.js", type: Script) {
+schema @server @upstream @link(src: "test.js", type: Script) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/jsonplaceholder-call-post.md_merged.snap
+++ b/tests/core/snapshots/jsonplaceholder-call-post.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8000) @upstream(batch: {delay: 100, headers: []}, httpCache: 42) {
+schema
+  @server(hostname: "0.0.0.0", port: 8000)
+  @upstream(batch: {delay: 100, headers: []}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/merge-linked-config.md_merged.snap
+++ b/tests/core/snapshots/merge-linked-config.md_merged.snap
@@ -7,7 +7,8 @@ schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: []}, httpCache: 10)
   @link(src: "link-1.graphql", type: Config)
-  @link(src: "link-2.graphql", type: Config) {
+  @link(src: "link-2.graphql", type: Config)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/modified-field.md_merged.snap
+++ b/tests/core/snapshots/modified-field.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/mutation-put.md_merged.snap
+++ b/tests/core/snapshots/mutation-put.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/mutation.md_merged.snap
+++ b/tests/core/snapshots/mutation.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/n-plus-one-list.md_merged.snap
+++ b/tests/core/snapshots/n-plus-one-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/n-plus-one.md_merged.snap
+++ b/tests/core/snapshots/n-plus-one.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/nested-objects.md_merged.snap
+++ b/tests/core/snapshots/nested-objects.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/nested-recursive-types.md_merged.snap
+++ b/tests/core/snapshots/nested-recursive-types.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/nesting-level3.md_merged.snap
+++ b/tests/core/snapshots/nesting-level3.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/nullable-arg-query.md_merged.snap
+++ b/tests/core/snapshots/nullable-arg-query.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/omit-index-list.md_merged.snap
+++ b/tests/core/snapshots/omit-index-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/omit-many.md_merged.snap
+++ b/tests/core/snapshots/omit-many.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/omit-resolved-by-parent.md_merged.snap
+++ b/tests/core/snapshots/omit-resolved-by-parent.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/on-response-body-grpc.md_merged.snap
+++ b/tests/core/snapshots/on-response-body-grpc.md_merged.snap
@@ -7,7 +7,8 @@ schema
   @server(port: 8000)
   @upstream
   @link(src: "test.js", type: Script)
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/recursive-types.md_merged.snap
+++ b/tests/core/snapshots/recursive-types.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/ref-other-nested.md_merged.snap
+++ b/tests/core/snapshots/ref-other-nested.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/ref-other.md_merged.snap
+++ b/tests/core/snapshots/ref-other.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/related-fields-recursive.md_merged.snap
+++ b/tests/core/snapshots/related-fields-recursive.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8000) @upstream {
+schema @server(hostname: "0.0.0.0", port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/rename-field.md_merged.snap
+++ b/tests/core/snapshots/rename-field.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/request-to-upstream-batching.md_merged.snap
+++ b/tests/core/snapshots/request-to-upstream-batching.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(batchRequests: true) @upstream(batch: {delay: 1, headers: [], maxSize: 100}) {
+schema
+  @server(batchRequests: true)
+  @upstream(batch: {delay: 1, headers: [], maxSize: 100})
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/resolve-with-headers.md_merged.snap
+++ b/tests/core/snapshots/resolve-with-headers.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(allowedHeaders: ["authorization"]) {
+schema @server @upstream(allowedHeaders: ["authorization"]) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/resolve-with-vars.md_merged.snap
+++ b/tests/core/snapshots/resolve-with-vars.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(vars: [{key: "id", value: "1"}]) @upstream {
+schema @server(vars: [{key: "id", value: "1"}]) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/resolved-by-parent.md_merged.snap
+++ b/tests/core/snapshots/resolved-by-parent.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/rest-api-error.md_merged.snap
+++ b/tests/core/snapshots/rest-api-error.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(src: "operation-user.graphql", type: Operation) {
+schema
+  @server
+  @upstream
+  @link(src: "operation-user.graphql", type: Operation)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/rest-api-post.md_merged.snap
+++ b/tests/core/snapshots/rest-api-post.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(src: "operation-user.graphql", type: Operation) {
+schema
+  @server
+  @upstream
+  @link(src: "operation-user.graphql", type: Operation)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/rest-api.md_merged.snap
+++ b/tests/core/snapshots/rest-api.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(src: "operation-user.graphql", type: Operation) {
+schema
+  @server
+  @upstream
+  @link(src: "operation-user.graphql", type: Operation)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/routes-param-on-server-directive.md_merged.snap
+++ b/tests/core/snapshots/routes-param-on-server-directive.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000, routes: {status: "/health", graphQL: "/tailcall-gql"}) @upstream {
+schema
+  @server(port: 8000, routes: {status: "/health", graphQL: "/tailcall-gql"})
+  @upstream
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/showcase.md_merged.snap
+++ b/tests/core/snapshots/showcase.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(showcase: true) @upstream {
+schema @server(showcase: true) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/simple-graphql.md_merged.snap
+++ b/tests/core/snapshots/simple-graphql.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/simple-query.md_merged.snap
+++ b/tests/core/snapshots/simple-query.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-add-field-list.md_merged.snap
+++ b/tests/core/snapshots/test-add-field-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-add-field.md_merged.snap
+++ b/tests/core/snapshots/test-add-field.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-add-link-to-empty-config.md_merged.snap
+++ b/tests/core/snapshots/test-add-link-to-empty-config.md_merged.snap
@@ -3,7 +3,12 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(src: "link-expr.graphql", type: Config) @link(src: "link-enum.graphql", type: Config) {
+schema
+  @server
+  @upstream
+  @link(src: "link-expr.graphql", type: Config)
+  @link(src: "link-enum.graphql", type: Config)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-alias-on-enum.md_merged.snap
+++ b/tests/core/snapshots/test-alias-on-enum.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(batchRequests: true) @upstream(batch: {delay: 1, headers: [], maxSize: 100}) {
+schema
+  @server(batchRequests: true)
+  @upstream(batch: {delay: 1, headers: [], maxSize: 100})
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-batching-group-by.md_merged.snap
+++ b/tests/core/snapshots/test-batching-group-by.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 4000) @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+schema
+  @server(port: 4000)
+  @upstream(batch: {delay: 1, headers: [], maxSize: 1000})
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-cache.md_merged.snap
+++ b/tests/core/snapshots/test-cache.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-custom-scalar.md_merged.snap
+++ b/tests/core/snapshots/test-custom-scalar.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-custom-types.md_merged.snap
+++ b/tests/core/snapshots/test-custom-types.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Que
   mutation: Mut
 }

--- a/tests/core/snapshots/test-dbl-usage-many.md_merged.snap
+++ b/tests/core/snapshots/test-dbl-usage-many.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-dedupe.md_merged.snap
+++ b/tests/core/snapshots/test-dedupe.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream(batch: {delay: 1, headers: []}) {
+schema @server(port: 8000) @upstream(batch: {delay: 1, headers: []}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-description-many.md_merged.snap
+++ b/tests/core/snapshots/test-description-many.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-enable-jit.md_merged.snap
+++ b/tests/core/snapshots/test-enable-jit.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "0.0.0.0", port: 8000) @upstream {
+schema @server(hostname: "0.0.0.0", port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-enum-aliases.md_merged.snap
+++ b/tests/core/snapshots/test-enum-aliases.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-enum-as-argument.md_merged.snap
+++ b/tests/core/snapshots/test-enum-as-argument.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-enum-default.md_merged.snap
+++ b/tests/core/snapshots/test-enum-default.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8080)
   @upstream(batch: {delay: 10, headers: []}, httpCache: 42)
-  @link(id: "news", src: "./service.proto", type: Protobuf) {
+  @link(id: "news", src: "./service.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-enum-description.md_merged.snap
+++ b/tests/core/snapshots/test-enum-description.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-enum-merge.md_client.snap
+++ b/tests/core/snapshots/test-enum-merge.md_client.snap
@@ -1,0 +1,18 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+snapshot_kind: text
+---
+enum Foo {
+  BAR
+  BAZ
+  BOOM
+}
+
+type Query {
+  foo: Foo
+}
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/test-enum-merge.md_merged.snap
+++ b/tests/core/snapshots/test-enum-merge.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) @link(src: "schema_1.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-enum.md_merged.snap
+++ b/tests/core/snapshots/test-enum.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-eval-partial.md_merged.snap
+++ b/tests/core/snapshots/test-eval-partial.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8080) @upstream(batch: {delay: 100, headers: []}, httpCache: 42) {
+schema
+  @server(port: 8080)
+  @upstream(batch: {delay: 100, headers: []}, httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-expr-scalar-as-string.md_merged.snap
+++ b/tests/core/snapshots/test-expr-scalar-as-string.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-expr-with-mustache.md_merged.snap
+++ b/tests/core/snapshots/test-expr-with-mustache.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-expr.md_merged.snap
+++ b/tests/core/snapshots/test-expr.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-graphqlsource.md_merged.snap
+++ b/tests/core/snapshots/test-graphqlsource.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-grpc.md_merged.snap
+++ b/tests/core/snapshots/test-grpc.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: [], maxSize: 1000})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+  @link(id: "news", src: "news.proto", type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-http-baseurl.md_merged.snap
+++ b/tests/core/snapshots/test-http-baseurl.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-http-batchKey.md_merged.snap
+++ b/tests/core/snapshots/test-http-batchKey.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream(batch: {delay: 10, headers: [], maxSize: 1000}) {
+schema
+  @server(port: 8000)
+  @upstream(batch: {delay: 10, headers: [], maxSize: 1000})
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-http-headers.md_merged.snap
+++ b/tests/core/snapshots/test-http-headers.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-http-tmpl.md_merged.snap
+++ b/tests/core/snapshots/test-http-tmpl.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-http-with-mustache-expr.md_merged.snap
+++ b/tests/core/snapshots/test-http-with-mustache-expr.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-http.md_merged.snap
+++ b/tests/core/snapshots/test-http.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-inline-list.md_merged.snap
+++ b/tests/core/snapshots/test-inline-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-inline.md_merged.snap
+++ b/tests/core/snapshots/test-inline.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-input-documentation.md_merged.snap
+++ b/tests/core/snapshots/test-input-documentation.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
   mutation: Mutation
 }

--- a/tests/core/snapshots/test-input-out.md_merged.snap
+++ b/tests/core/snapshots/test-input-out.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-input-with-arg-out.md_merged.snap
+++ b/tests/core/snapshots/test-input-with-arg-out.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-interface-result.md_merged.snap
+++ b/tests/core/snapshots/test-interface-result.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-interface.md_merged.snap
+++ b/tests/core/snapshots/test-interface.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-js-multi-onRequest-handlers.md_merged.snap
+++ b/tests/core/snapshots/test-js-multi-onRequest-handlers.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(onRequest: "foo") @link(src: "test1.js", type: Script) {
+schema
+  @server
+  @upstream(onRequest: "foo")
+  @link(src: "test1.js", type: Script)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-js-request-response-2.md_merged.snap
+++ b/tests/core/snapshots/test-js-request-response-2.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(onRequest: "onRequest") @link(src: "test.js", type: Script) {
+schema
+  @server
+  @upstream(onRequest: "onRequest")
+  @link(src: "test.js", type: Script)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-js-request-response.md_merged.snap
+++ b/tests/core/snapshots/test-js-request-response.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(onRequest: "onRequest") @link(src: "test.js", type: Script) {
+schema
+  @server
+  @upstream(onRequest: "onRequest")
+  @link(src: "test.js", type: Script)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-link-support.md_merged.snap
+++ b/tests/core/snapshots/test-link-support.md_merged.snap
@@ -6,7 +6,8 @@ snapshot_kind: text
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: [], maxSize: 1000})
-  @link(id: "news", src: "news.proto", meta: {description: "Test"}, type: Protobuf) {
+  @link(id: "news", src: "news.proto", meta: {description: "Test"}, type: Protobuf)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-list-args.md_merged.snap
+++ b/tests/core/snapshots/test-list-args.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(queryValidation: true) @upstream {
+schema @server(queryValidation: true) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-merge-input.md_client.snap
+++ b/tests/core/snapshots/test-merge-input.md_client.snap
@@ -1,0 +1,16 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+snapshot_kind: text
+---
+type Query {
+  foo(x: Test): Boolean
+}
+
+input Test {
+  b: String
+}
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/test-merge-input.md_merged.snap
+++ b/tests/core/snapshots/test-merge-input.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) @link(src: "schema_1.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-merge-nested.md_client.snap
+++ b/tests/core/snapshots/test-merge-nested.md_client.snap
@@ -1,0 +1,23 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+snapshot_kind: text
+---
+type Foo {
+  """
+  test2
+  """
+  a: String
+  """
+  test1
+  """
+  b: String
+}
+
+type Query {
+  hi: Foo
+}
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/test-merge-nested.md_merged.snap
+++ b/tests/core/snapshots/test-merge-nested.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) @link(src: "schema_1.graphql", type: Config) {
   query: Query
 }
 
@@ -19,5 +19,5 @@ type Foo {
 }
 
 type Query {
-  hi: Foo @expr(body: "world") @expr(body: {a: "world"})
+  hi: Foo @expr(body: {b: "hello"}) @expr(body: {a: "world"})
 }

--- a/tests/core/snapshots/test-merge-right-with-link-config.md_merged.snap
+++ b/tests/core/snapshots/test-merge-right-with-link-config.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(allowedHeaders: ["Authorization"]) @link(src: "stripe-types.graphql", type: Config) {
+schema
+  @server
+  @upstream(allowedHeaders: ["Authorization"])
+  @link(src: "stripe-types.graphql", type: Config)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-merge-server-sdl.md_merged.snap
+++ b/tests/core/snapshots/test-merge-server-sdl.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-merge-union.md_client.snap
+++ b/tests/core/snapshots/test-merge-union.md_client.snap
@@ -1,0 +1,27 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+snapshot_kind: text
+---
+type Bar {
+  bar: String
+}
+
+type Baz {
+  baz: String
+}
+
+type Foo {
+  a: String
+  foo: String
+}
+
+union FooBar = Bar | Baz | Foo
+
+type Query {
+  foo: FooBar
+}
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/test-merge-union.md_merged.snap
+++ b/tests/core/snapshots/test-merge-union.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) @link(src: "schema_1.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-modify.md_merged.snap
+++ b/tests/core/snapshots/test-modify.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-multi-interface.md_merged.snap
+++ b/tests/core/snapshots/test-multi-interface.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-multiple-config-types.md_merged.snap
+++ b/tests/core/snapshots/test-multiple-config-types.md_merged.snap
@@ -3,7 +3,11 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(id: "types", src: "types.graphql", type: Config) {
+schema
+  @server
+  @upstream
+  @link(id: "types", src: "types.graphql", type: Config)
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-multiple-resolvable-directives-on-field.md_merged.snap
+++ b/tests/core/snapshots/test-multiple-resolvable-directives-on-field.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-nested-input.md_merged.snap
+++ b/tests/core/snapshots/test-nested-input.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-nested-value.md_merged.snap
+++ b/tests/core/snapshots/test-nested-value.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-null-in-array.md_merged.snap
+++ b/tests/core/snapshots/test-null-in-array.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-null-in-object.md_merged.snap
+++ b/tests/core/snapshots/test-null-in-object.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-omit-list.md_merged.snap
+++ b/tests/core/snapshots/test-omit-list.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-omit.md_merged.snap
+++ b/tests/core/snapshots/test-omit.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-on-response-body.md_merged.snap
+++ b/tests/core/snapshots/test-on-response-body.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream @link(src: "test.js", type: Script) {
+schema @server @upstream @link(src: "test.js", type: Script) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-optional-key-skip-empty.md_merged.snap
+++ b/tests/core/snapshots/test-optional-key-skip-empty.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream {
+schema @server(port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-params-as-body.md_merged.snap
+++ b/tests/core/snapshots/test-params-as-body.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream {
+schema @server(port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-query-documentation.md_merged.snap
+++ b/tests/core/snapshots/test-query-documentation.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-query.md_merged.snap
+++ b/tests/core/snapshots/test-query.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-ref-other.md_merged.snap
+++ b/tests/core/snapshots/test-ref-other.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8000) @upstream {
+schema @server(port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-required-fields.md_merged.snap
+++ b/tests/core/snapshots/test-required-fields.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-scalars-builtin.md_merged.snap
+++ b/tests/core/snapshots/test-scalars-builtin.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "localhost", port: 8000) @upstream {
+schema @server(hostname: "localhost", port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-scalars-integers.md_merged.snap
+++ b/tests/core/snapshots/test-scalars-integers.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "localhost", port: 8000) @upstream {
+schema @server(hostname: "localhost", port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-scalars-validation.md_merged.snap
+++ b/tests/core/snapshots/test-scalars-validation.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "localhost", port: 8000) @upstream {
+schema @server(hostname: "localhost", port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-scalars.md_merged.snap
+++ b/tests/core/snapshots/test-scalars.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(hostname: "localhost", port: 8000) @upstream {
+schema @server(hostname: "localhost", port: 8000) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-server-vars.md_merged.snap
+++ b/tests/core/snapshots/test-server-vars.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(vars: [{key: "foo", value: "bar"}]) @upstream {
+schema @server(vars: [{key: "foo", value: "bar"}]) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-set-cookie-headers.md_merged.snap
+++ b/tests/core/snapshots/test-set-cookie-headers.md_merged.snap
@@ -3,7 +3,10 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(headers: {setCookies: true}, hostname: "0.0.0.0", port: 8080) @upstream {
+schema
+  @server(headers: {setCookies: true}, hostname: "0.0.0.0", port: 8080)
+  @upstream
+  @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-union-ambiguous.md_merged.snap
+++ b/tests/core/snapshots/test-union-ambiguous.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-union-fieldtype.md_merged.snap
+++ b/tests/core/snapshots/test-union-fieldtype.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-union-optional.md_merged.snap
+++ b/tests/core/snapshots/test-union-optional.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-union.md_merged.snap
+++ b/tests/core/snapshots/test-union.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-upstream-headers.md_merged.snap
+++ b/tests/core/snapshots/test-upstream-headers.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(allowedHeaders: ["X-bar", "x-foo"]) {
+schema @server @upstream(allowedHeaders: ["X-bar", "x-foo"]) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/test-upstream.md_merged.snap
+++ b/tests/core/snapshots/test-upstream.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(proxy: {url: "http://localhost:8085"}) {
+schema @server @upstream(proxy: {url: "http://localhost:8085"}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/union-nested-resolver.md_merged.snap
+++ b/tests/core/snapshots/union-nested-resolver.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server(port: 8030) @upstream {
+schema @server(port: 8030) @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/upstream-batching.md_merged.snap
+++ b/tests/core/snapshots/upstream-batching.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 100}) {
+schema @server @upstream(batch: {delay: 1, headers: [], maxSize: 100}) @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/upstream-fail-request.md_merged.snap
+++ b/tests/core/snapshots/upstream-fail-request.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/with-args-url.md_merged.snap
+++ b/tests/core/snapshots/with-args-url.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/with-args.md_merged.snap
+++ b/tests/core/snapshots/with-args.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/with-nesting.md_merged.snap
+++ b/tests/core/snapshots/with-nesting.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/yaml-nested-unions.md_merged.snap
+++ b/tests/core/snapshots/yaml-nested-unions.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/yaml-union-in-type.md_merged.snap
+++ b/tests/core/snapshots/yaml-union-in-type.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/core/snapshots/yaml-union.md_merged.snap
+++ b/tests/core/snapshots/yaml-union.md_merged.snap
@@ -3,7 +3,7 @@ source: tests/core/spec.rs
 expression: formatter
 snapshot_kind: text
 ---
-schema @server @upstream {
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
   query: Query
 }
 

--- a/tests/execution/add-field-index-list.md
+++ b/tests/execution/add-field-index-list.md
@@ -1,6 +1,6 @@
 # Sending field index list
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/add-field-many-list.md
+++ b/tests/execution/add-field-many-list.md
@@ -4,7 +4,7 @@ identity: true
 
 # add-field-many-list
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/add-field-many.md
+++ b/tests/execution/add-field-many.md
@@ -4,7 +4,7 @@ identity: true
 
 # add-field-many
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/add-field-modify.md
+++ b/tests/execution/add-field-modify.md
@@ -1,6 +1,6 @@
 # Add field modify
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/add-field-with-composition.md
+++ b/tests/execution/add-field-with-composition.md
@@ -1,6 +1,6 @@
 # Add field with composition
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/add-field-with-modify.md
+++ b/tests/execution/add-field-with-modify.md
@@ -1,6 +1,6 @@
 # Add field with modify
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/add-field.md
+++ b/tests/execution/add-field.md
@@ -1,6 +1,6 @@
 # Add field
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/apollo-federation-entities-batch.md
+++ b/tests/execution/apollo-federation-entities-batch.md
@@ -1,7 +1,18 @@
 # Apollo federation query for batching resolvers
 
+```yaml @config
+server:
+  port: 8000
+  enableFederation: true
+
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/apollo-federation-entities-batch.md
+++ b/tests/execution/apollo-federation-entities-batch.md
@@ -1,6 +1,6 @@
 # Apollo federation query for batching resolvers
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/apollo-federation-entities-validation.md
+++ b/tests/execution/apollo-federation-entities-validation.md
@@ -4,7 +4,7 @@ error: true
 
 # Apollo federation query validation
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/apollo-federation-entities-validation.md
+++ b/tests/execution/apollo-federation-entities-validation.md
@@ -4,8 +4,18 @@ error: true
 
 # Apollo federation query validation
 
+```yaml @config
+server:
+  port: 8000
+  enableFederation: true
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/apollo-federation-entities.md
+++ b/tests/execution/apollo-federation-entities.md
@@ -1,6 +1,6 @@
 # Apollo federation query
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000, enableFederation: true)
   @upstream(httpCache: 42, batch: {delay: 100})

--- a/tests/execution/apollo-federation-entities.md
+++ b/tests/execution/apollo-federation-entities.md
@@ -1,10 +1,19 @@
 # Apollo federation query
 
+```yaml @config
+server:
+  port: 8000
+  enableFederation: true
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+links:
+  - src: ./posts.graphql
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000, enableFederation: true)
-  @upstream(httpCache: 42, batch: {delay: 100})
-  @link(src: "./posts.graphql") {
+schema {
   query: Query
 }
 

--- a/tests/execution/apollo-federation-validation.md
+++ b/tests/execution/apollo-federation-validation.md
@@ -4,8 +4,18 @@ error: true
 
 # Apollo federation validation
 
+```yaml @config
+server:
+  port: 8000
+  enableFederation: true
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/apollo-federation-validation.md
+++ b/tests/execution/apollo-federation-validation.md
@@ -4,7 +4,7 @@ error: true
 
 # Apollo federation validation
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/apollo-tracing.md
+++ b/tests/execution/apollo-tracing.md
@@ -1,6 +1,6 @@
 # Apollo Tracing
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000, hostname: "0.0.0.0")
   @telemetry(export: {apollo: {apiKey: "<api_key>", graphRef: "tailcall-demo-3@current"}}) {

--- a/tests/execution/async-cache-disabled.md
+++ b/tests/execution/async-cache-disabled.md
@@ -1,6 +1,6 @@
 # Async Cache Disabled
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) {
   query: Query
 }

--- a/tests/execution/async-cache-disabled.md
+++ b/tests/execution/async-cache-disabled.md
@@ -1,7 +1,13 @@
 # Async Cache Disabled
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+```
+
 ```graphql @schema
-schema @server(port: 8000, queryValidation: false) {
+schema {
   query: Query
 }
 

--- a/tests/execution/async-cache-enable-multiple-resolvers.md
+++ b/tests/execution/async-cache-enable-multiple-resolvers.md
@@ -1,7 +1,13 @@
 # Async Cache Enabled
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+```
+
 ```graphql @schema
-schema @server(port: 8000, queryValidation: false) {
+schema {
   query: Query
 }
 

--- a/tests/execution/async-cache-enable-multiple-resolvers.md
+++ b/tests/execution/async-cache-enable-multiple-resolvers.md
@@ -1,6 +1,6 @@
 # Async Cache Enabled
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) {
   query: Query
 }

--- a/tests/execution/async-cache-enabled.md
+++ b/tests/execution/async-cache-enabled.md
@@ -1,7 +1,13 @@
 # Async Cache Enabled
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+```
+
 ```graphql @schema
-schema @server(port: 8000, queryValidation: false) {
+schema {
   query: Query
 }
 

--- a/tests/execution/async-cache-enabled.md
+++ b/tests/execution/async-cache-enabled.md
@@ -1,6 +1,6 @@
 # Async Cache Enabled
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) {
   query: Query
 }

--- a/tests/execution/async-cache-global.md
+++ b/tests/execution/async-cache-global.md
@@ -1,7 +1,13 @@
 # Async Cache Inflight Enabled
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+```
+
 ```graphql @schema
-schema @server(port: 8000, queryValidation: false) {
+schema {
   query: Query
 }
 

--- a/tests/execution/async-cache-global.md
+++ b/tests/execution/async-cache-global.md
@@ -1,6 +1,6 @@
 # Async Cache Inflight Enabled
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) {
   query: Query
 }

--- a/tests/execution/async-cache-inflight-request.md
+++ b/tests/execution/async-cache-inflight-request.md
@@ -1,7 +1,13 @@
 # Async Cache Inflight and InRequest
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+```
+
 ```graphql @schema
-schema @server(port: 8000, queryValidation: false) {
+schema {
   query: Query
 }
 

--- a/tests/execution/async-cache-inflight-request.md
+++ b/tests/execution/async-cache-inflight-request.md
@@ -1,6 +1,6 @@
 # Async Cache Inflight and InRequest
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) {
   query: Query
 }

--- a/tests/execution/auth-basic.md
+++ b/tests/execution/auth-basic.md
@@ -1,6 +1,6 @@
 # Auth with BasicAuth
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @link(id: "htpasswd", type: Htpasswd, src: ".htpasswd") {
   query: Query
   mutation: Mutation

--- a/tests/execution/auth-basic.md
+++ b/tests/execution/auth-basic.md
@@ -1,7 +1,16 @@
 # Auth with BasicAuth
 
+```yaml @config
+server:
+  port: 8000
+links:
+  - id: htpasswd
+    src: .htpasswd
+    type: Htpasswd
+```
+
 ```graphql @schema
-schema @server(port: 8000) @link(id: "htpasswd", type: Htpasswd, src: ".htpasswd") {
+schema {
   query: Query
   mutation: Mutation
 }

--- a/tests/execution/auth-jwt.md
+++ b/tests/execution/auth-jwt.md
@@ -1,6 +1,6 @@
 # Auth with JWT loaded from expr
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @link(id: "jwks", type: Jwks, src: "jwks.json") {
   query: Query
   mutation: Mutation

--- a/tests/execution/auth-jwt.md
+++ b/tests/execution/auth-jwt.md
@@ -1,7 +1,16 @@
 # Auth with JWT loaded from expr
 
+```yaml @config
+server:
+  port: 8000
+links:
+  - id: jwks
+    src: jwks.json
+    type: Jwks
+```
+
 ```graphql @schema
-schema @server(port: 8000) @link(id: "jwks", type: Jwks, src: "jwks.json") {
+schema {
   query: Query
   mutation: Mutation
 }

--- a/tests/execution/auth-multiple-complex.md
+++ b/tests/execution/auth-multiple-complex.md
@@ -1,12 +1,20 @@
 # auth multiple
 
+```yaml @config
+links:
+  - id: a
+    src: .htpasswd_a
+    type: Htpasswd
+  - id: b
+    src: .htpasswd_b
+    type: Htpasswd
+  - id: c
+    src: .htpasswd_c
+    type: Htpasswd
+```
+
 ```graphql @schema
-schema
-  @server
-  @upstream
-  @link(id: "a", src: ".htpasswd_a", type: Htpasswd)
-  @link(id: "b", src: ".htpasswd_b", type: Htpasswd)
-  @link(id: "c", src: ".htpasswd_c", type: Htpasswd) {
+schema {
   query: Query
 }
 

--- a/tests/execution/auth-multiple-complex.md
+++ b/tests/execution/auth-multiple-complex.md
@@ -1,6 +1,6 @@
 # auth multiple
 
-```graphql @config
+```graphql @schema
 schema
   @server
   @upstream

--- a/tests/execution/auth-multiple.md
+++ b/tests/execution/auth-multiple.md
@@ -1,12 +1,20 @@
 # auth multiple
 
+```yaml @config
+links:
+  - id: a
+    src: .htpasswd_a
+    type: Htpasswd
+  - id: b
+    src: .htpasswd_b
+    type: Htpasswd
+  - id: c
+    src: .htpasswd_c
+    type: Htpasswd
+```
+
 ```graphql @schema
-schema
-  @server
-  @upstream
-  @link(id: "a", src: ".htpasswd_a", type: Htpasswd)
-  @link(id: "b", src: ".htpasswd_b", type: Htpasswd)
-  @link(id: "c", src: ".htpasswd_c", type: Htpasswd) {
+schema {
   query: Query
 }
 

--- a/tests/execution/auth-multiple.md
+++ b/tests/execution/auth-multiple.md
@@ -1,6 +1,6 @@
 # auth multiple
 
-```graphql @config
+```graphql @schema
 schema
   @server
   @upstream

--- a/tests/execution/auth-protected-without-auth.md
+++ b/tests/execution/auth-protected-without-auth.md
@@ -4,7 +4,7 @@ error: true
 
 # Using @protected operator without specifying server.auth config
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/auth-validations.md
+++ b/tests/execution/auth-validations.md
@@ -4,7 +4,7 @@ error: true
 
 # auth multiple
 
-```graphql @config
+```graphql @schema
 schema @server @upstream @link(id: "a", src: ".htpasswd_a", type: Htpasswd) {
   query: Query
 }

--- a/tests/execution/auth-validations.md
+++ b/tests/execution/auth-validations.md
@@ -4,8 +4,15 @@ error: true
 
 # auth multiple
 
+```yaml @config
+links:
+  - id: a
+    src: .htpasswd_a
+    type: Htpasswd
+```
+
 ```graphql @schema
-schema @server @upstream @link(id: "a", src: ".htpasswd_a", type: Htpasswd) {
+schema {
   query: Query
 }
 

--- a/tests/execution/auth.md
+++ b/tests/execution/auth.md
@@ -4,7 +4,7 @@ identity: true
 
 # auth
 
-```graphql @config
+```graphql @schema
 schema
   @server
   @upstream

--- a/tests/execution/auth.md
+++ b/tests/execution/auth.md
@@ -4,12 +4,18 @@ identity: true
 
 # auth
 
+```yaml @config
+links:
+  - id: htpasswd
+    src: .htpasswd
+    type: Htpasswd
+  - id: jwks
+    src: jwks.json
+    type: Jwks
+```
+
 ```graphql @schema
-schema
-  @server
-  @upstream
-  @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd)
-  @link(id: "jwks", src: "jwks.json", type: Jwks) {
+schema @server @upstream {
   query: Query
 }
 

--- a/tests/execution/auth_order.md
+++ b/tests/execution/auth_order.md
@@ -1,7 +1,14 @@
 # auth order
 
+```yaml @config
+links:
+  - id: htpasswd
+    src: .htpasswd
+    type: Htpasswd
+```
+
 ```graphql @schema
-schema @server @upstream @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd) {
+schema {
   query: Query
 }
 

--- a/tests/execution/auth_order.md
+++ b/tests/execution/auth_order.md
@@ -1,6 +1,6 @@
 # auth order
 
-```graphql @config
+```graphql @schema
 schema @server @upstream @link(id: "htpasswd", src: ".htpasswd", type: Htpasswd) {
   query: Query
 }

--- a/tests/execution/batching-default.md
+++ b/tests/execution/batching-default.md
@@ -1,7 +1,14 @@
 # Batching default
 
+```yaml @config
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+```
+
 ```graphql @schema
-schema @server @upstream(httpCache: 42, batch: {delay: 10}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching-default.md
+++ b/tests/execution/batching-default.md
@@ -1,6 +1,6 @@
 # Batching default
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(httpCache: 42, batch: {delay: 10}) {
   query: Query
 }

--- a/tests/execution/batching-disabled.md
+++ b/tests/execution/batching-disabled.md
@@ -1,6 +1,6 @@
 # Batching disabled
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(httpCache: 42, batch: {maxSize: 100, delay: 0, headers: []}) {
   query: Query
 }

--- a/tests/execution/batching-disabled.md
+++ b/tests/execution/batching-disabled.md
@@ -1,7 +1,15 @@
 # Batching disabled
 
+```yaml @config
+upstream:
+  httpCache: 42
+  batch:
+    maxSize: 100
+    delay: 0
+```
+
 ```graphql @schema
-schema @server @upstream(httpCache: 42, batch: {maxSize: 100, delay: 0, headers: []}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching-group-by-default.md
+++ b/tests/execution/batching-group-by-default.md
@@ -1,6 +1,6 @@
 # Batching group by default
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(httpCache: 42, batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/batching-group-by-default.md
+++ b/tests/execution/batching-group-by-default.md
@@ -1,7 +1,15 @@
 # Batching group by default
 
+```yaml @config
+upstream:
+  httpCache: 42
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @server @upstream(httpCache: 42, batch: {delay: 1, maxSize: 1000}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching-group-by-optional-key.md
+++ b/tests/execution/batching-group-by-optional-key.md
@@ -1,6 +1,6 @@
 # Batching group by
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) @upstream(httpCache: 42, batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/batching-group-by-optional-key.md
+++ b/tests/execution/batching-group-by-optional-key.md
@@ -1,7 +1,18 @@
 # Batching group by
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+upstream:
+  httpCache: 42
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @server(port: 8000, queryValidation: false) @upstream(httpCache: 42, batch: {delay: 1, maxSize: 1000}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching-group-by.md
+++ b/tests/execution/batching-group-by.md
@@ -1,6 +1,6 @@
 # Batching group by
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) @upstream(httpCache: 42, batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/batching-group-by.md
+++ b/tests/execution/batching-group-by.md
@@ -1,7 +1,18 @@
 # Batching group by
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+upstream:
+  httpCache: 42
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @server(port: 8000, queryValidation: false) @upstream(httpCache: 42, batch: {delay: 1, maxSize: 1000}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching-post.md
+++ b/tests/execution/batching-post.md
@@ -1,9 +1,18 @@
 # Batching post
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+upstream:
+  httpCache: 42
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000, queryValidation: false)
-  @upstream(httpCache: 42, batch: {maxSize: 1000, delay: 1, headers: []}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching-post.md
+++ b/tests/execution/batching-post.md
@@ -1,6 +1,6 @@
 # Batching post
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000, queryValidation: false)
   @upstream(httpCache: 42, batch: {maxSize: 1000, delay: 1, headers: []}) {

--- a/tests/execution/batching-validation.md
+++ b/tests/execution/batching-validation.md
@@ -4,7 +4,7 @@ error: true
 
 # batching validation
 
-```graphql @config
+```graphql @schema
 schema @upstream(httpCache: 42, batch: {delay: 1}) {
   query: Query
 }

--- a/tests/execution/batching-validation.md
+++ b/tests/execution/batching-validation.md
@@ -2,10 +2,17 @@
 error: true
 ---
 
+```yaml @config
+upstream:
+  httpCache: 42
+  batch:
+    delay: 1
+```
+
 # batching validation
 
 ```graphql @schema
-schema @upstream(httpCache: 42, batch: {delay: 1}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching.md
+++ b/tests/execution/batching.md
@@ -1,7 +1,12 @@
 # Sending a batched graphql request
 
+```yaml @config
+server:
+  batchRequests: true
+```
+
 ```graphql @schema
-schema @server(batchRequests: true) @upstream {
+schema {
   query: Query
 }
 

--- a/tests/execution/batching.md
+++ b/tests/execution/batching.md
@@ -1,6 +1,6 @@
 # Sending a batched graphql request
 
-```graphql @config
+```graphql @schema
 schema @server(batchRequests: true) @upstream {
   query: Query
 }

--- a/tests/execution/body-batching-cases.md
+++ b/tests/execution/body-batching-cases.md
@@ -1,6 +1,6 @@
 # Batching default
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 1}) {
   query: Query
 }

--- a/tests/execution/body-batching-cases.md
+++ b/tests/execution/body-batching-cases.md
@@ -1,7 +1,16 @@
 # Batching default
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 1
+```
+
 ```graphql @schema
-schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 1}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/body-batching.md
+++ b/tests/execution/body-batching.md
@@ -1,9 +1,18 @@
 # Batching post
 
+```yaml @config
+server:
+  port: 8000
+  queryValidation: false
+upstream:
+  httpCache: 42
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000, queryValidation: false)
-  @upstream(httpCache: 42, batch: {maxSize: 1000, delay: 1, headers: []}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/body-batching.md
+++ b/tests/execution/body-batching.md
@@ -1,6 +1,6 @@
 # Batching post
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000, queryValidation: false)
   @upstream(httpCache: 42, batch: {maxSize: 1000, delay: 1, headers: []}) {

--- a/tests/execution/cache-control.md
+++ b/tests/execution/cache-control.md
@@ -1,6 +1,6 @@
 # Sending requests to verify Cache-Control behavior
 
-```graphql @config
+```graphql @schema
 schema @server(headers: {cacheControl: true}) @upstream {
   query: Query
 }

--- a/tests/execution/cache-control.md
+++ b/tests/execution/cache-control.md
@@ -1,7 +1,13 @@
 # Sending requests to verify Cache-Control behavior
 
+```yaml @config
+server:
+  headers:
+    cacheControl: true
+```
+
 ```graphql @schema
-schema @server(headers: {cacheControl: true}) @upstream {
+schema {
   query: Query
 }
 

--- a/tests/execution/caching-collision.md
+++ b/tests/execution/caching-collision.md
@@ -1,7 +1,14 @@
 # Caching Collision
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @upstream(batch: {delay: 1, maxSize: 1000}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/caching-collision.md
+++ b/tests/execution/caching-collision.md
@@ -1,6 +1,6 @@
 # Caching Collision
 
-```graphql @config
+```graphql @schema
 schema @upstream(batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/caching.md
+++ b/tests/execution/caching.md
@@ -1,6 +1,6 @@
 # Caching
 
-```graphql @config
+```graphql @schema
 schema @upstream(batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/caching.md
+++ b/tests/execution/caching.md
@@ -1,7 +1,14 @@
 # Caching
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @upstream(batch: {delay: 1, maxSize: 1000}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/call-graphql-datasource.md
+++ b/tests/execution/call-graphql-datasource.md
@@ -1,6 +1,6 @@
 # Call operator with graphQL datasource
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/call-graphql-datasource.md
+++ b/tests/execution/call-graphql-datasource.md
@@ -1,7 +1,15 @@
 # Call operator with graphQL datasource
 
+```yaml @config
+server:
+  port: 8000
+  hostname: "0.0.0.0"
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/call-multiple-steps-piping.md
+++ b/tests/execution/call-multiple-steps-piping.md
@@ -1,6 +1,6 @@
 # Call multiple steps piping
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/call-mutation.md
+++ b/tests/execution/call-mutation.md
@@ -1,6 +1,6 @@
 # Call mutation
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
   mutation: Mutation

--- a/tests/execution/call-mutation.md
+++ b/tests/execution/call-mutation.md
@@ -1,7 +1,7 @@
 # Call mutation
 
 ```graphql @schema
-schema @server {
+schema {
   query: Query
   mutation: Mutation
 }

--- a/tests/execution/call-operator.md
+++ b/tests/execution/call-operator.md
@@ -36,11 +36,20 @@ message NewsList {
 }
 ```
 
+```yaml @config
+upstream:
+  httpCache: 42
+server:
+  port: 8000
+  hostname: "0.0.0.0"
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000, hostname: "0.0.0.0")
-  @upstream(httpCache: 42)
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/call-operator.md
+++ b/tests/execution/call-operator.md
@@ -36,7 +36,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000, hostname: "0.0.0.0")
   @upstream(httpCache: 42)

--- a/tests/execution/cors-allow-cred-false.md
+++ b/tests/execution/cors-allow-cred-false.md
@@ -1,19 +1,22 @@
 # Cors allow cred false
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+server:
+  headers:
+    cors:
+      allowHeaders: ["Authorization"]
+      allowMethods: [POST, OPTIONS]
+      allowOrigins: ["abc.com", "xyz.com"]
+      allowPrivateNetwork: true
+      maxAge: 23
+```
+
 ```graphql @schema
-schema
-  @upstream(batch: {delay: 1, maxSize: 1000})
-  @server(
-    headers: {
-      cors: {
-        allowHeaders: ["Authorization"]
-        allowMethods: [POST, OPTIONS]
-        allowOrigins: ["abc.com", "xyz.com"]
-        allowPrivateNetwork: true
-        maxAge: 23
-      }
-    }
-  ) {
+schema {
   query: Query
 }
 

--- a/tests/execution/cors-allow-cred-false.md
+++ b/tests/execution/cors-allow-cred-false.md
@@ -1,6 +1,6 @@
 # Cors allow cred false
 
-```graphql @config
+```graphql @schema
 schema
   @upstream(batch: {delay: 1, maxSize: 1000})
   @server(

--- a/tests/execution/cors-allow-cred-true.md
+++ b/tests/execution/cors-allow-cred-true.md
@@ -1,6 +1,6 @@
 # Cors allow cred true
 
-```graphql @config
+```graphql @schema
 schema
   @upstream(batch: {delay: 1, maxSize: 1000})
   @server(

--- a/tests/execution/cors-allow-cred-true.md
+++ b/tests/execution/cors-allow-cred-true.md
@@ -1,19 +1,22 @@
 # Cors allow cred true
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+server:
+  headers:
+    cors:
+      allowCredentials: true
+      allowMethods: [OPTIONS, POST, GET]
+      allowOrigins: ["abc.com", "xyz.com"]
+      exposeHeaders: [""]
+      maxAge: 23
+```
+
 ```graphql @schema
-schema
-  @upstream(batch: {delay: 1, maxSize: 1000})
-  @server(
-    headers: {
-      cors: {
-        allowCredentials: true
-        allowMethods: [OPTIONS, POST, GET]
-        allowOrigins: ["abc.com", "xyz.com"]
-        exposeHeaders: [""]
-        maxAge: 23
-      }
-    }
-  ) {
+schema {
   query: Query
 }
 

--- a/tests/execution/cors-allow-cred-vary.md
+++ b/tests/execution/cors-allow-cred-vary.md
@@ -1,19 +1,22 @@
 # Cors allow cred vary
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+server:
+  headers:
+    cors:
+      allowCredentials: true
+      allowMethods: [OPTIONS, POST, GET]
+      allowOrigins: ["abc.com", "xyz.com"]
+      exposeHeaders: [""]
+      maxAge: 23
+```
+
 ```graphql @schema
-schema
-  @upstream(batch: {delay: 1, maxSize: 1000})
-  @server(
-    headers: {
-      cors: {
-        allowCredentials: true
-        allowMethods: [OPTIONS, POST, GET]
-        allowOrigins: ["abc.com", "xyz.com"]
-        exposeHeaders: [""]
-        maxAge: 23
-      }
-    }
-  ) {
+schema {
   query: Query
 }
 

--- a/tests/execution/cors-allow-cred-vary.md
+++ b/tests/execution/cors-allow-cred-vary.md
@@ -1,6 +1,6 @@
 # Cors allow cred vary
 
-```graphql @config
+```graphql @schema
 schema
   @upstream(batch: {delay: 1, maxSize: 1000})
   @server(

--- a/tests/execution/cors-invalid-expose-headers.md
+++ b/tests/execution/cors-invalid-expose-headers.md
@@ -4,10 +4,21 @@ error: true
 
 # Cors invalid exposeHeaders
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+server:
+  headers:
+    cors:
+      allowCredentials: true
+      exposeHeaders: ["*"]
+      allowMethods: [POST, OPTIONS]
+```
+
 ```graphql @schema
-schema
-  @upstream(batch: {delay: 1, maxSize: 1000})
-  @server(headers: {cors: {allowCredentials: true, exposeHeaders: ["*"], allowMethods: [POST, OPTIONS]}}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/cors-invalid-expose-headers.md
+++ b/tests/execution/cors-invalid-expose-headers.md
@@ -4,7 +4,7 @@ error: true
 
 # Cors invalid exposeHeaders
 
-```graphql @config
+```graphql @schema
 schema
   @upstream(batch: {delay: 1, maxSize: 1000})
   @server(headers: {cors: {allowCredentials: true, exposeHeaders: ["*"], allowMethods: [POST, OPTIONS]}}) {

--- a/tests/execution/cors-invalid-headers.md
+++ b/tests/execution/cors-invalid-headers.md
@@ -4,10 +4,21 @@ error: true
 
 # Cors invalid allowHeaders
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+server:
+  headers:
+    cors:
+      allowCredentials: true
+      allowHeaders: ["*"]
+      allowMethods: [POST, OPTIONS]
+```
+
 ```graphql @schema
-schema
-  @upstream(batch: {delay: 1, maxSize: 1000})
-  @server(headers: {cors: {allowCredentials: true, allowHeaders: ["*"], allowMethods: [POST, OPTIONS]}}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/cors-invalid-headers.md
+++ b/tests/execution/cors-invalid-headers.md
@@ -4,7 +4,7 @@ error: true
 
 # Cors invalid allowHeaders
 
-```graphql @config
+```graphql @schema
 schema
   @upstream(batch: {delay: 1, maxSize: 1000})
   @server(headers: {cors: {allowCredentials: true, allowHeaders: ["*"], allowMethods: [POST, OPTIONS]}}) {

--- a/tests/execution/cors-invalid-methods.md
+++ b/tests/execution/cors-invalid-methods.md
@@ -4,7 +4,7 @@ error: true
 
 # Cors invalid allowMethods
 
-```graphql @config
+```graphql @schema
 schema @upstream(batch: {delay: 1, maxSize: 1000}) @server(headers: {cors: {allowCredentials: true}}) {
   query: Query
 }

--- a/tests/execution/cors-invalid-methods.md
+++ b/tests/execution/cors-invalid-methods.md
@@ -4,8 +4,19 @@ error: true
 
 # Cors invalid allowMethods
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+server:
+  headers:
+    cors:
+      allowCredentials: true
+```
+
 ```graphql @schema
-schema @upstream(batch: {delay: 1, maxSize: 1000}) @server(headers: {cors: {allowCredentials: true}}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/cors-invalid-origins.md
+++ b/tests/execution/cors-invalid-origins.md
@@ -4,10 +4,21 @@ error: true
 
 # Cors invalid allowOrigins
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+server:
+  headers:
+    cors:
+      allowCredentials: true
+      allowOrigins: ["*"]
+      allowMethods: [POST, OPTIONS]
+```
+
 ```graphql @schema
-schema
-  @upstream(batch: {delay: 1, maxSize: 1000})
-  @server(headers: {cors: {allowCredentials: true, allowOrigins: ["*"], allowMethods: [POST, OPTIONS]}}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/cors-invalid-origins.md
+++ b/tests/execution/cors-invalid-origins.md
@@ -4,7 +4,7 @@ error: true
 
 # Cors invalid allowOrigins
 
-```graphql @config
+```graphql @schema
 schema
   @upstream(batch: {delay: 1, maxSize: 1000})
   @server(headers: {cors: {allowCredentials: true, allowOrigins: ["*"], allowMethods: [POST, OPTIONS]}}) {

--- a/tests/execution/custom-headers.md
+++ b/tests/execution/custom-headers.md
@@ -1,6 +1,6 @@
 # Custom Headers
 
-```graphql @config
+```graphql @schema
 schema @server(headers: {custom: [{key: "x-id", value: "1"}, {key: "x-name", value: "John Doe"}]}) @upstream {
   query: Query
 }

--- a/tests/execution/custom-headers.md
+++ b/tests/execution/custom-headers.md
@@ -1,7 +1,17 @@
 # Custom Headers
 
+```yaml @config
+server:
+  headers:
+    custom:
+      - key: "x-id"
+        value: "1"
+      - key: "x-name"
+        value: "John Doe"
+```
+
 ```graphql @schema
-schema @server(headers: {custom: [{key: "x-id", value: "1"}, {key: "x-name", value: "John Doe"}]}) @upstream {
+schema {
   query: Query
 }
 

--- a/tests/execution/custom-scalars.md
+++ b/tests/execution/custom-scalars.md
@@ -1,6 +1,6 @@
 # Using all custom scalars
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/dedupe_batch_query_execution.md
+++ b/tests/execution/dedupe_batch_query_execution.md
@@ -1,6 +1,6 @@
 # Async Cache Inflight Enabled
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, queryValidation: false) {
   query: Query
 }

--- a/tests/execution/default-value-arg.md
+++ b/tests/execution/default-value-arg.md
@@ -1,6 +1,6 @@
 # default value for input Type
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/default-value-config.md
+++ b/tests/execution/default-value-config.md
@@ -1,6 +1,6 @@
 # default value for input Type
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/enum-args.md
+++ b/tests/execution/enum-args.md
@@ -1,6 +1,6 @@
 # Enum Arguments
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/env-value.md
+++ b/tests/execution/env-value.md
@@ -1,6 +1,6 @@
 # Env value
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/experimental-headers-error.md
+++ b/tests/execution/experimental-headers-error.md
@@ -4,8 +4,14 @@ error: true
 
 # test-experimental-headers-error
 
+```yaml @config
+server:
+  headers:
+    experimental: ["non-experimental", "foo", "bar", "tailcall"]
+```
+
 ```graphql @schema
-schema @server(headers: {experimental: ["non-experimental", "foo", "bar", "tailcall"]}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/experimental-headers-error.md
+++ b/tests/execution/experimental-headers-error.md
@@ -4,7 +4,7 @@ error: true
 
 # test-experimental-headers-error
 
-```graphql @config
+```graphql @schema
 schema @server(headers: {experimental: ["non-experimental", "foo", "bar", "tailcall"]}) {
   query: Query
 }

--- a/tests/execution/experimental-headers.md
+++ b/tests/execution/experimental-headers.md
@@ -1,6 +1,6 @@
 # Experimental headers
 
-```graphql @config
+```graphql @schema
 schema @server(headers: {experimental: ["x-tailcall", "X-experimental"]}) {
   query: Query
 }

--- a/tests/execution/experimental-headers.md
+++ b/tests/execution/experimental-headers.md
@@ -1,7 +1,15 @@
 # Experimental headers
 
+```yaml @config
+server:
+  headers:
+    experimental:
+      - "x-tailcall"
+      - "X-experimental"
+```
+
 ```graphql @schema
-schema @server(headers: {experimental: ["x-tailcall", "X-experimental"]}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/federation-subgraph-force-disabled.md
+++ b/tests/execution/federation-subgraph-force-disabled.md
@@ -1,6 +1,6 @@
 # Federation subgraph with no entities in the config
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, enableFederation: false) @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/federation-subgraph-force-disabled.md
+++ b/tests/execution/federation-subgraph-force-disabled.md
@@ -1,7 +1,17 @@
 # Federation subgraph with no entities in the config
 
+```yaml @config
+server:
+  port: 8000
+  enableFederation: false
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8000, enableFederation: false) @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/federation-subgraph-force-enabled.md
+++ b/tests/execution/federation-subgraph-force-enabled.md
@@ -1,6 +1,6 @@
 # Federation subgraph with no entities in the config and enableFederation=true
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/federation-subgraph-force-enabled.md
+++ b/tests/execution/federation-subgraph-force-enabled.md
@@ -1,7 +1,17 @@
 # Federation subgraph with no entities in the config and enableFederation=true
 
+```yaml @config
+server:
+  port: 8000
+  enableFederation: true
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8000, enableFederation: true) @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/federation-subgraph-no-entities.md
+++ b/tests/execution/federation-subgraph-no-entities.md
@@ -1,7 +1,16 @@
 # Federation subgraph with no entities in the config
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/federation-subgraph-no-entities.md
+++ b/tests/execution/federation-subgraph-no-entities.md
@@ -1,6 +1,6 @@
 # Federation subgraph with no entities in the config
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-001.md
+++ b/tests/execution/graphql-conformance-001.md
@@ -1,6 +1,6 @@
 # Basic queries with field ordering check
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-001.md
+++ b/tests/execution/graphql-conformance-001.md
@@ -1,7 +1,16 @@
 # Basic queries with field ordering check
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-002.md
+++ b/tests/execution/graphql-conformance-002.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query to the remote server. It sends a shallow version of the query.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-002.md
+++ b/tests/execution/graphql-conformance-002.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query to the remote server. It sends a shallow version of the query.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-003.md
+++ b/tests/execution/graphql-conformance-003.md
@@ -1,6 +1,6 @@
 # Test field inputs query
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-003.md
+++ b/tests/execution/graphql-conformance-003.md
@@ -1,7 +1,16 @@
 # Test field inputs query
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-004.md
+++ b/tests/execution/graphql-conformance-004.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the alias to the remote server.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-004.md
+++ b/tests/execution/graphql-conformance-004.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the alias to the remote server.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-005.md
+++ b/tests/execution/graphql-conformance-005.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the alias to the remote server.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-005.md
+++ b/tests/execution/graphql-conformance-005.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the alias to the remote server.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-006.md
+++ b/tests/execution/graphql-conformance-006.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-006.md
+++ b/tests/execution/graphql-conformance-006.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-007.md
+++ b/tests/execution/graphql-conformance-007.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-007.md
+++ b/tests/execution/graphql-conformance-007.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-008.md
+++ b/tests/execution/graphql-conformance-008.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-008.md
+++ b/tests/execution/graphql-conformance-008.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-009.md
+++ b/tests/execution/graphql-conformance-009.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not construct the query correctly. Moreover it does not validate the query that is invalid (contains a missing field).
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-009.md
+++ b/tests/execution/graphql-conformance-009.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not construct the query correctly. Moreover it does not validate the query that is invalid (contains a missing field).
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-010.md
+++ b/tests/execution/graphql-conformance-010.md
@@ -1,7 +1,16 @@
 # Test ordering of input fields
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-010.md
+++ b/tests/execution/graphql-conformance-010.md
@@ -1,6 +1,6 @@
 # Test ordering of input fields
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-011.md
+++ b/tests/execution/graphql-conformance-011.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because tailcall does not send the `@log` directive to the remote server. Moreover it does not correctly format the scalar to string value.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-011.md
+++ b/tests/execution/graphql-conformance-011.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because tailcall does not send the `@log` directive to the remote server. Moreover it does not correctly format the scalar to string value.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-012.md
+++ b/tests/execution/graphql-conformance-012.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-012.md
+++ b/tests/execution/graphql-conformance-012.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-013.md
+++ b/tests/execution/graphql-conformance-013.md
@@ -1,7 +1,16 @@
 # Test schema inspection
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-013.md
+++ b/tests/execution/graphql-conformance-013.md
@@ -1,6 +1,6 @@
 # Test schema inspection
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-014.md
+++ b/tests/execution/graphql-conformance-014.md
@@ -1,6 +1,6 @@
 # Test double query
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-014.md
+++ b/tests/execution/graphql-conformance-014.md
@@ -1,7 +1,16 @@
 # Test double query
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-015.md
+++ b/tests/execution/graphql-conformance-015.md
@@ -1,6 +1,6 @@
 # Optional input fields
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-015.md
+++ b/tests/execution/graphql-conformance-015.md
@@ -1,7 +1,16 @@
 # Optional input fields
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-017.md
+++ b/tests/execution/graphql-conformance-017.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-017.md
+++ b/tests/execution/graphql-conformance-017.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not send the whole query with the **fragments** to the remote server.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-018.md
+++ b/tests/execution/graphql-conformance-018.md
@@ -1,6 +1,6 @@
 # Basic queries with field modify check
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }
@@ -39,7 +39,7 @@ type User {
     query: |
       query getUser {
         user(id: 4) {
-          city 
+          city
           newName
         }
       }

--- a/tests/execution/graphql-conformance-018.md
+++ b/tests/execution/graphql-conformance-018.md
@@ -1,7 +1,16 @@
 # Basic queries with field modify check
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-001.md
+++ b/tests/execution/graphql-conformance-http-001.md
@@ -1,6 +1,6 @@
 # Basic queries with field ordering check
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-001.md
+++ b/tests/execution/graphql-conformance-http-001.md
@@ -1,7 +1,16 @@
 # Basic queries with field ordering check
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-002.md
+++ b/tests/execution/graphql-conformance-http-002.md
@@ -1,6 +1,6 @@
 # Test complex nested query
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-002.md
+++ b/tests/execution/graphql-conformance-http-002.md
@@ -1,7 +1,16 @@
 # Test complex nested query
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-003.md
+++ b/tests/execution/graphql-conformance-http-003.md
@@ -1,6 +1,6 @@
 # Test field inputs query
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-003.md
+++ b/tests/execution/graphql-conformance-http-003.md
@@ -1,7 +1,16 @@
 # Test field inputs query
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-004.md
+++ b/tests/execution/graphql-conformance-http-004.md
@@ -1,6 +1,6 @@
 # Test complex aliasing
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-004.md
+++ b/tests/execution/graphql-conformance-http-004.md
@@ -1,7 +1,16 @@
 # Test complex aliasing
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-005.md
+++ b/tests/execution/graphql-conformance-http-005.md
@@ -1,5 +1,14 @@
 # Test field aliasing
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query

--- a/tests/execution/graphql-conformance-http-005.md
+++ b/tests/execution/graphql-conformance-http-005.md
@@ -1,6 +1,6 @@
 # Test field aliasing
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-006.md
+++ b/tests/execution/graphql-conformance-http-006.md
@@ -1,6 +1,6 @@
 # Test complex nested query
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-006.md
+++ b/tests/execution/graphql-conformance-http-006.md
@@ -1,7 +1,16 @@
 # Test complex nested query
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-007.md
+++ b/tests/execution/graphql-conformance-http-007.md
@@ -1,6 +1,6 @@
 # Test named fragments.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-007.md
+++ b/tests/execution/graphql-conformance-http-007.md
@@ -1,7 +1,16 @@
 # Test named fragments.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-008.md
+++ b/tests/execution/graphql-conformance-http-008.md
@@ -1,6 +1,6 @@
 # Test inline fragments.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-008.md
+++ b/tests/execution/graphql-conformance-http-008.md
@@ -1,7 +1,16 @@
 # Test inline fragments.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-009.md
+++ b/tests/execution/graphql-conformance-http-009.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because we do not check that variables are defined
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-009.md
+++ b/tests/execution/graphql-conformance-http-009.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because we do not check that variables are defined
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-010.md
+++ b/tests/execution/graphql-conformance-http-010.md
@@ -1,7 +1,16 @@
 # Test ordering of input fields
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-010.md
+++ b/tests/execution/graphql-conformance-http-010.md
@@ -1,6 +1,6 @@
 # Test ordering of input fields
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-011.md
+++ b/tests/execution/graphql-conformance-http-011.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: Skipped because Tailcall does not parse the scalar type correctly into a string.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-011.md
+++ b/tests/execution/graphql-conformance-http-011.md
@@ -6,8 +6,17 @@ skip: true
 
 TODO: Skipped because Tailcall does not parse the scalar type correctly into a string.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-012.md
+++ b/tests/execution/graphql-conformance-http-012.md
@@ -1,6 +1,6 @@
 # Test unions
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-012.md
+++ b/tests/execution/graphql-conformance-http-012.md
@@ -1,7 +1,16 @@
 # Test unions
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-013.md
+++ b/tests/execution/graphql-conformance-http-013.md
@@ -1,7 +1,16 @@
 # Test schema inspection
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-013.md
+++ b/tests/execution/graphql-conformance-http-013.md
@@ -1,6 +1,6 @@
 # Test schema inspection
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-014.md
+++ b/tests/execution/graphql-conformance-http-014.md
@@ -1,6 +1,6 @@
 # Test double query
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-014.md
+++ b/tests/execution/graphql-conformance-http-014.md
@@ -1,7 +1,16 @@
 # Test double query
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-015.md
+++ b/tests/execution/graphql-conformance-http-015.md
@@ -1,6 +1,6 @@
 # Optional input fields
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-http-015.md
+++ b/tests/execution/graphql-conformance-http-015.md
@@ -1,7 +1,16 @@
 # Optional input fields
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-017.md
+++ b/tests/execution/graphql-conformance-http-017.md
@@ -1,7 +1,16 @@
 # Complex fragments.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-http-017.md
+++ b/tests/execution/graphql-conformance-http-017.md
@@ -1,6 +1,6 @@
 # Complex fragments.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-nested-lists-fragment.md
+++ b/tests/execution/graphql-conformance-nested-lists-fragment.md
@@ -1,7 +1,16 @@
 # List of lists.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-nested-lists-fragment.md
+++ b/tests/execution/graphql-conformance-nested-lists-fragment.md
@@ -1,6 +1,6 @@
 # List of lists.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-nested-lists-http.md
+++ b/tests/execution/graphql-conformance-nested-lists-http.md
@@ -1,7 +1,16 @@
 # List of lists.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-nested-lists-http.md
+++ b/tests/execution/graphql-conformance-nested-lists-http.md
@@ -1,6 +1,6 @@
 # List of lists.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-conformance-nested-lists.md
+++ b/tests/execution/graphql-conformance-nested-lists.md
@@ -1,7 +1,16 @@
 # List of lists.
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-conformance-nested-lists.md
+++ b/tests/execution/graphql-conformance-nested-lists.md
@@ -1,6 +1,6 @@
 # List of lists.
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-dataloader-batch-request.md
+++ b/tests/execution/graphql-dataloader-batch-request.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema @upstream(batch: {delay: 1}) {
   query: Query
 }

--- a/tests/execution/graphql-dataloader-batch-request.md
+++ b/tests/execution/graphql-dataloader-batch-request.md
@@ -1,7 +1,13 @@
 # Graphql datasource
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+```
+
 ```graphql @schema
-schema @upstream(batch: {delay: 1}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-dataloader-no-batch-request.md
+++ b/tests/execution/graphql-dataloader-no-batch-request.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema @upstream(batch: {delay: 1}) {
   query: Query
 }

--- a/tests/execution/graphql-dataloader-no-batch-request.md
+++ b/tests/execution/graphql-dataloader-no-batch-request.md
@@ -1,7 +1,13 @@
 # Graphql datasource
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+```
+
 ```graphql @schema
-schema @upstream(batch: {delay: 1}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-datasource-errors.md
+++ b/tests/execution/graphql-datasource-errors.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/graphql-datasource-mutation.md
+++ b/tests/execution/graphql-datasource-mutation.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
   mutation: Mutation

--- a/tests/execution/graphql-datasource-no-args.md
+++ b/tests/execution/graphql-datasource-no-args.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/graphql-datasource-query-directives.md
+++ b/tests/execution/graphql-datasource-query-directives.md
@@ -2,7 +2,7 @@
 
 Directives in query should be passed as is
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/graphql-datasource-with-args.md
+++ b/tests/execution/graphql-datasource-with-args.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/graphql-datasource-with-empty-enum.md
+++ b/tests/execution/graphql-datasource-with-empty-enum.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/graphql-datasource-with-mandatory-enum.md
+++ b/tests/execution/graphql-datasource-with-mandatory-enum.md
@@ -1,6 +1,6 @@
 # Graphql datasource
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/graphql-nested-datasource.md
+++ b/tests/execution/graphql-nested-datasource.md
@@ -1,7 +1,16 @@
 # GraphQL datasource inside another graphQL datasource
 
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/graphql-nested-datasource.md
+++ b/tests/execution/graphql-nested-datasource.md
@@ -1,6 +1,6 @@
 # GraphQL datasource inside another graphQL datasource
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/graphql-nested.md
+++ b/tests/execution/graphql-nested.md
@@ -1,6 +1,6 @@
 # Complicated queries
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "0.0.0.0") {
   query: Query
 }

--- a/tests/execution/grpc-batch.md
+++ b/tests/execution/grpc-batch.md
@@ -1,5 +1,18 @@
 # Grpc datasource with batching
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```protobuf @file:news.proto
 syntax = "proto3";
 
@@ -37,10 +50,7 @@ message NewsList {
 ```
 
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(httpCache: 42, batch: {delay: 10})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-batch.md
+++ b/tests/execution/grpc-batch.md
@@ -36,7 +36,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(httpCache: 42, batch: {delay: 10})

--- a/tests/execution/grpc-error.md
+++ b/tests/execution/grpc-error.md
@@ -36,11 +36,21 @@ message NewsList {
 }
 ```
 
+```yaml @config
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+server:
+  port: 8000
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(httpCache: 42, batch: {delay: 10})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 
@@ -49,12 +59,14 @@ type Query {
   newsById(news: NewsInput!): News!
     @grpc(method: "news.NewsService.GetNews", url: "http://localhost:50051", body: "{{.args.news}}")
 }
+
 input NewsInput {
   id: Int
   title: String
   body: String
   postImage: String
 }
+
 type NewsData {
   news: [News]
 }

--- a/tests/execution/grpc-error.md
+++ b/tests/execution/grpc-error.md
@@ -36,7 +36,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(httpCache: 42, batch: {delay: 10})

--- a/tests/execution/grpc-json.md
+++ b/tests/execution/grpc-json.md
@@ -36,7 +36,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/grpc-json.md
+++ b/tests/execution/grpc-json.md
@@ -36,8 +36,17 @@ message NewsList {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @server(port: 8000) @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-map.md
+++ b/tests/execution/grpc-map.md
@@ -1,5 +1,17 @@
 # Grpc map type
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+links:
+  - src: "map.proto"
+    type: Protobuf
+```
+
 ```protobuf @file:map.proto
 syntax = "proto3";
 
@@ -20,11 +32,7 @@ service MapService {
 ```
 
 ```graphql @schema
-schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 10}) @link(src: "map.proto", type: Protobuf) {
-  query: Query
-}
-
-schema @server @upstream {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-map.md
+++ b/tests/execution/grpc-map.md
@@ -19,7 +19,7 @@ service MapService {
 
 ```
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 10}) @link(src: "map.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/grpc-oneof.md
+++ b/tests/execution/grpc-oneof.md
@@ -44,7 +44,7 @@ service OneOfService {
 
 ```
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 10}) @link(src: "oneof.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/grpc-oneof.md
+++ b/tests/execution/grpc-oneof.md
@@ -44,8 +44,20 @@ service OneOfService {
 
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+links:
+  - src: "oneof.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @server(port: 8000) @upstream(httpCache: 42, batch: {delay: 10}) @link(src: "oneof.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-proto-with-same-package.md
+++ b/tests/execution/grpc-proto-with-same-package.md
@@ -33,8 +33,18 @@ service BarService {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+links:
+  - src: "foo.proto"
+    type: Protobuf
+  - src: "bar.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @server(port: 8000) @link(src: "foo.proto", type: Protobuf) @link(src: "bar.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-proto-with-same-package.md
+++ b/tests/execution/grpc-proto-with-same-package.md
@@ -33,7 +33,7 @@ service BarService {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @link(src: "foo.proto", type: Protobuf) @link(src: "bar.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/grpc-reflection.md
+++ b/tests/execution/grpc-reflection.md
@@ -1,6 +1,6 @@
 # Grpc datasource
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream(httpCache: 42) @link(src: "http://localhost:50051", type: Grpc) {
   query: Query
 }

--- a/tests/execution/grpc-reflection.md
+++ b/tests/execution/grpc-reflection.md
@@ -1,7 +1,17 @@
 # Grpc datasource
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+links:
+  - src: "http://localhost:50051"
+    type: Grpc
+```
+
 ```graphql @schema
-schema @server(port: 8000) @upstream(httpCache: 42) @link(src: "http://localhost:50051", type: Grpc) {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-simple.md
+++ b/tests/execution/grpc-simple.md
@@ -36,11 +36,21 @@ message NewsList {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(httpCache: 42, batch: {delay: 10})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-simple.md
+++ b/tests/execution/grpc-simple.md
@@ -36,7 +36,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(httpCache: 42, batch: {delay: 10})

--- a/tests/execution/grpc-url-from-upstream.md
+++ b/tests/execution/grpc-url-from-upstream.md
@@ -36,11 +36,21 @@ message NewsList {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(httpCache: 42, batch: {delay: 10})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/grpc-url-from-upstream.md
+++ b/tests/execution/grpc-url-from-upstream.md
@@ -36,7 +36,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(httpCache: 42, batch: {delay: 10})

--- a/tests/execution/http-select.md
+++ b/tests/execution/http-select.md
@@ -1,7 +1,16 @@
 # Basic queries with field ordering check
 
+```yaml @config
+server:
+  port: 8001
+  queryValidation: false
+  hostname: "0.0.0.0"
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/http-select.md
+++ b/tests/execution/http-select.md
@@ -1,6 +1,6 @@
 # Basic queries with field ordering check
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/inline-field.md
+++ b/tests/execution/inline-field.md
@@ -1,6 +1,6 @@
 # Inline field
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/inline-index-list.md
+++ b/tests/execution/inline-index-list.md
@@ -1,6 +1,6 @@
 # Test inline index list
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/inline-many-list.md
+++ b/tests/execution/inline-many-list.md
@@ -4,7 +4,7 @@ identity: true
 
 # inline-many-list
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/inline-many.md
+++ b/tests/execution/inline-many.md
@@ -4,7 +4,7 @@ identity: true
 
 # inline-many
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/input-type-protected-error.md
+++ b/tests/execution/input-type-protected-error.md
@@ -4,7 +4,7 @@ error: true
 
 # input-type-protected-error
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
   mutation: Mutation

--- a/tests/execution/introspection-query-with-disabled-introspection.md
+++ b/tests/execution/introspection-query-with-disabled-introspection.md
@@ -1,7 +1,17 @@
 # Test schema inspection with false flag
 
+```yaml @config
+server:
+  port: 8001
+  queryValidation: false
+  hostname: "0.0.0.0"
+  introspection: false
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0", introspection: false) @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/introspection-query-with-disabled-introspection.md
+++ b/tests/execution/introspection-query-with-disabled-introspection.md
@@ -1,6 +1,6 @@
 # Test schema inspection with false flag
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8001, queryValidation: false, hostname: "0.0.0.0", introspection: false) @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/io-cache.md
+++ b/tests/execution/io-cache.md
@@ -1,6 +1,6 @@
 # Call operator with GraphQL data source
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "0.0.0.0") @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/io-cache.md
+++ b/tests/execution/io-cache.md
@@ -1,7 +1,15 @@
 # Call operator with GraphQL data source
 
+```yaml @config
+server:
+  port: 8000
+  hostname: "0.0.0.0"
+upstream:
+  httpCache: 42
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "0.0.0.0") @upstream(httpCache: 42) {
+schema {
   query: Query
 }
 

--- a/tests/execution/jit-enum-array.md
+++ b/tests/execution/jit-enum-array.md
@@ -1,6 +1,6 @@
 # Test expr with mustache
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/js-directive.md
+++ b/tests/execution/js-directive.md
@@ -11,8 +11,14 @@ function name(val) {
 }
 ```
 
+```yaml @config
+links:
+  - type: Script
+    src: test.js
+```
+
 ```graphql @schema
-schema @server @link(type: Script, src: "test.js") {
+schema {
   query: Query
 }
 

--- a/tests/execution/js-directive.md
+++ b/tests/execution/js-directive.md
@@ -11,7 +11,7 @@ function name(val) {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @link(type: Script, src: "test.js") {
   query: Query
 }

--- a/tests/execution/jsonplaceholder-call-post.md
+++ b/tests/execution/jsonplaceholder-call-post.md
@@ -1,7 +1,17 @@
 # jsonplaceholder-call-post
 
+```yaml @config
+server:
+  port: 8000
+  hostname: "0.0.0.0"
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "0.0.0.0") @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/jsonplaceholder-call-post.md
+++ b/tests/execution/jsonplaceholder-call-post.md
@@ -1,6 +1,6 @@
 # jsonplaceholder-call-post
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "0.0.0.0") @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/merge-linked-config.md
+++ b/tests/execution/merge-linked-config.md
@@ -3,7 +3,7 @@
 Merge should happen only on schema while configurations like schema, upstream, telemetry should be defined only by the root config
 
 ```graphql @file:link-1.graphql
-schema @server(port: 3000) @upstream(httpCache: 42, batch: {delay: 22}) {
+schema {
   query: Query
 }
 
@@ -17,7 +17,7 @@ type Query {
 ```
 
 ```graphql @file:link-2.graphql
-schema @server(port: 4000) @upstream(httpCache: 33, batch: {delay: 48}) {
+schema {
   query: Query
 }
 
@@ -38,12 +38,22 @@ type User {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 10
+  batch:
+    delay: 10
+links:
+  - src: "link-1.graphql"
+    type: Config
+  - src: "link-2.graphql"
+    type: Config
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(httpCache: 10, batch: {delay: 10})
-  @link(src: "link-1.graphql", type: Config)
-  @link(src: "link-2.graphql", type: Config) {
+schema {
   query: Query
 }
 ```

--- a/tests/execution/merge-linked-config.md
+++ b/tests/execution/merge-linked-config.md
@@ -38,7 +38,7 @@ type User {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(httpCache: 10, batch: {delay: 10})

--- a/tests/execution/modified-field.md
+++ b/tests/execution/modified-field.md
@@ -1,6 +1,6 @@
 # Modified field
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/mutation-put.md
+++ b/tests/execution/mutation-put.md
@@ -1,6 +1,6 @@
 # Mutation put
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
   mutation: Mutation

--- a/tests/execution/mutation.md
+++ b/tests/execution/mutation.md
@@ -1,6 +1,6 @@
 # Mutation
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
   mutation: Mutation

--- a/tests/execution/n-plus-one-list.md
+++ b/tests/execution/n-plus-one-list.md
@@ -1,7 +1,14 @@
 # n + 1 Request List
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @upstream(batch: {delay: 1, maxSize: 1000}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/n-plus-one-list.md
+++ b/tests/execution/n-plus-one-list.md
@@ -1,6 +1,6 @@
 # n + 1 Request List
 
-```graphql @config
+```graphql @schema
 schema @upstream(batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/n-plus-one.md
+++ b/tests/execution/n-plus-one.md
@@ -1,7 +1,14 @@
 # n + 1 Request
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @upstream(batch: {delay: 1, maxSize: 1000}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/n-plus-one.md
+++ b/tests/execution/n-plus-one.md
@@ -1,6 +1,6 @@
 # n + 1 Request
 
-```graphql @config
+```graphql @schema
 schema @upstream(batch: {delay: 1, maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/nested-objects.md
+++ b/tests/execution/nested-objects.md
@@ -1,6 +1,6 @@
 # Nested objects
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/nested-recursive-types.md
+++ b/tests/execution/nested-recursive-types.md
@@ -1,6 +1,6 @@
 # Nested Recursive Type
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
   mutation: Mutation

--- a/tests/execution/nesting-level3.md
+++ b/tests/execution/nesting-level3.md
@@ -1,6 +1,6 @@
 # Nesting level 3
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/non-scalar-value-in-query.md
+++ b/tests/execution/non-scalar-value-in-query.md
@@ -4,7 +4,7 @@ error: true
 
 # test objects in args
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/nullable-arg-query.md
+++ b/tests/execution/nullable-arg-query.md
@@ -1,6 +1,6 @@
 # Nullable arg query
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/omit-index-list.md
+++ b/tests/execution/omit-index-list.md
@@ -1,6 +1,6 @@
 # Test inline index list
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/omit-many.md
+++ b/tests/execution/omit-many.md
@@ -4,7 +4,7 @@ identity: true
 
 # omit-many
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/omit-resolved-by-parent.md
+++ b/tests/execution/omit-resolved-by-parent.md
@@ -1,6 +1,6 @@
 # Resolved by parent
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/on-response-body-grpc.md
+++ b/tests/execution/on-response-body-grpc.md
@@ -31,7 +31,7 @@ message NewsId {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @link(type: Script, src: "test.js") @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/on-response-body-grpc.md
+++ b/tests/execution/on-response-body-grpc.md
@@ -31,8 +31,19 @@ message NewsId {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+links:
+  - type: Script
+    src: "test.js"
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @server(port: 8000) @link(type: Script, src: "test.js") @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/predefined-scalar.md
+++ b/tests/execution/predefined-scalar.md
@@ -2,7 +2,7 @@
 error: true
 ---
 
-```graphql @config
+```graphql @schema
 scalar Boolean
 scalar Float
 scalar ID

--- a/tests/execution/recursive-types-no-resolver.md
+++ b/tests/execution/recursive-types-no-resolver.md
@@ -6,7 +6,7 @@ error: true
 
 Should throw error about missing resolver without panicking with stack overflow error.
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/recursive-types.md
+++ b/tests/execution/recursive-types.md
@@ -1,6 +1,6 @@
 # Recursive Type
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
   mutation: Mutation

--- a/tests/execution/ref-other-nested.md
+++ b/tests/execution/ref-other-nested.md
@@ -1,6 +1,6 @@
 # Ref other nested
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/ref-other.md
+++ b/tests/execution/ref-other.md
@@ -1,6 +1,6 @@
 # Ref other
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/related-fields-recursive.md
+++ b/tests/execution/related-fields-recursive.md
@@ -1,4 +1,4 @@
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "0.0.0.0") {
   query: Query
 }

--- a/tests/execution/related-fields-recursive.md
+++ b/tests/execution/related-fields-recursive.md
@@ -1,5 +1,11 @@
+```yaml @config
+server:
+  port: 8000
+  hostname: "0.0.0.0"
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "0.0.0.0") {
+schema {
   query: Query
 }
 

--- a/tests/execution/rename-field.md
+++ b/tests/execution/rename-field.md
@@ -1,6 +1,6 @@
 # Rename field
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/request-to-upstream-batching.md
+++ b/tests/execution/request-to-upstream-batching.md
@@ -1,7 +1,16 @@
 # Batched graphql request to batched upstream query
 
+```yaml @config
+server:
+  batchRequests: true
+upstream:
+  batch:
+    delay: 1
+    maxSize: 100
+```
+
 ```graphql @schema
-schema @server(batchRequests: true) @upstream(batch: {maxSize: 100, delay: 1, headers: []}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/request-to-upstream-batching.md
+++ b/tests/execution/request-to-upstream-batching.md
@@ -1,6 +1,6 @@
 # Batched graphql request to batched upstream query
 
-```graphql @config
+```graphql @schema
 schema @server(batchRequests: true) @upstream(batch: {maxSize: 100, delay: 1, headers: []}) {
   query: Query
 }

--- a/tests/execution/resolve-with-headers.md
+++ b/tests/execution/resolve-with-headers.md
@@ -1,7 +1,13 @@
 # Resolve with headers
 
+```yaml @config
+upstream:
+  allowedHeaders:
+    - authorization
+```
+
 ```graphql @schema
-schema @upstream(allowedHeaders: ["authorization"]) {
+schema {
   query: Query
 }
 

--- a/tests/execution/resolve-with-headers.md
+++ b/tests/execution/resolve-with-headers.md
@@ -1,6 +1,6 @@
 # Resolve with headers
 
-```graphql @config
+```graphql @schema
 schema @upstream(allowedHeaders: ["authorization"]) {
   query: Query
 }

--- a/tests/execution/resolve-with-vars.md
+++ b/tests/execution/resolve-with-vars.md
@@ -1,6 +1,6 @@
 # Resolve with vars
 
-```graphql @config
+```graphql @schema
 schema @server(vars: [{key: "id", value: "1"}]) {
   query: Query
 }

--- a/tests/execution/resolve-with-vars.md
+++ b/tests/execution/resolve-with-vars.md
@@ -1,7 +1,12 @@
 # Resolve with vars
 
+```yaml @config
+server:
+  vars: [{key: "id", value: "1"}]
+```
+
 ```graphql @schema
-schema @server(vars: [{key: "id", value: "1"}]) {
+schema {
   query: Query
 }
 

--- a/tests/execution/resolved-by-parent.md
+++ b/tests/execution/resolved-by-parent.md
@@ -1,6 +1,6 @@
 # Resolved by parent
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/rest-api-error.md
+++ b/tests/execution/rest-api-error.md
@@ -9,7 +9,7 @@ query ($id: Int!) @rest(method: GET, path: "/user/$id") {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @link(type: Operation, src: "operation-user.graphql") {
   query: Query
 }

--- a/tests/execution/rest-api-error.md
+++ b/tests/execution/rest-api-error.md
@@ -9,8 +9,14 @@ query ($id: Int!) @rest(method: GET, path: "/user/$id") {
 }
 ```
 
+```yaml @config
+links:
+  - type: Operation
+    src: operation-user.graphql
+```
+
 ```graphql @schema
-schema @server @link(type: Operation, src: "operation-user.graphql") {
+schema {
   query: Query
 }
 

--- a/tests/execution/rest-api-post.md
+++ b/tests/execution/rest-api-post.md
@@ -9,7 +9,7 @@ query ($id: Int!) @rest(method: POST, path: "/user/$id") {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @link(type: Operation, src: "operation-user.graphql") {
   query: Query
 }

--- a/tests/execution/rest-api-post.md
+++ b/tests/execution/rest-api-post.md
@@ -9,8 +9,14 @@ query ($id: Int!) @rest(method: POST, path: "/user/$id") {
 }
 ```
 
+```yaml @config
+links:
+  - type: Operation
+    src: operation-user.graphql
+```
+
 ```graphql @schema
-schema @server @link(type: Operation, src: "operation-user.graphql") {
+schema {
   query: Query
 }
 

--- a/tests/execution/rest-api.md
+++ b/tests/execution/rest-api.md
@@ -9,7 +9,7 @@ query ($id: Int!) @rest(method: GET, path: "/user/$id") {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @link(type: Operation, src: "operation-user.graphql") {
   query: Query
 }

--- a/tests/execution/rest-api.md
+++ b/tests/execution/rest-api.md
@@ -9,8 +9,14 @@ query ($id: Int!) @rest(method: GET, path: "/user/$id") {
 }
 ```
 
+```yaml @config
+links:
+  - type: Operation
+    src: operation-user.graphql
+```
+
 ```graphql @schema
-schema @server @link(type: Operation, src: "operation-user.graphql") {
+schema {
   query: Query
 }
 

--- a/tests/execution/routes-param-on-server-directive.md
+++ b/tests/execution/routes-param-on-server-directive.md
@@ -1,7 +1,15 @@
 # Sending field index list
 
+```yaml @config
+server:
+  port: 8000
+  routes:
+    graphQL: "/tailcall-gql"
+    status: "/health"
+```
+
 ```graphql @schema
-schema @server(port: 8000, routes: {graphQL: "/tailcall-gql", status: "/health"}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/routes-param-on-server-directive.md
+++ b/tests/execution/routes-param-on-server-directive.md
@@ -1,6 +1,6 @@
 # Sending field index list
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, routes: {graphQL: "/tailcall-gql", status: "/health"}) {
   query: Query
 }

--- a/tests/execution/showcase.md
+++ b/tests/execution/showcase.md
@@ -1,6 +1,6 @@
 # Showcase GraphQL Request
 
-```graphql @config
+```graphql @schema
 schema @server(showcase: true) {
   query: Query
 }

--- a/tests/execution/showcase.md
+++ b/tests/execution/showcase.md
@@ -1,7 +1,12 @@
 # Showcase GraphQL Request
 
+```yaml @config
+server:
+  showcase: true
+```
+
 ```graphql @schema
-schema @server(showcase: true) {
+schema {
   query: Query
 }
 

--- a/tests/execution/simple-graphql.md
+++ b/tests/execution/simple-graphql.md
@@ -1,6 +1,6 @@
 # Simple GraphQL Request
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/simple-query.md
+++ b/tests/execution/simple-query.md
@@ -1,6 +1,6 @@
 # Simple query
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-add-field-error.md
+++ b/tests/execution/test-add-field-error.md
@@ -4,7 +4,7 @@ error: true
 
 # test-add-field-error
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-add-field-list.md
+++ b/tests/execution/test-add-field-list.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-add-field-list
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-add-field.md
+++ b/tests/execution/test-add-field.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-add-field
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-add-link-to-empty-config.md
+++ b/tests/execution/test-add-link-to-empty-config.md
@@ -29,7 +29,7 @@ type Query {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @upstream @link(src: "link-expr.graphql", type: Config) @link(src: "link-enum.graphql", type: Config) {
   query: Query
 }

--- a/tests/execution/test-add-link-to-empty-config.md
+++ b/tests/execution/test-add-link-to-empty-config.md
@@ -4,6 +4,14 @@ identity: true
 
 # test-add-link-to-empty-config
 
+```yaml @config
+links:
+  - src: "link-expr.graphql"
+    type: Config
+  - src: "link-enum.graphql"
+    type: Config
+```
+
 ```graphql @file:link-expr.graphql
 schema @server @upstream {
   query: Query
@@ -15,7 +23,7 @@ type Query {
 ```
 
 ```graphql @file:link-enum.graphql
-schema @server {
+schema @server @upstream {
   query: Query
 }
 
@@ -30,7 +38,7 @@ type Query {
 ```
 
 ```graphql @schema
-schema @server @upstream @link(src: "link-expr.graphql", type: Config) @link(src: "link-enum.graphql", type: Config) {
+schema @server @upstream {
   query: Query
 }
 ```

--- a/tests/execution/test-alias-on-enum.md
+++ b/tests/execution/test-alias-on-enum.md
@@ -1,11 +1,17 @@
 # test-alias-on-enum
 
-```graphql @schema
-schema @server(batchRequests: true) @upstream(batch: {delay: 1, headers: [], maxSize: 100}) {
-  query: Query
-}
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    headers: []
+    maxSize: 100
+server:
+  batchRequests: true
+```
 
-schema @server(enableJIT: false) {
+```graphql @schema
+schema {
   query: Query
 }
 

--- a/tests/execution/test-alias-on-enum.md
+++ b/tests/execution/test-alias-on-enum.md
@@ -1,6 +1,6 @@
 # test-alias-on-enum
 
-```graphql @config
+```graphql @schema
 schema @server(batchRequests: true) @upstream(batch: {delay: 1, headers: [], maxSize: 100}) {
   query: Query
 }

--- a/tests/execution/test-all-blueprint-errors.md
+++ b/tests/execution/test-all-blueprint-errors.md
@@ -4,7 +4,7 @@ error: true
 
 # test-all-blueprint-errors
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
   mutation: Mutation

--- a/tests/execution/test-batch-operator-post.md
+++ b/tests/execution/test-batch-operator-post.md
@@ -4,8 +4,14 @@ error: true
 
 # test-batch-operator-post
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+```
+
 ```graphql @schema
-schema @server @upstream(batch: {delay: 1}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-batch-operator-post.md
+++ b/tests/execution/test-batch-operator-post.md
@@ -4,7 +4,7 @@ error: true
 
 # test-batch-operator-post
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(batch: {delay: 1}) {
   query: Query
 }

--- a/tests/execution/test-batching-group-by.md
+++ b/tests/execution/test-batching-group-by.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-batching-group-by
 
-```graphql @config
+```graphql @schema
 schema @server(port: 4000) @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
   query: Query
 }

--- a/tests/execution/test-batching-group-by.md
+++ b/tests/execution/test-batching-group-by.md
@@ -4,8 +4,17 @@ identity: true
 
 # test-batching-group-by
 
+```yaml @config
+server:
+  port: 4000
+upstream:
+  batch:
+    delay: 1
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @server(port: 4000) @upstream(batch: {delay: 1, headers: [], maxSize: 1000}) {
+schema @server @upstream {
   query: Query
 }
 

--- a/tests/execution/test-cache.md
+++ b/tests/execution/test-cache.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-cache
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-call-operator-errors.md
+++ b/tests/execution/test-call-operator-errors.md
@@ -4,7 +4,7 @@ error: true
 
 # test-call-operator
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-custom-scalar.md
+++ b/tests/execution/test-custom-scalar.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-custom-scalar
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-custom-types.md
+++ b/tests/execution/test-custom-types.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-custom-types
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Que
   mutation: Mut

--- a/tests/execution/test-dbl-usage-many.md
+++ b/tests/execution/test-dbl-usage-many.md
@@ -1,6 +1,6 @@
 # test-dbl-usage
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-dedupe.md
+++ b/tests/execution/test-dedupe.md
@@ -1,6 +1,6 @@
 # testing dedupe functionality
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream(batch: {delay: 1}) {
   query: Query
 }

--- a/tests/execution/test-dedupe.md
+++ b/tests/execution/test-dedupe.md
@@ -1,7 +1,15 @@
 # testing dedupe functionality
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  batch:
+    delay: 1
+```
+
 ```graphql @schema
-schema @server(port: 8000) @upstream(batch: {delay: 1}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-description-many.md
+++ b/tests/execution/test-description-many.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-description-many
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-directives-undef-null-fields.md
+++ b/tests/execution/test-directives-undef-null-fields.md
@@ -4,8 +4,13 @@ error: true
 
 # test-directives-undef-null-fields
 
+```yaml @config
+server:
+  vars: [{key: "a", value: "1"}, {key: "c", value: "d"}]
+```
+
 ```graphql @schema
-schema @server(vars: [{key: "a", value: "1"}, {key: "c", value: "d"}]) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-directives-undef-null-fields.md
+++ b/tests/execution/test-directives-undef-null-fields.md
@@ -4,7 +4,7 @@ error: true
 
 # test-directives-undef-null-fields
 
-```graphql @config
+```graphql @schema
 schema @server(vars: [{key: "a", value: "1"}, {key: "c", value: "d"}]) {
   query: Query
 }

--- a/tests/execution/test-discriminator-invalid.md
+++ b/tests/execution/test-discriminator-invalid.md
@@ -4,7 +4,7 @@ error: true
 
 # Test union type resolve
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-duplicated-link.md
+++ b/tests/execution/test-duplicated-link.md
@@ -33,7 +33,7 @@ type Post {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder")
   @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder1")

--- a/tests/execution/test-duplicated-link.md
+++ b/tests/execution/test-duplicated-link.md
@@ -4,8 +4,27 @@ error: true
 
 # test-duplicated-link
 
+```yaml @config
+links:
+  - id: placeholder
+    src: jsonplaceholder.graphql
+    type: Config
+  - id: placeholder1
+    src: jsonplaceholder.graphql
+    type: Config
+  - id: placeholder1
+    src: jsonplaceholder.graphql
+    type: Config
+  - id: placeholder2
+    src: jsonplaceholder.graphql
+    type: Config
+  - id: placeholder2
+    src: jsonplaceholder.graphql
+    type: Config
+```
+
 ```graphql @file:jsonplaceholder.graphql
-schema @server(port: 8000, hostname: "0.0.0.0") @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 
@@ -34,12 +53,7 @@ type Post {
 ```
 
 ```graphql @schema
-schema
-  @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder")
-  @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder1")
-  @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder1")
-  @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder2")
-  @link(type: Config, src: "jsonplaceholder.graphql", id: "placeholder2") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-empty-link.md
+++ b/tests/execution/test-empty-link.md
@@ -4,8 +4,15 @@ error: true
 
 # test-empty-link
 
+```yaml @config
+links:
+  - type: Config
+    src: ""
+  - type: Config
+```
+
 ```graphql @schema
-schema @link(type: Config, src: "") @link(type: Config) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-empty-link.md
+++ b/tests/execution/test-empty-link.md
@@ -4,7 +4,7 @@ error: true
 
 # test-empty-link
 
-```graphql @config
+```graphql @schema
 schema @link(type: Config, src: "") @link(type: Config) {
   query: Query
 }

--- a/tests/execution/test-enable-jit.md
+++ b/tests/execution/test-enable-jit.md
@@ -1,7 +1,14 @@
 # test-enable-jit
 
+```yaml @config
+server:
+  port: 8000
+  hostname: "0.0.0.0"
+  enableJIT: true
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "0.0.0.0", enableJIT: true) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-enable-jit.md
+++ b/tests/execution/test-enable-jit.md
@@ -1,6 +1,6 @@
 # test-enable-jit
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "0.0.0.0", enableJIT: true) {
   query: Query
 }

--- a/tests/execution/test-enum-aliases.md
+++ b/tests/execution/test-enum-aliases.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-enum-aliases
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-enum-as-argument.md
+++ b/tests/execution/test-enum-as-argument.md
@@ -1,6 +1,6 @@
 # test enum as argument
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-enum-default.md
+++ b/tests/execution/test-enum-default.md
@@ -28,12 +28,22 @@ message NewsList {
 }
 ```
 
+```yaml @config
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+server:
+  port: 8080
+links:
+  - id: "news"
+    src: "./service.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
 # for test upstream server see [repo](https://github.com/tailcallhq/rust-grpc)
-schema
-  @server(port: 8080)
-  @upstream(httpCache: 42, batch: {delay: 10})
-  @link(id: "news", src: "./service.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-enum-default.md
+++ b/tests/execution/test-enum-default.md
@@ -28,7 +28,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 # for test upstream server see [repo](https://github.com/tailcallhq/rust-grpc)
 schema
   @server(port: 8080)

--- a/tests/execution/test-enum-description.md
+++ b/tests/execution/test-enum-description.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-enum-description
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-enum-empty.md
+++ b/tests/execution/test-enum-empty.md
@@ -4,7 +4,7 @@ error: true
 
 # test-enum-empty
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-enum-merge.md
+++ b/tests/execution/test-enum-merge.md
@@ -1,6 +1,6 @@
 # test-enum-merge
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }
@@ -15,7 +15,7 @@ type Query {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-enum.md
+++ b/tests/execution/test-enum.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-enum
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-eval-partial.md
+++ b/tests/execution/test-eval-partial.md
@@ -1,4 +1,4 @@
-```graphql @config
+```graphql @schema
 schema @server(port: 8080) @upstream(httpCache: 42, batch: {delay: 100}) {
   query: Query
 }

--- a/tests/execution/test-eval-partial.md
+++ b/tests/execution/test-eval-partial.md
@@ -1,5 +1,14 @@
+```yaml @config
+server:
+  port: 8080
+upstream:
+  httpCache: 42
+  batch:
+    delay: 100
+```
+
 ```graphql @schema
-schema @server(port: 8080) @upstream(httpCache: 42, batch: {delay: 100}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-expr-error.md
+++ b/tests/execution/test-expr-error.md
@@ -4,7 +4,7 @@ error: true
 
 # test-expr-error
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-expr-scalar-as-string.md
+++ b/tests/execution/test-expr-scalar-as-string.md
@@ -1,6 +1,6 @@
 # Test expr for data that contains scalar type in string
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-expr-with-add-field.md
+++ b/tests/execution/test-expr-with-add-field.md
@@ -4,7 +4,7 @@ error: true
 
 # test-expr-with-add-field
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-expr-with-inline.md
+++ b/tests/execution/test-expr-with-inline.md
@@ -4,7 +4,7 @@ error: true
 
 # test-expr-with-inline
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-expr-with-mustache.md
+++ b/tests/execution/test-expr-with-mustache.md
@@ -1,6 +1,6 @@
 # Test expr with mustache
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-expr.md
+++ b/tests/execution/test-expr.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-expr
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-field-already-implemented-from-Interface.md
+++ b/tests/execution/test-field-already-implemented-from-Interface.md
@@ -4,7 +4,7 @@ error: true
 
 # test-field-already-implemented-from-Interface
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-graphql-with-add-field.md
+++ b/tests/execution/test-graphql-with-add-field.md
@@ -4,7 +4,7 @@ error: true
 
 # test-graphql-with-add-field
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-graphqlsource-no-base-url.md
+++ b/tests/execution/test-graphqlsource-no-base-url.md
@@ -4,7 +4,7 @@ error: true
 
 # test-graphqlsource-no-base-url
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-graphqlsource.md
+++ b/tests/execution/test-graphqlsource.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-graphqlsource
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-groupby-without-batching.md
+++ b/tests/execution/test-groupby-without-batching.md
@@ -4,7 +4,7 @@ error: true
 
 # test-groupby-without-batching
 
-```graphql @config
+```graphql @schema
 schema @upstream(httpCache: 42) {
   query: Query
 }

--- a/tests/execution/test-grpc-group-by.md
+++ b/tests/execution/test-grpc-group-by.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(httpCache: 42, batch: {delay: 10})

--- a/tests/execution/test-grpc-group-by.md
+++ b/tests/execution/test-grpc-group-by.md
@@ -40,11 +40,21 @@ message NewsList {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(httpCache: 42, batch: {delay: 10})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-invalid-method-format.md
+++ b/tests/execution/test-grpc-invalid-method-format.md
@@ -4,7 +4,7 @@ error: true
 
 # test-grpc-invalid-method-format
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-grpc-invalid-proto-id.md
+++ b/tests/execution/test-grpc-invalid-proto-id.md
@@ -4,7 +4,7 @@ error: true
 
 # test-grpc-invalid-proto-id
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-grpc-missing-fields.md
+++ b/tests/execution/test-grpc-missing-fields.md
@@ -39,8 +39,15 @@ message NewsList {
 }
 ```
 
+```yaml @config
+links:
+  - id: news
+    src: news.proto
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-missing-fields.md
+++ b/tests/execution/test-grpc-missing-fields.md
@@ -39,7 +39,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-nested-data.md
+++ b/tests/execution/test-grpc-nested-data.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(httpCache: 42, batch: {delay: 10})

--- a/tests/execution/test-grpc-nested-data.md
+++ b/tests/execution/test-grpc-nested-data.md
@@ -40,11 +40,21 @@ message NewsList {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  httpCache: 42
+  batch:
+    delay: 10
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(httpCache: 42, batch: {delay: 10})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-nested-optional.md
+++ b/tests/execution/test-grpc-nested-optional.md
@@ -40,8 +40,15 @@ message NewsList {
 }
 ```
 
+```yaml @config
+links:
+  - id: news
+    src: news.proto
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-nested-optional.md
+++ b/tests/execution/test-grpc-nested-optional.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-optional.md
+++ b/tests/execution/test-grpc-optional.md
@@ -40,8 +40,15 @@ message NewsList {
 }
 ```
 
+```yaml @config
+links:
+  - id: news
+    src: news.proto
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-optional.md
+++ b/tests/execution/test-grpc-optional.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-proto-path.md
+++ b/tests/execution/test-grpc-proto-path.md
@@ -4,8 +4,15 @@ error: true
 
 # test-grpc-proto-path
 
+```yaml @config
+links:
+  - id: news
+    src: tailcall/src/grpcnews.proto
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @link(id: "news", src: "tailcall/src/grpcnews.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-proto-path.md
+++ b/tests/execution/test-grpc-proto-path.md
@@ -4,7 +4,7 @@ error: true
 
 # test-grpc-proto-path
 
-```graphql @config
+```graphql @schema
 schema @link(id: "news", src: "tailcall/src/grpcnews.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-service-method.md
+++ b/tests/execution/test-grpc-service-method.md
@@ -40,8 +40,15 @@ message NewsList {
 }
 ```
 
+```yaml @config
+links:
+  - id: news
+    src: news.proto
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-service-method.md
+++ b/tests/execution/test-grpc-service-method.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc-service.md
+++ b/tests/execution/test-grpc-service.md
@@ -40,8 +40,15 @@ message NewsList {
 }
 ```
 
+```yaml @config
+links:
+  - id: news
+    src: news.proto
+    type: Protobuf
+```
+
 ```graphql @schema
-schema @link(id: "news", src: "news.proto", type: Protobuf) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-grpc-service.md
+++ b/tests/execution/test-grpc-service.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-grpc.md
+++ b/tests/execution/test-grpc.md
@@ -40,11 +40,21 @@ message NewsList {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  batch:
+    delay: 10
+    maxSize: 1000
+links:
+  - id: "news"
+    src: "news.proto"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(batch: {delay: 10, headers: [], maxSize: 1000})
-  @link(id: "news", src: "news.proto", type: Protobuf) {
+schema @server @upstream {
   query: Query
 }
 

--- a/tests/execution/test-grpc.md
+++ b/tests/execution/test-grpc.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: [], maxSize: 1000})

--- a/tests/execution/test-hostname-faliure.md
+++ b/tests/execution/test-hostname-faliure.md
@@ -4,7 +4,7 @@ error: true
 
 # test-hostname-faliure
 
-```graphql @config
+```graphql @schema
 schema @server(hostname: "abc") {
   query: Query
 }

--- a/tests/execution/test-hostname-faliure.md
+++ b/tests/execution/test-hostname-faliure.md
@@ -4,8 +4,13 @@ error: true
 
 # test-hostname-faliure
 
+```yaml @config
+server:
+  hostname: abc
+```
+
 ```graphql @schema
-schema @server(hostname: "abc") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-http-baseurl.md
+++ b/tests/execution/test-http-baseurl.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-http-url
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-http-batchKey.md
+++ b/tests/execution/test-http-batchKey.md
@@ -1,6 +1,6 @@
 # Http with args as body
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream(batch: {maxSize: 1000, delay: 10}) {
   query: Query
 }

--- a/tests/execution/test-http-batchKey.md
+++ b/tests/execution/test-http-batchKey.md
@@ -1,7 +1,16 @@
 # Http with args as body
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  batch:
+    delay: 10
+    maxSize: 1000
+```
+
 ```graphql @schema
-schema @server(port: 8000) @upstream(batch: {maxSize: 1000, delay: 10}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-http-headers.md
+++ b/tests/execution/test-http-headers.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-http-headers
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-http-tmpl.md
+++ b/tests/execution/test-http-tmpl.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-http-tmpl
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-http-with-add-field.md
+++ b/tests/execution/test-http-with-add-field.md
@@ -4,7 +4,7 @@ error: true
 
 # test-http-with-add-field
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-http-with-inline.md
+++ b/tests/execution/test-http-with-inline.md
@@ -4,7 +4,7 @@ error: true
 
 # test-http-with-inline
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-http-with-mustache-expr.md
+++ b/tests/execution/test-http-with-mustache-expr.md
@@ -1,6 +1,6 @@
 # Test expr with mustache
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-http.md
+++ b/tests/execution/test-http.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-http
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-inline-error.md
+++ b/tests/execution/test-inline-error.md
@@ -4,7 +4,7 @@ error: true
 
 # test-inline-error
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-inline-list.md
+++ b/tests/execution/test-inline-list.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-inline-list
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-inline.md
+++ b/tests/execution/test-inline.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-inline
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-input-documentation.md
+++ b/tests/execution/test-input-documentation.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-input-type-documentation
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
   mutation: Mutation

--- a/tests/execution/test-input-out.md
+++ b/tests/execution/test-input-out.md
@@ -1,6 +1,6 @@
 # test-input-type
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-input-with-arg-out.md
+++ b/tests/execution/test-input-with-arg-out.md
@@ -1,6 +1,6 @@
 # test-input-with-arg-type
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-interface-result.md
+++ b/tests/execution/test-interface-result.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-interface-result
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-interface.md
+++ b/tests/execution/test-interface.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-interface
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-invalid-add-field.md
+++ b/tests/execution/test-invalid-add-field.md
@@ -4,7 +4,7 @@ error: true
 
 # Test invalid add fields
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) {
   query: Query
 }

--- a/tests/execution/test-invalid-query-in-http.md
+++ b/tests/execution/test-invalid-query-in-http.md
@@ -4,7 +4,7 @@ error: true
 
 # test-invalid-query-in-http
 
-```graphql @config
+```graphql @schema
 schema @server(vars: [{key: "id", value: "1"}]) {
   query: Query
 }

--- a/tests/execution/test-invalid-server.md
+++ b/tests/execution/test-invalid-server.md
@@ -4,7 +4,7 @@ error: true
 
 # test-invalid-server
 
-```graphql @config
+```graphql @schema
 schema @server(port: "8000") {
   query: Query
 }

--- a/tests/execution/test-js-multi-onRequest-handlers.md
+++ b/tests/execution/test-js-multi-onRequest-handlers.md
@@ -28,7 +28,7 @@ function bar({request}) {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(onRequest: "foo") @link(type: Script, src: "test1.js") {
   query: Query
 }

--- a/tests/execution/test-js-multi-onRequest-handlers.md
+++ b/tests/execution/test-js-multi-onRequest-handlers.md
@@ -28,8 +28,16 @@ function bar({request}) {
 }
 ```
 
+```yml @config
+upstream:
+  onRequest: "foo"
+links:
+  - type: Script
+    src: "test1.js"
+```
+
 ```graphql @schema
-schema @server @upstream(onRequest: "foo") @link(type: Script, src: "test1.js") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-js-multiple-scripts.md
+++ b/tests/execution/test-js-multiple-scripts.md
@@ -12,8 +12,18 @@ function onRequest(request) {}
 function onRequest(request) {}
 ```
 
+```yml @config
+upstream:
+  onRequest: "onRequest"
+links:
+  - type: Script
+    src: "test1.js"
+  - type: Script
+    src: "test2.js"
+```
+
 ```graphql @schema
-schema @server @link(type: Script, src: "test1.js") @link(type: Script, src: "test2.js") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-js-multiple-scripts.md
+++ b/tests/execution/test-js-multiple-scripts.md
@@ -12,7 +12,7 @@ function onRequest(request) {}
 function onRequest(request) {}
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @link(type: Script, src: "test1.js") @link(type: Script, src: "test2.js") {
   query: Query
 }

--- a/tests/execution/test-js-request-response-2.md
+++ b/tests/execution/test-js-request-response-2.md
@@ -24,8 +24,16 @@ function onRequest({request}) {
 }
 ```
 
+```yml @config
+upstream:
+  onRequest: "onRequest"
+links:
+  - type: Script
+    src: "test.js"
+```
+
 ```graphql @schema
-schema @server @upstream(onRequest: "onRequest") @link(type: Script, src: "test.js") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-js-request-response-2.md
+++ b/tests/execution/test-js-request-response-2.md
@@ -24,7 +24,7 @@ function onRequest({request}) {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(onRequest: "onRequest") @link(type: Script, src: "test.js") {
   query: Query
 }

--- a/tests/execution/test-js-request-response.md
+++ b/tests/execution/test-js-request-response.md
@@ -22,7 +22,7 @@ function onRequest({request}) {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(onRequest: "onRequest") @link(type: Script, src: "test.js") {
   query: Query
 }

--- a/tests/execution/test-js-request-response.md
+++ b/tests/execution/test-js-request-response.md
@@ -22,8 +22,16 @@ function onRequest({request}) {
 }
 ```
 
+```yml @config
+upstream:
+  onRequest: "onRequest"
+links:
+  - type: Script
+    src: "test.js"
+```
+
 ```graphql @schema
-schema @server @upstream(onRequest: "onRequest") @link(type: Script, src: "test.js") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-lack-resolver.md
+++ b/tests/execution/test-lack-resolver.md
@@ -4,7 +4,7 @@ error: true
 
 # test-lack-resolver
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) {
   query: Query
 }

--- a/tests/execution/test-link-support.md
+++ b/tests/execution/test-link-support.md
@@ -24,11 +24,24 @@ message NewsId {
 }
 ```
 
+```yaml @config
+server:
+  port: 8000
+upstream:
+  batch:
+    delay: 10
+    headers: []
+    maxSize: 1000
+links:
+  - id: "news"
+    src: "news.proto"
+    meta:
+      description: "Test"
+    type: Protobuf
+```
+
 ```graphql @schema
-schema
-  @server(port: 8000)
-  @upstream(batch: {delay: 10, headers: [], maxSize: 1000})
-  @link(id: "news", src: "news.proto", meta: {description: "Test"}, type: Protobuf) {
+schema @server @upstream {
   query: Query
 }
 

--- a/tests/execution/test-link-support.md
+++ b/tests/execution/test-link-support.md
@@ -24,7 +24,7 @@ message NewsId {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema
   @server(port: 8000)
   @upstream(batch: {delay: 10, headers: [], maxSize: 1000})

--- a/tests/execution/test-list-args.md
+++ b/tests/execution/test-list-args.md
@@ -1,7 +1,12 @@
 # With List args
 
+```yaml @config
+server:
+  queryValidation: true
+```
+
 ```graphql @schema
-schema @server(queryValidation: true) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-list-args.md
+++ b/tests/execution/test-list-args.md
@@ -1,6 +1,6 @@
 # With List args
 
-```graphql @config
+```graphql @schema
 schema @server(queryValidation: true) {
   query: Query
 }

--- a/tests/execution/test-merge-input.md
+++ b/tests/execution/test-merge-input.md
@@ -1,6 +1,6 @@
 # Test merge input
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }
@@ -15,7 +15,7 @@ type Query {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-merge-input.md
+++ b/tests/execution/test-merge-input.md
@@ -1,7 +1,7 @@
 # Test merge input
 
 ```graphql @schema
-schema @server {
+schema {
   query: Query
 }
 
@@ -16,7 +16,7 @@ type Query {
 ```
 
 ```graphql @schema
-schema @server {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-merge-invalid.md
+++ b/tests/execution/test-merge-invalid.md
@@ -4,7 +4,7 @@ error: true
 
 # Test merge error
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }
@@ -18,7 +18,7 @@ type Foo {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-merge-nested.md
+++ b/tests/execution/test-merge-nested.md
@@ -1,6 +1,6 @@
 # test-merge-nested
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }
@@ -17,7 +17,7 @@ type Foo {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-merge-nested.md
+++ b/tests/execution/test-merge-nested.md
@@ -6,7 +6,7 @@ schema @server {
 }
 
 type Query {
-  hi: Foo @expr(body: "world")
+  hi: Foo @expr(body: {b: "hello"})
 }
 
 type Foo {

--- a/tests/execution/test-merge-right-with-link-config.md
+++ b/tests/execution/test-merge-right-with-link-config.md
@@ -1,5 +1,13 @@
 # test-merge-right-with-link-config
 
+```yaml @config
+upstream:
+  allowedHeaders: ["Authorization"]
+links:
+  - src: "stripe-types.graphql"
+    type: Config
+```
+
 ```graphql @file:stripe-types.graphql
 type Foo {
   bar: String
@@ -7,7 +15,7 @@ type Foo {
 ```
 
 ```graphql @schema
-schema @upstream(allowedHeaders: ["Authorization"]) @link(src: "stripe-types.graphql", type: Config) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-merge-right-with-link-config.md
+++ b/tests/execution/test-merge-right-with-link-config.md
@@ -6,7 +6,7 @@ type Foo {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @upstream(allowedHeaders: ["Authorization"]) @link(src: "stripe-types.graphql", type: Config) {
   query: Query
 }

--- a/tests/execution/test-merge-server-sdl.md
+++ b/tests/execution/test-merge-server-sdl.md
@@ -1,6 +1,6 @@
 # test-merge-server-sdl
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-merge-union.md
+++ b/tests/execution/test-merge-union.md
@@ -1,6 +1,6 @@
 # test-merge-union
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }
@@ -20,7 +20,7 @@ type Query {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-missing-argument-on-all-resolvers.md
+++ b/tests/execution/test-missing-argument-on-all-resolvers.md
@@ -40,6 +40,13 @@ message NewsList {
 }
 ```
 
+```yaml @config
+links:
+  - id: news
+    type: Protobuf
+    src: news.proto
+```
+
 ```graphql @schema
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query

--- a/tests/execution/test-missing-argument-on-all-resolvers.md
+++ b/tests/execution/test-missing-argument-on-all-resolvers.md
@@ -40,7 +40,7 @@ message NewsList {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @link(id: "news", src: "news.proto", type: Protobuf) {
   query: Query
 }

--- a/tests/execution/test-missing-mutation-resolver.md
+++ b/tests/execution/test-missing-mutation-resolver.md
@@ -4,7 +4,7 @@ error: true
 
 # test-missing-mutation-resolver
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
   mutation: Mutation

--- a/tests/execution/test-missing-query-resolver.md
+++ b/tests/execution/test-missing-query-resolver.md
@@ -4,7 +4,7 @@ error: true
 
 # test-missing-query-resolver
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-missing-root-types.md
+++ b/tests/execution/test-missing-root-types.md
@@ -4,7 +4,7 @@ error: true
 
 # test-missing-root-types
 
-```graphql @config
+```graphql @schema
 schema {
   query: QueryType
   mutation: MutationDef

--- a/tests/execution/test-missing-schema-query.md
+++ b/tests/execution/test-missing-schema-query.md
@@ -4,7 +4,7 @@ error: true
 
 # test-missing-schema-query
 
-```graphql @config
+```graphql @schema
 schema {
   mutation: Mutation
 }

--- a/tests/execution/test-modify.md
+++ b/tests/execution/test-modify.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-modify
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-multi-interface.md
+++ b/tests/execution/test-multi-interface.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-multi-interface
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-multiple-config-types.md
+++ b/tests/execution/test-multiple-config-types.md
@@ -1,7 +1,14 @@
 # Multiple Configs
 
+```yaml @config
+links:
+  - id: types
+    type: Config
+    src: types.graphql
+```
+
 ```graphql @schema
-schema @server @link(id: "types", type: Config, src: "types.graphql") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-multiple-config-types.md
+++ b/tests/execution/test-multiple-config-types.md
@@ -1,6 +1,6 @@
 # Multiple Configs
 
-```graphql @config
+```graphql @schema
 schema @server @link(id: "types", type: Config, src: "types.graphql") {
   query: Query
 }

--- a/tests/execution/test-multiple-resolvable-directives-on-field-validation.md
+++ b/tests/execution/test-multiple-resolvable-directives-on-field-validation.md
@@ -4,7 +4,7 @@ error: true
 
 # Test validation for multiple resolvable directives on field
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-multiple-resolvable-directives-on-field.md
+++ b/tests/execution/test-multiple-resolvable-directives-on-field.md
@@ -1,6 +1,6 @@
 # Multiple resolvable directives on field
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-nested-input.md
+++ b/tests/execution/test-nested-input.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-nested-input
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-nested-value.md
+++ b/tests/execution/test-nested-value.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-nested-value
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-no-base-url.md
+++ b/tests/execution/test-no-base-url.md
@@ -4,7 +4,7 @@ error: true
 
 # test-no-base-url
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/test-null-in-array.md
+++ b/tests/execution/test-null-in-array.md
@@ -1,6 +1,6 @@
 # Empty Array Response
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-null-in-object.md
+++ b/tests/execution/test-null-in-object.md
@@ -1,6 +1,6 @@
 # Empty Object Response
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-omit-list.md
+++ b/tests/execution/test-omit-list.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-omit-list
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-omit.md
+++ b/tests/execution/test-omit.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-omit
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-on-response-body.md
+++ b/tests/execution/test-on-response-body.md
@@ -8,7 +8,7 @@ function onResponse(data) {
 }
 ```
 
-```graphql @config
+```graphql @schema
 schema @server @link(type: Script, src: "test.js") {
   query: Query
 }

--- a/tests/execution/test-on-response-body.md
+++ b/tests/execution/test-on-response-body.md
@@ -8,8 +8,14 @@ function onResponse(data) {
 }
 ```
 
+```yaml @config
+links:
+  - src: test.js
+    type: Script
+```
+
 ```graphql @schema
-schema @server @link(type: Script, src: "test.js") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-optional-key-skip-empty.md
+++ b/tests/execution/test-optional-key-skip-empty.md
@@ -1,6 +1,6 @@
 # Setting SkipEmpty
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) {
   query: Query
 }

--- a/tests/execution/test-optional-key-skip-empty.md
+++ b/tests/execution/test-optional-key-skip-empty.md
@@ -1,7 +1,12 @@
 # Setting SkipEmpty
 
+```yaml @config
+server:
+  port: 8000
+```
+
 ```graphql @schema
-schema @server(port: 8000) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-params-as-body.md
+++ b/tests/execution/test-params-as-body.md
@@ -1,7 +1,12 @@
 # Http with args as body
 
+```yaml @config
+server:
+  port: 8000
+```
+
 ```graphql @schema
-schema @server(port: 8000) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-params-as-body.md
+++ b/tests/execution/test-params-as-body.md
@@ -1,6 +1,6 @@
 # Http with args as body
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) {
   query: Query
 }

--- a/tests/execution/test-query-documentation.md
+++ b/tests/execution/test-query-documentation.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-query-documentation
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-query.md
+++ b/tests/execution/test-query.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-query
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-ref-other.md
+++ b/tests/execution/test-ref-other.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-ref-other
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000) @upstream {
   query: Query
 }

--- a/tests/execution/test-ref-other.md
+++ b/tests/execution/test-ref-other.md
@@ -4,6 +4,11 @@ identity: true
 
 # test-ref-other
 
+```yaml @config
+server:
+  port: 8000
+```
+
 ```graphql @schema
 schema @server(port: 8000) @upstream {
   query: Query

--- a/tests/execution/test-required-fields.md
+++ b/tests/execution/test-required-fields.md
@@ -1,6 +1,6 @@
 # Test API
 
-```graphql @config
+```graphql @schema
 schema @server(enableJIT: true) {
   query: Query
 }

--- a/tests/execution/test-response-header-value.md
+++ b/tests/execution/test-response-header-value.md
@@ -4,8 +4,14 @@ error: true
 
 # test-response-header-value
 
+```yaml @config
+server:
+  headers:
+    custom: [{key: "a", value: "a \n b"}]
+```
+
 ```graphql @schema
-schema @server(headers: {custom: [{key: "a", value: "a \n b"}]}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-response-header-value.md
+++ b/tests/execution/test-response-header-value.md
@@ -4,7 +4,7 @@ error: true
 
 # test-response-header-value
 
-```graphql @config
+```graphql @schema
 schema @server(headers: {custom: [{key: "a", value: "a \n b"}]}) {
   query: Query
 }

--- a/tests/execution/test-response-headers-multi.md
+++ b/tests/execution/test-response-headers-multi.md
@@ -4,8 +4,14 @@ error: true
 
 # test-response-headers-multi
 
+```yaml @config
+server:
+  headers:
+    custom: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]
+```
+
 ```graphql @schema
-schema @server(headers: {custom: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-response-headers-multi.md
+++ b/tests/execution/test-response-headers-multi.md
@@ -4,7 +4,7 @@ error: true
 
 # test-response-headers-multi
 
-```graphql @config
+```graphql @schema
 schema @server(headers: {custom: [{key: "a b", value: "a \n b"}, {key: "a c", value: "a \n b"}]}) {
   query: Query
 }

--- a/tests/execution/test-response-headers-name.md
+++ b/tests/execution/test-response-headers-name.md
@@ -4,8 +4,14 @@ error: true
 
 # test-response-headers-name
 
+```yaml @config
+server:
+  headers:
+    custom: [{key: "🤣", value: "a"}]
+```
+
 ```graphql @schema
-schema @server(headers: {custom: [{key: "🤣", value: "a"}]}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-response-headers-name.md
+++ b/tests/execution/test-response-headers-name.md
@@ -4,7 +4,7 @@ error: true
 
 # test-response-headers-name
 
-```graphql @config
+```graphql @schema
 schema @server(headers: {custom: [{key: "🤣", value: "a"}]}) {
   query: Query
 }

--- a/tests/execution/test-scalars-builtin.md
+++ b/tests/execution/test-scalars-builtin.md
@@ -1,6 +1,6 @@
 # Test builtin GraphQL scalars
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "localhost") {
   query: Query
 }

--- a/tests/execution/test-scalars-builtin.md
+++ b/tests/execution/test-scalars-builtin.md
@@ -1,7 +1,13 @@
 # Test builtin GraphQL scalars
 
+```yaml @config
+server:
+  port: 8000
+  hostname: localhost
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "localhost") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-scalars-integers.md
+++ b/tests/execution/test-scalars-integers.md
@@ -1,7 +1,13 @@
 # Test scalars related to integer representation
 
+```yaml @config
+server:
+  port: 8000
+  hostname: localhost
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "localhost") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-scalars-integers.md
+++ b/tests/execution/test-scalars-integers.md
@@ -1,6 +1,6 @@
 # Test scalars related to integer representation
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "localhost") {
   query: Query
 }

--- a/tests/execution/test-scalars-validation.md
+++ b/tests/execution/test-scalars-validation.md
@@ -1,6 +1,6 @@
 # Test scalar validation for input and output types
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8000, hostname: "localhost") {
   query: Query
 }

--- a/tests/execution/test-scalars-validation.md
+++ b/tests/execution/test-scalars-validation.md
@@ -1,7 +1,13 @@
 # Test scalar validation for input and output types
 
+```yaml @config
+server:
+  port: 8000
+  hostname: localhost
+```
+
 ```graphql @schema
-schema @server(port: 8000, hostname: "localhost") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-scalars.md
+++ b/tests/execution/test-scalars.md
@@ -1,10 +1,16 @@
 # Test scalars
 
+```yaml @config
+server:
+  port: 8000
+  hostname: localhost
+```
+
 ```graphql @schema
 # this is custom scalars in config
 scalar AnyScalar
 
-schema @server(port: 8000, hostname: "localhost") {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-scalars.md
+++ b/tests/execution/test-scalars.md
@@ -1,6 +1,6 @@
 # Test scalars
 
-```graphql @config
+```graphql @schema
 # this is custom scalars in config
 scalar AnyScalar
 

--- a/tests/execution/test-server-vars.md
+++ b/tests/execution/test-server-vars.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-server-vars
 
-```graphql @config
+```graphql @schema
 schema @server(vars: [{key: "foo", value: "bar"}]) @upstream {
   query: Query
 }

--- a/tests/execution/test-server-vars.md
+++ b/tests/execution/test-server-vars.md
@@ -4,8 +4,15 @@ identity: true
 
 # test-server-vars
 
+```yaml @config
+server:
+  vars:
+    - key: "foo"
+      value: "bar"
+```
+
 ```graphql @schema
-schema @server(vars: [{key: "foo", value: "bar"}]) @upstream {
+schema @server @upstream {
   query: Query
 }
 

--- a/tests/execution/test-set-cookie-headers.md
+++ b/tests/execution/test-set-cookie-headers.md
@@ -1,7 +1,15 @@
 # Set Cookie Header
 
+```yaml @config
+server:
+  port: 8080
+  hostname: "0.0.0.0"
+  headers:
+    setCookies: true
+```
+
 ```graphql @schema
-schema @server(port: 8080, hostname: "0.0.0.0", headers: {setCookies: true}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/test-set-cookie-headers.md
+++ b/tests/execution/test-set-cookie-headers.md
@@ -1,6 +1,6 @@
 # Set Cookie Header
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8080, hostname: "0.0.0.0", headers: {setCookies: true}) {
   query: Query
 }

--- a/tests/execution/test-undefined-query.md
+++ b/tests/execution/test-undefined-query.md
@@ -4,7 +4,7 @@ error: true
 
 # test-undefined-query
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-union-ambiguous.md
+++ b/tests/execution/test-union-ambiguous.md
@@ -2,7 +2,7 @@
 
 In some cases, when the resolved data shape does not strongly correspond to GraphQL types, the discriminator may return the first possible type or no possible types at all.
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-union-fieldtype.md
+++ b/tests/execution/test-union-fieldtype.md
@@ -1,6 +1,6 @@
 # Test union type resolve
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-union-many-types.md
+++ b/tests/execution/test-union-many-types.md
@@ -6,7 +6,7 @@ skip: true
 
 TODO: snapshot mismatch when running the test on 32bit architecture
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-union-optional.md
+++ b/tests/execution/test-union-optional.md
@@ -1,6 +1,6 @@
 # Test union optional
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/test-union.md
+++ b/tests/execution/test-union.md
@@ -4,7 +4,7 @@ identity: true
 
 # Test union type resolve
 
-```graphql @config
+```graphql @schema
 schema @server @upstream {
   query: Query
 }

--- a/tests/execution/test-upstream-headers.md
+++ b/tests/execution/test-upstream-headers.md
@@ -1,7 +1,12 @@
 # test-upstream-headers
 
+```yaml @config
+upstream:
+  allowedHeaders: ["x-foo", "X-bar"]
+```
+
 ```graphql @schema
-schema @upstream(allowedHeaders: ["x-foo", "X-bar"]) {
+schema {
   query: Query
 }
 type Query {

--- a/tests/execution/test-upstream-headers.md
+++ b/tests/execution/test-upstream-headers.md
@@ -1,6 +1,6 @@
 # test-upstream-headers
 
-```graphql @config
+```graphql @schema
 schema @upstream(allowedHeaders: ["x-foo", "X-bar"]) {
   query: Query
 }

--- a/tests/execution/test-upstream.md
+++ b/tests/execution/test-upstream.md
@@ -4,8 +4,14 @@ identity: true
 
 # test-upstream
 
+```yaml @config
+upstream:
+  proxy:
+    url: "http://localhost:8085"
+```
+
 ```graphql @schema
-schema @server @upstream(proxy: {url: "http://localhost:8085"}) {
+schema @server @upstream {
   query: Query
 }
 

--- a/tests/execution/test-upstream.md
+++ b/tests/execution/test-upstream.md
@@ -4,7 +4,7 @@ identity: true
 
 # test-upstream
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(proxy: {url: "http://localhost:8085"}) {
   query: Query
 }

--- a/tests/execution/undeclared-type-no-base-url.md
+++ b/tests/execution/undeclared-type-no-base-url.md
@@ -4,7 +4,7 @@ error: true
 
 # undeclared-type-no-base-url
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/undeclared-type.md
+++ b/tests/execution/undeclared-type.md
@@ -4,7 +4,7 @@ error: true
 
 # undeclared-type
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/union-nested-resolver.md
+++ b/tests/execution/union-nested-resolver.md
@@ -1,6 +1,6 @@
 # Field with resolver in one of the possible types of Union
 
-```graphql @config
+```graphql @schema
 schema @server(port: 8030) @upstream {
   query: Query
 }

--- a/tests/execution/union-nested-resolver.md
+++ b/tests/execution/union-nested-resolver.md
@@ -1,7 +1,12 @@
 # Field with resolver in one of the possible types of Union
 
+```yaml @config
+server:
+  port: 8030
+```
+
 ```graphql @schema
-schema @server(port: 8030) @upstream {
+schema {
   query: Query
 }
 

--- a/tests/execution/upstream-batching.md
+++ b/tests/execution/upstream-batching.md
@@ -1,6 +1,6 @@
 # Sending requests to be batched by the upstream server
 
-```graphql @config
+```graphql @schema
 schema @server @upstream(batch: {maxSize: 100, delay: 1, headers: []}) {
   query: Query
 }

--- a/tests/execution/upstream-batching.md
+++ b/tests/execution/upstream-batching.md
@@ -1,7 +1,14 @@
 # Sending requests to be batched by the upstream server
 
+```yaml @config
+upstream:
+  batch:
+    delay: 1
+    maxSize: 100
+```
+
 ```graphql @schema
-schema @server @upstream(batch: {maxSize: 100, delay: 1, headers: []}) {
+schema {
   query: Query
 }
 

--- a/tests/execution/upstream-fail-request.md
+++ b/tests/execution/upstream-fail-request.md
@@ -1,6 +1,6 @@
 # Simple GraphQL Request
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/with-args-url.md
+++ b/tests/execution/with-args-url.md
@@ -1,6 +1,6 @@
 # With args URL
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/with-args.md
+++ b/tests/execution/with-args.md
@@ -1,6 +1,6 @@
 # With args
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/with-nesting.md
+++ b/tests/execution/with-nesting.md
@@ -1,6 +1,6 @@
 # With nesting
 
-```graphql @config
+```graphql @schema
 schema @server {
   query: Query
 }

--- a/tests/execution/yaml-nested-unions.md
+++ b/tests/execution/yaml-nested-unions.md
@@ -1,6 +1,6 @@
 # Using union types inside other union types
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/yaml-union-in-type.md
+++ b/tests/execution/yaml-union-in-type.md
@@ -1,6 +1,6 @@
 # Using Union types inside usual type
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }

--- a/tests/execution/yaml-union.md
+++ b/tests/execution/yaml-union.md
@@ -1,6 +1,6 @@
 # Using Union types in yaml config
 
-```graphql @config
+```graphql @schema
 schema {
   query: Query
 }


### PR DESCRIPTION
**Summary:**  
Migrate execution_spec tests to runtime config instead of graphql configuration only.

Please, note that most of the snapshots are changed only in the way of adding new link that now represents graphql schema and the behaviour is not changed.-

**Issue Reference(s):**  
Related to https://github.com/tailcallhq/tailcall/issues/3164

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
