### PR TITLE
fix: query interface with fragments

### DIFF
--- a/src/core/blueprint/index.rs
+++ b/src/core/blueprint/index.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use indexmap::IndexMap;
 
 use super::InputObjectTypeDefinition;
@@ -36,6 +38,16 @@ impl Index {
         let def = self.map.get(type_name).map(|(def, _)| def);
 
         matches!(def, Some(Definition::Scalar(_))) || scalar::Scalar::is_predefined(type_name)
+    }
+
+    pub fn get_interfaces(&self) -> HashSet<String> {
+        self.map
+            .iter()
+            .filter_map(|(_, (def, _))| match def {
+                Definition::Interface(interface) => Some(interface.name.to_owned()),
+                _ => None,
+            })
+            .collect()
     }
 
     pub fn type_is_enum(&self, type_name: &str) -> bool {

--- a/src/core/blueprint/index.rs
+++ b/src/core/blueprint/index.rs
@@ -44,7 +44,7 @@ impl Index {
         self.map
             .iter()
             .filter_map(|(_, (def, _))| match def {
-                Definition::Interface(i) => Some(i.name.to_owned()),
+                Definition::Interface(interface) => Some(interface.name.to_owned()),
                 _ => None,
             })
             .collect()

--- a/src/core/blueprint/index.rs
+++ b/src/core/blueprint/index.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use indexmap::IndexMap;
 
 use super::InputObjectTypeDefinition;
@@ -36,6 +38,18 @@ impl Index {
         let def = self.map.get(type_name).map(|(def, _)| def);
 
         matches!(def, Some(Definition::Scalar(_))) || scalar::Scalar::is_predefined(type_name)
+    }
+
+    pub fn get_interfaces(&self) -> Box<HashSet<String>> {
+        Box::new(
+            self.map
+                .iter()
+                .filter_map(|(_, (def, _))| match def {
+                    Definition::Interface(i) => Some(i.name.to_owned()),
+                    _ => None,
+                })
+                .collect(),
+        )
     }
 
     pub fn type_is_enum(&self, type_name: &str) -> bool {

--- a/src/core/blueprint/index.rs
+++ b/src/core/blueprint/index.rs
@@ -40,16 +40,14 @@ impl Index {
         matches!(def, Some(Definition::Scalar(_))) || scalar::Scalar::is_predefined(type_name)
     }
 
-    pub fn get_interfaces(&self) -> Box<HashSet<String>> {
-        Box::new(
-            self.map
-                .iter()
-                .filter_map(|(_, (def, _))| match def {
-                    Definition::Interface(i) => Some(i.name.to_owned()),
-                    _ => None,
-                })
-                .collect(),
-        )
+    pub fn get_interfaces(&self) -> HashSet<String> {
+        self.map
+            .iter()
+            .filter_map(|(_, (def, _))| match def {
+                Definition::Interface(i) => Some(i.name.to_owned()),
+                _ => None,
+            })
+            .collect()
     }
 
     pub fn type_is_enum(&self, type_name: &str) -> bool {

--- a/src/core/blueprint/index.rs
+++ b/src/core/blueprint/index.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use indexmap::IndexMap;
 
 use super::InputObjectTypeDefinition;
@@ -38,16 +36,6 @@ impl Index {
         let def = self.map.get(type_name).map(|(def, _)| def);
 
         matches!(def, Some(Definition::Scalar(_))) || scalar::Scalar::is_predefined(type_name)
-    }
-
-    pub fn get_interfaces(&self) -> HashSet<String> {
-        self.map
-            .iter()
-            .filter_map(|(_, (def, _))| match def {
-                Definition::Interface(interface) => Some(interface.name.to_owned()),
-                _ => None,
-            })
-            .collect()
     }
 
     pub fn type_is_enum(&self, type_name: &str) -> bool {

--- a/src/core/jit/builder.rs
+++ b/src/core/jit/builder.rs
@@ -364,7 +364,7 @@ impl<'a> Builder<'a> {
             operation.ty,
             self.index.clone(),
             is_introspection_query,
-            Some(*self.index.get_interfaces()),
+            Some(self.index.get_interfaces()),
         );
         Ok(plan)
     }

--- a/src/core/jit/builder.rs
+++ b/src/core/jit/builder.rs
@@ -128,6 +128,7 @@ impl<'a> Builder<'a> {
     #[inline(always)]
     fn iter(
         &self,
+        parent_fragment: Option<&str>,
         selection: &SelectionSet,
         type_condition: &str,
         fragments: &HashMap<&str, &FragmentDefinition>,
@@ -168,6 +169,7 @@ impl<'a> Builder<'a> {
                         .map(|(k, v)| (k.node.as_str().to_string(), v.node.to_owned()))
                         .collect::<HashMap<_, _>>();
 
+                    let parent_fragment = parent_fragment.map(|s| s.to_owned());
                     // Check if the field is present in the schema index
                     if let Some(field_def) = self.index.get_field(type_condition, field_name) {
                         let mut args = Vec::with_capacity(request_args.len());
@@ -198,8 +200,12 @@ impl<'a> Builder<'a> {
                         let id = FieldId::new(self.field_id.next());
 
                         // Recursively gather child fields for the selection set
-                        let child_fields =
-                            self.iter(&gql_field.selection_set.node, type_of.name(), fragments);
+                        let child_fields = self.iter(
+                            None,
+                            &gql_field.selection_set.node,
+                            type_of.name(),
+                            fragments,
+                        );
 
                         let ir = match field_def {
                             QueryField::Field((field_def, _)) => field_def.resolver.clone(),
@@ -220,6 +226,7 @@ impl<'a> Builder<'a> {
                         let field = Field {
                             id,
                             selection: child_fields,
+                            parent_fragment,
                             name: field_name.to_string(),
                             output_name: gql_field
                                 .alias
@@ -252,6 +259,7 @@ impl<'a> Builder<'a> {
                             args: Vec::new(),
                             pos: selection.pos.into(),
                             selection: vec![], // __typename has no child selection
+                            parent_fragment,
                             directives,
                             is_enum: false,
                             scalar: Some(scalar::Scalar::Empty),
@@ -265,6 +273,7 @@ impl<'a> Builder<'a> {
                         fragments.get(fragment_spread.fragment_name.node.as_str())
                     {
                         fields.extend(self.iter(
+                            Some(fragment.type_condition.node.on.node.as_str()),
                             &fragment.selection_set.node,
                             fragment.type_condition.node.on.node.as_str(),
                             fragments,
@@ -277,8 +286,12 @@ impl<'a> Builder<'a> {
                         .as_ref()
                         .map(|cond| cond.node.on.node.as_str())
                         .unwrap_or(type_condition);
-
-                    fields.extend(self.iter(&fragment.selection_set.node, type_of, fragments));
+                    fields.extend(self.iter(
+                        Some(type_of),
+                        &fragment.selection_set.node,
+                        type_of,
+                        fragments,
+                    ));
                 }
             }
         }
@@ -334,7 +347,7 @@ impl<'a> Builder<'a> {
         let name = self
             .get_type(operation.ty)
             .ok_or(BuildError::RootOperationTypeNotDefined { operation: operation.ty })?;
-        let fields = self.iter(&operation.selection_set.node, name, &fragments);
+        let fields = self.iter(None, &operation.selection_set.node, name, &fragments);
 
         let is_introspection_query = operation.selection_set.node.items.iter().any(|f| {
             if let Selection::Field(Positioned { node: gql_field, .. }) = &f.node {
@@ -351,6 +364,7 @@ impl<'a> Builder<'a> {
             operation.ty,
             self.index.clone(),
             is_introspection_query,
+            Some(*self.index.get_interfaces()),
         );
         Ok(plan)
     }

--- a/src/core/jit/builder.rs
+++ b/src/core/jit/builder.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -11,7 +11,7 @@ use async_graphql_value::Value;
 
 use super::model::{Directive as JitDirective, *};
 use super::BuildError;
-use crate::core::blueprint::{Blueprint, Definition, Index, QueryField};
+use crate::core::blueprint::{Blueprint, Index, QueryField};
 use crate::core::counter::{Count, Counter};
 use crate::core::jit::model::OperationPlan;
 use crate::core::{scalar, Type};
@@ -66,7 +66,6 @@ impl Conditions {
 
 pub struct Builder<'a> {
     pub index: Arc<Index>,
-    pub interfaces: Arc<HashSet<String>>,
     pub arg_id: Counter<usize>,
     pub field_id: Counter<usize>,
     pub document: &'a ExecutableDocument,
@@ -76,23 +75,12 @@ pub struct Builder<'a> {
 impl<'a> Builder<'a> {
     pub fn new(blueprint: &Blueprint, document: &'a ExecutableDocument) -> Self {
         let index = Arc::new(blueprint.index());
-        let interfaces = Arc::new(
-            blueprint
-                .definitions
-                .iter()
-                .filter_map(|def| match def {
-                    Definition::Interface(interface) => Some(interface.name.to_owned()),
-                    _ => None,
-                })
-                .collect(),
-        );
 
         Self {
             document,
             index,
             arg_id: Counter::default(),
             field_id: Counter::default(),
-            interfaces,
         }
     }
 
@@ -377,7 +365,7 @@ impl<'a> Builder<'a> {
             operation.ty,
             self.index.clone(),
             is_introspection_query,
-            Some(Arc::clone(&self.interfaces)),
+            Some(self.index.get_interfaces()),
         );
         Ok(plan)
     }

--- a/src/core/jit/model.rs
+++ b/src/core/jit/model.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::num::NonZeroU64;
 use std::sync::Arc;
@@ -187,6 +187,7 @@ pub struct Field<Input> {
     pub include: Option<Variable>,
     pub args: Vec<Arg<Input>>,
     pub selection: Vec<Field<Input>>,
+    pub parent_fragment: Option<String>,
     pub pos: Pos,
     pub directives: Vec<Directive<Input>>,
     pub is_enum: bool,
@@ -245,6 +246,7 @@ impl<Input> Field<Input> {
                 .into_iter()
                 .map(|f| f.try_map(map))
                 .collect::<Result<Vec<Field<Output>>, Error>>()?,
+            parent_fragment: None,
             skip: self.skip,
             include: self.include,
             pos: self.pos,
@@ -315,6 +317,7 @@ pub struct OperationPlan<Input> {
     pub min_cache_ttl: Option<NonZeroU64>,
     pub selection: Vec<Field<Input>>,
     pub before: Option<IR>,
+    pub interfaces: Option<HashSet<String>>,
 }
 
 impl<Input> OperationPlan<Input> {
@@ -339,6 +342,7 @@ impl<Input> OperationPlan<Input> {
             is_protected: self.is_protected,
             min_cache_ttl: self.min_cache_ttl,
             before: self.before,
+            interfaces: None,
         })
     }
 }
@@ -351,6 +355,7 @@ impl<Input> OperationPlan<Input> {
         operation_type: OperationType,
         index: Arc<Index>,
         is_introspection_query: bool,
+        interfaces: Option<HashSet<String>>,
     ) -> Self
     where
         Input: Clone,
@@ -366,6 +371,7 @@ impl<Input> OperationPlan<Input> {
             is_protected: false,
             min_cache_ttl: None,
             before: Default::default(),
+            interfaces,
         }
     }
 

--- a/src/core/jit/model.rs
+++ b/src/core/jit/model.rs
@@ -317,7 +317,7 @@ pub struct OperationPlan<Input> {
     pub min_cache_ttl: Option<NonZeroU64>,
     pub selection: Vec<Field<Input>>,
     pub before: Option<IR>,
-    pub interfaces: Option<Arc<HashSet<String>>>,
+    pub interfaces: Option<HashSet<String>>,
 }
 
 impl<Input> OperationPlan<Input> {
@@ -355,7 +355,7 @@ impl<Input> OperationPlan<Input> {
         operation_type: OperationType,
         index: Arc<Index>,
         is_introspection_query: bool,
-        interfaces: Option<Arc<HashSet<String>>>,
+        interfaces: Option<HashSet<String>>,
     ) -> Self
     where
         Input: Clone,

--- a/src/core/jit/model.rs
+++ b/src/core/jit/model.rs
@@ -317,7 +317,7 @@ pub struct OperationPlan<Input> {
     pub min_cache_ttl: Option<NonZeroU64>,
     pub selection: Vec<Field<Input>>,
     pub before: Option<IR>,
-    pub interfaces: Option<HashSet<String>>,
+    pub interfaces: Option<Arc<HashSet<String>>>,
 }
 
 impl<Input> OperationPlan<Input> {
@@ -355,7 +355,7 @@ impl<Input> OperationPlan<Input> {
         operation_type: OperationType,
         index: Arc<Index>,
         is_introspection_query: bool,
-        interfaces: Option<HashSet<String>>,
+        interfaces: Option<Arc<HashSet<String>>>,
     ) -> Self
     where
         Input: Clone,

--- a/src/core/jit/transform/graphql.rs
+++ b/src/core/jit/transform/graphql.rs
@@ -105,8 +105,8 @@ fn format_selection_set<'a, A: 'a + Display + JsonLikeOwned>(
     //Don't force user to query the type and get it automatically
     if is_parent_interface {
         normal_fields.push("__typename".to_owned());
+        normal_fields.push(fragments_set.join(" "));
     }
-    normal_fields.push(fragments_set.join(" "));
     Some(format!("{{ {} }}", normal_fields.join(" ")))
 }
 

--- a/src/core/jit/transform/graphql.rs
+++ b/src/core/jit/transform/graphql.rs
@@ -105,7 +105,7 @@ fn format_selection_set<'a, A: 'a + Display + JsonLikeOwned>(
     //Don't force user to query the type and get it automatically
     if is_parent_interface {
         normal_fields.push("__typename".to_owned());
-        normal_fields.push(fragments_set.join(" "));
+        normal_fields.extend(fragments_set);
     }
     Some(format!("{{ {} }}", normal_fields.join(" ")))
 }

--- a/src/core/jit/transform/graphql.rs
+++ b/src/core/jit/transform/graphql.rs
@@ -95,7 +95,7 @@ fn format_selection_set<'a, A: 'a + Display + JsonLikeOwned>(
         return None;
     }
 
-    let string_set: Vec<String> = fragments_fields
+    let fragments_set: Vec<String> = fragments_fields
         .into_iter()
         .map(|(fragment_name, fields)| {
             format!("... on {} {{ {} }}", fragment_name, fields.join(" "))
@@ -106,7 +106,7 @@ fn format_selection_set<'a, A: 'a + Display + JsonLikeOwned>(
     if is_parent_interface {
         normal_fields.push("__typename".to_owned());
     }
-    normal_fields.push(string_set.join(" "));
+    normal_fields.push(fragments_set.join(" "));
     Some(format!("{{ {} }}", normal_fields.join(" ")))
 }
 

--- a/src/core/jit/transform/input_resolver.rs
+++ b/src/core/jit/transform/input_resolver.rs
@@ -84,6 +84,7 @@ where
             is_const: self.plan.is_const,
             is_protected: self.plan.is_protected,
             min_cache_ttl: self.plan.min_cache_ttl,
+            interfaces: None,
             selection,
             before: self.plan.before,
         })

--- a/tests/core/snapshots/graphql-with-fragments.md_0.snap
+++ b/tests/core/snapshots/graphql-with-fragments.md_0.snap
@@ -1,0 +1,27 @@
+---
+source: tests/core/spec.rs
+expression: response
+snapshot_kind: text
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "queryNodeC": [
+        {
+          "name": "nodeA",
+          "__typename": "NodeA",
+          "nodeA_id": "nodeA_id"
+        },
+        {
+          "name": "nodeB",
+          "__typename": "NodeB",
+          "nodeB_id": "nodeB_id"
+        }
+      ]
+    }
+  }
+}

--- a/tests/core/snapshots/graphql-with-fragments.md_client.snap
+++ b/tests/core/snapshots/graphql-with-fragments.md_client.snap
@@ -1,0 +1,28 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+snapshot_kind: text
+---
+type NodeA implements NodeC {
+  name: String
+  nodeA_id: String
+}
+
+type NodeB implements NodeC {
+  name: String
+  nodeB_id: String
+}
+
+interface NodeC {
+  name: String
+}
+
+type Query {
+  queryNodeA: [NodeA!]
+  queryNodeB: [NodeB!]
+  queryNodeC: [NodeC!]
+}
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/graphql-with-fragments.md_merged.snap
+++ b/tests/core/snapshots/graphql-with-fragments.md_merged.snap
@@ -1,0 +1,28 @@
+---
+source: tests/core/spec.rs
+expression: formatter
+snapshot_kind: text
+---
+schema @server @upstream @link(src: "schema_0.graphql", type: Config) {
+  query: Query
+}
+
+interface NodeC {
+  name: String
+}
+
+type NodeA implements NodeC {
+  name: String
+  nodeA_id: String
+}
+
+type NodeB implements NodeC {
+  name: String
+  nodeB_id: String
+}
+
+type Query {
+  queryNodeA: [NodeA!] @graphQL(url: "http://upstream/graphql", name: "nodeA")
+  queryNodeB: [NodeB!] @graphQL(url: "http://upstream/graphql", name: "nodeB")
+  queryNodeC: [NodeC!] @graphQL(url: "http://upstream/graphql", name: "nodeC")
+}

--- a/tests/execution/graphql-with-fragments.md
+++ b/tests/execution/graphql-with-fragments.md
@@ -1,0 +1,63 @@
+```graphql @schema
+schema @server(port: 8000, hostname: "0.0.0.0") {
+  query: Query
+}
+
+type Query {
+  queryNodeC: [NodeC!] @graphQL(url: "http://upstream/graphql", name: "nodeC")
+  queryNodeA: [NodeA!] @graphQL(url: "http://upstream/graphql", name: "nodeA")
+  queryNodeB: [NodeB!] @graphQL(url: "http://upstream/graphql", name: "nodeB")
+}
+
+type NodeA implements NodeC {
+  name: String
+  nodeA_id: String
+}
+
+type NodeB implements NodeC {
+  name: String
+  nodeB_id: String
+}
+
+interface NodeC {
+  name: String
+}
+```
+
+```yml @mock
+- request:
+    method: POST
+    url: http://upstream/graphql
+    textBody: {"query": "query { nodeC { name __typename ...on NodeA { nodeA_id } ...on NodeB { nodeB_id } } }"}
+  expectedHits: 1
+  response:
+    status: 200
+    body:
+      data:
+        nodeC:
+          - name: nodeA
+            __typename: NodeA
+            nodeA_id: nodeA_id
+          - name: nodeB
+            __typename: NodeB
+            nodeB_id: nodeB_id
+```
+
+```yml @test
+- method: POST
+  url: http://localhost:8080/graphql
+  body:
+    query: |
+      query queryNodeC {
+        queryNodeC {
+          name
+          __typename
+          ...on NodeA {
+            nodeA_id
+          }
+          ...on NodeB {
+            nodeB_id
+          }
+        }
+      }
+```


### PR DESCRIPTION
**Summary:**  
This PR is created to be able to query interfaces with fragments

**Issue Reference(s):**  
Fixes #3232

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
