### PR TITLE
fix: improve error handling in post-install script

### DIFF
--- a/npm/post-install.js
+++ b/npm/post-install.js
@@ -19,8 +19,10 @@ const pkg = `@tailcallhq/core-${platform}-${arch}${libc}`
 
 try {
   // @ts-ignore
-  const {stdout, stderr} = await execa(`npm install ${pkg}@${version} --no-save`)
+  const {stdout, stderr} = await execa(`npm install ${pkg} --no-save`)
   stderr ? console.log(stderr) : console.log(`Successfully installed optional dependency: ${pkg}`, stdout)
 } catch (error) {
-  console.error(`Failed to install optional dependency: ${pkg}`, error.stderr)
+  console.error(`Failed to install optional dependency: ${pkg}`, error.stderr || error.message || 'Unknown error')
+  // Kill the process with a non-zero exit code
+  process.exit(1)
 }


### PR DESCRIPTION
**Summary:** 
- Throw error on **MSVC** not found for Windows.
- Variable `version` not defined in file
- Execa sometimes throws `undefined` for errors: https://github.com/sindresorhus/execa/blob/main/docs/errors.md#exit-code
  - So added `process.exit(1)` for `npm i` to fail.

**Issue Reference(s):**  
Fixes #3384

- As fixed js file not configured below commands

---

**Build & Testing:**

- [ ] I ran `cargo test` successfully.
- [ ] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

**Checklist:**

- [ ] I have added relevant unit & integration tests.
- [ ] I have updated the [documentation] accordingly.
- [ ] I have performed a self-review of my code.
- [ ] PR follows the naming convention of `<type>(<optional scope>): <title>`

[documentation]: https://github.com/tailcallhq/tailcallhq.github.io/tree/develop/docs
