### PR TITLE
fix(connectRPC): add Connect-Protocol-Version header to gRPC requests

### DIFF
--- a/src/core/generator/proto/connect_rpc.rs
+++ b/src/core/generator/proto/connect_rpc.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+
 use tailcall_valid::Valid;
 
 use crate::core::config::{Config, Grpc, Http, Resolver, ResolverSet};
@@ -12,9 +13,13 @@ enum ConnectProtocolVersion {
 
 impl Display for ConnectProtocolVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            ConnectProtocolVersion::V1 => "1".to_string(),
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                ConnectProtocolVersion::V1 => "1".to_string(),
+            }
+        )
     }
 }
 

--- a/src/core/generator/proto/connect_rpc.rs
+++ b/src/core/generator/proto/connect_rpc.rs
@@ -1,7 +1,22 @@
+use std::fmt::Display;
 use tailcall_valid::Valid;
 
 use crate::core::config::{Config, Grpc, Http, Resolver, ResolverSet};
 use crate::core::Transform;
+
+const HEADER_CONNECT_PROTOCOL_VERSION: &str = "Connect-Protocol-Version";
+
+enum ConnectProtocolVersion {
+    V1,
+}
+
+impl Display for ConnectProtocolVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            ConnectProtocolVersion::V1 => "1".to_string(),
+        })
+    }
+}
 
 pub struct ConnectRPC;
 
@@ -47,7 +62,12 @@ impl From<Grpc> for Http {
         let endpoint = parts[parts.len() - 1].to_string();
 
         let new_url = format!("{}/{}/{}", url, method, endpoint);
-        let headers = grpc.headers;
+        let mut headers = grpc.headers;
+        headers.push(crate::core::config::KeyValue {
+            key: HEADER_CONNECT_PROTOCOL_VERSION.to_string(),
+            value: ConnectProtocolVersion::V1.to_string(),
+        });
+
         let batch_key = grpc.batch_key;
         let dedupe = grpc.dedupe;
         let select = grpc.select;
@@ -135,6 +155,14 @@ mod tests {
                 .unwrap()
                 .value,
             "bar".to_string()
+        );
+        assert_eq!(
+            http.headers
+                .iter()
+                .find(|h| h.key == "Connect-Protocol-Version")
+                .unwrap()
+                .value,
+            "1".to_string()
         );
         assert_eq!(http.body, Some(json!({})));
     }

--- a/tests/cli/snapshots/cli_spec__test__generator_spec__tests__cli__fixtures__generator__proto-connect-rpc.md.snap
+++ b/tests/cli/snapshots/cli_spec__test__generator_spec__tests__cli__fixtures__generator__proto-connect-rpc.md.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli/gen.rs
+assertion_line: 333
 expression: config.to_sdl()
 snapshot_kind: text
 ---
@@ -61,12 +62,12 @@ type News {
 }
 
 type Query {
-  GEN__news__NewsService__AddNews(news: GEN__news__NewsInput!): News @http(url: "http://localhost:50051/news.NewsService/AddNews", body: "{{.args.news}}", method: "POST")
-  GEN__news__NewsService__DeleteNews(newsId: Id!): Empty @http(url: "http://localhost:50051/news.NewsService/DeleteNews", body: "{{.args.newsId}}", method: "POST")
-  GEN__news__NewsService__EditNews(news: GEN__news__NewsInput!): News @http(url: "http://localhost:50051/news.NewsService/EditNews", body: "{{.args.news}}", method: "POST")
-  GEN__news__NewsService__GetAllNews: GEN__news__NewsList @http(url: "http://localhost:50051/news.NewsService/GetAllNews", body: {}, method: "POST")
-  GEN__news__NewsService__GetMultipleNews(multipleNewsId: GEN__news__MultipleNewsId!): GEN__news__NewsList @http(url: "http://localhost:50051/news.NewsService/GetMultipleNews", body: "{{.args.multipleNewsId}}", method: "POST")
-  GEN__news__NewsService__GetNews(newsId: Id!): News @http(url: "http://localhost:50051/news.NewsService/GetNews", body: "{{.args.newsId}}", method: "POST")
+  GEN__news__NewsService__AddNews(news: GEN__news__NewsInput!): News @http(url: "http://localhost:50051/news.NewsService/AddNews", body: "{{.args.news}}", headers: [{key: "Connect-Protocol-Version", value: "1"}], method: "POST")
+  GEN__news__NewsService__DeleteNews(newsId: Id!): Empty @http(url: "http://localhost:50051/news.NewsService/DeleteNews", body: "{{.args.newsId}}", headers: [{key: "Connect-Protocol-Version", value: "1"}], method: "POST")
+  GEN__news__NewsService__EditNews(news: GEN__news__NewsInput!): News @http(url: "http://localhost:50051/news.NewsService/EditNews", body: "{{.args.news}}", headers: [{key: "Connect-Protocol-Version", value: "1"}], method: "POST")
+  GEN__news__NewsService__GetAllNews: GEN__news__NewsList @http(url: "http://localhost:50051/news.NewsService/GetAllNews", body: {}, headers: [{key: "Connect-Protocol-Version", value: "1"}], method: "POST")
+  GEN__news__NewsService__GetMultipleNews(multipleNewsId: GEN__news__MultipleNewsId!): GEN__news__NewsList @http(url: "http://localhost:50051/news.NewsService/GetMultipleNews", body: "{{.args.multipleNewsId}}", headers: [{key: "Connect-Protocol-Version", value: "1"}], method: "POST")
+  GEN__news__NewsService__GetNews(newsId: Id!): News @http(url: "http://localhost:50051/news.NewsService/GetNews", body: "{{.args.newsId}}", headers: [{key: "Connect-Protocol-Version", value: "1"}], method: "POST")
   users: [User] @http(url: "http://jsonplaceholder.typicode.com/users")
 }
 


### PR DESCRIPTION
**Summary:**  

When using [fauxrpc]（ https://github.com/sudorandom/fauxrpc ）When calling as a connectRPC Server service, it was found that the request would be 404. After debugging, it was discovered that some connectRPC servers had done header validation and needed to pass the 'Connect Protocol Version' header for validation to comply with connect related specifications.

related link: https://connectrpc.com/docs/protocol/#unary-request

The Connect-Protocol-Version header distinguishes unary Connect RPC traffic from other requests that may use the same Content-Type. (In the future, it may also be used to support revisions to this protocol.) Clients, especially generated clients, should send this header.
Servers and proxies may reject traffic without this header with an HTTP status code of 400.

**Issue Reference(s):**  
Fixes #3330

**Build & Testing:**

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [x] I have added relevant unit & integration tests.
- [x] I have updated the [documentation] accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
