### PR TITLE
refactor: Move retry logic from infer_type_name to wizard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5711,6 +5711,7 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-retry",
  "tokio-test",
  "tonic 0.11.0",
  "tonic-types",
@@ -6168,6 +6169,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ headers = "0.3.9" # previous version until hyper is updated to 1+
 http = "0.2.12" # previous version until hyper is updated to 1+
 insta = { version = "1.38.0", features = ["json"] }
 tokio = { version = "1.37.0", features = ["rt", "time"] }
+tokio-retry = "0.3"
 reqwest = { version = "0.11", features = [
     "json",
     "rustls-tls",
@@ -66,6 +67,7 @@ rustls-pemfile = { version = "1.0.4" }
 schemars = { version = "0.8.17", features = ["derive"] }
 hyper = { version = "0.14.28", features = ["server"], default-features = false }
 tokio = { workspace = true }
+tokio-retry = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }
 derive_setters = "0.1.6"

--- a/src/cli/llm/error.rs
+++ b/src/cli/llm/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     GenAI(genai::Error),
     EmptyResponse,
     Serde(serde_json::Error),
+    Reqwest(reqwest::Error),
 }
 
 pub type Result<A> = std::result::Result<A, Error>;


### PR DESCRIPTION
**Summary:**  
Move retry logic from infer_type_name to wizard

**Issue Reference(s):**  
Fixes #2671

/claim #2671

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
