### PR TITLE
feat: accept queries in the format of application/graphql

### DIFF
--- a/tests/core/snapshots/content-type-graphql.md_0.snap
+++ b/tests/core/snapshots/content-type-graphql.md_0.snap
@@ -1,0 +1,19 @@
+---
+source: tests/core/spec.rs
+expression: response
+snapshot_kind: text
+---
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "data": {
+      "user": {
+        "city": "Globe",
+        "name": "Tailcall"
+      }
+    }
+  }
+}

--- a/tests/core/snapshots/content-type-graphql.md_client.snap
+++ b/tests/core/snapshots/content-type-graphql.md_client.snap
@@ -1,0 +1,18 @@
+---
+source: tests/core/spec.rs
+expression: formatted
+snapshot_kind: text
+---
+type Query {
+  user(id: ID!): User!
+}
+
+type User {
+  city: String
+  id: ID!
+  name: String!
+}
+
+schema {
+  query: Query
+}

--- a/tests/core/snapshots/content-type-graphql.md_merged.snap
+++ b/tests/core/snapshots/content-type-graphql.md_merged.snap
@@ -1,0 +1,22 @@
+---
+source: tests/core/spec.rs
+expression: formatter
+snapshot_kind: text
+---
+schema
+  @server(hostname: "0.0.0.0", port: 8001, queryValidation: false)
+  @upstream(httpCache: 42)
+  @link(src: "schema_0.graphql", type: Config) {
+  query: Query
+}
+
+type Query {
+  user(id: ID!): User!
+    @graphQL(args: [{key: "id", value: "{{.args.id}}"}], url: "http://upstream/graphql", name: "user")
+}
+
+type User {
+  city: String
+  id: ID!
+  name: String!
+}

--- a/tests/core/spec.rs
+++ b/tests/core/spec.rs
@@ -293,7 +293,7 @@ async fn run_test(
                     |acc, (key, value)| acc.header(key, value),
                 )
                 .body(body)?;
-
+            println!("{:?}", req);
             if app_ctx.blueprint.server.enable_batch_requests {
                 handle_request::<GraphQLBatchRequest>(req, app_ctx).await
             } else {

--- a/tests/core/spec.rs
+++ b/tests/core/spec.rs
@@ -293,7 +293,7 @@ async fn run_test(
                     |acc, (key, value)| acc.header(key, value),
                 )
                 .body(body)?;
-            println!("{:?}", req);
+
             if app_ctx.blueprint.server.enable_batch_requests {
                 handle_request::<GraphQLBatchRequest>(req, app_ctx).await
             } else {

--- a/tests/execution/content-type-graphql.md
+++ b/tests/execution/content-type-graphql.md
@@ -1,0 +1,57 @@
+# Basic queries with field ordering check
+
+```yaml @config
+server:
+  port: 8001
+  hostname: "0.0.0.0"
+  queryValidation: false
+upstream:
+  httpCache: 42
+```
+
+```graphql @schema
+schema {
+  query: Query
+}
+
+type Query {
+  user(id: ID!): User!
+    @graphQL(url: "http://upstream/graphql", name: "user", args: [{key: "id", value: "{{.args.id}}"}])
+}
+
+type User {
+  id: ID!
+  name: String!
+  city: String
+}
+```
+
+```yml @mock
+- request:
+    method: POST
+    url: http://upstream/graphql
+    textBody: '{ "query": "query { user(id: 4) { city name } }" }'
+  expectedHits: 1
+  response:
+    status: 200
+    body:
+      data:
+        user:
+          city: Globe
+          name: Tailcall
+```
+
+```yml @test
+# Positive: basic 1
+- method: POST
+  url: http://localhost:8080/graphql
+  headers:
+    content-type: application/graphql
+  body: |
+    query {
+      user(id: 4) {
+        city
+        name
+      }
+    }
+```


### PR DESCRIPTION
**Summary:**  
In this PR we will accept queries in the format of content-type: application/graphql

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
