### PR TITLE
feat: make dedupe faster at I/O level

### DIFF
--- a/src/core/helpers/value.rs
+++ b/src/core/helpers/value.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use async_graphql_value::ConstValue;
 
@@ -34,5 +37,12 @@ pub fn hash<H: Hasher>(const_value: &ConstValue, state: &mut H) {
                 hash(value, state);
             })
         }
+    }
+}
+
+pub fn arc_result_to_result<T: Clone, E: Clone>(arc_result: Arc<Result<T, E>>) -> Result<T, E> {
+    match &*arc_result {
+        Ok(t) => Ok(t.clone()),
+        Err(e) => Err(e.clone()),
     }
 }

--- a/src/core/jit/graphql_executor.rs
+++ b/src/core/jit/graphql_executor.rs
@@ -12,6 +12,7 @@ use tailcall_hasher::TailcallHasher;
 use super::{AnyResponse, BatchResponse, Response};
 use crate::core::app_context::AppContext;
 use crate::core::async_graphql_hyper::OperationId;
+use crate::core::helpers::value::arc_result_to_result;
 use crate::core::http::RequestContext;
 use crate::core::jit::{self, ConstValueExecutor, OPHash, Pos, Positioned};
 
@@ -53,12 +54,12 @@ impl JITExecutor {
             .dedupe(&self.operation_id, || {
                 Box::pin(async move {
                     let resp = self.exec(exec, jit_request).await;
-                    Ok(resp)
+                    Arc::new(Ok(resp))
                 })
             })
             .await;
 
-        out.unwrap_or_default()
+        arc_result_to_result(out).unwrap_or_default()
     }
 
     #[inline(always)]


### PR DESCRIPTION
**Summary:**  
Uses [Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html) to ensure that dedupe requests do not generate new clones of the response, but rather point to the same response using the Atomically referenced counter.

**Issue Reference(s):**  
Fixes #3028 

/claim #3028 

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests. [Modified relevant tests after code changes]
- [x] I have updated the [documentation] accordingly. [No update required for documentation]
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
