### PR TITLE
fix: Revert fix(deps): update rust crate quote to v1.0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4519,9 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]


### PR DESCRIPTION
Reverts tailcallhq/tailcall#3326