### PR TITLE
fix(3384): improve Windows installation with MSVC detection and better errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you're on Windows, you'll need to install:
 
 1. Microsoft Visual C++ Build Tools - [Download here](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
 2. Make sure your Node.js architecture (x86/x64) matches your Windows architecture
+3. Run the installation command with administrator privileges
 
 ### Yarn
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ npm i -g @tailcallhq/tailcall
 ```
 
 #### Windows Requirements
+
 If you're on Windows, you'll need to install:
+
 1. Microsoft Visual C++ Build Tools - [Download here](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
 2. Make sure your Node.js architecture (x86/x64) matches your Windows architecture
 
@@ -37,6 +39,7 @@ yarn global add @tailcallhq/tailcall
 ```
 
 #### Windows Requirements
+
 The same Windows requirements apply for Yarn installations as NPM.
 
 ### Home Brew

--- a/README.md
+++ b/README.md
@@ -25,11 +25,19 @@ Please support us by giving the repository a star
 npm i -g @tailcallhq/tailcall
 ```
 
+#### Windows Requirements
+If you're on Windows, you'll need to install:
+1. Microsoft Visual C++ Build Tools - [Download here](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+2. Make sure your Node.js architecture (x86/x64) matches your Windows architecture
+
 ### Yarn
 
 ```bash
 yarn global add @tailcallhq/tailcall
 ```
+
+#### Windows Requirements
+The same Windows requirements apply for Yarn installations as NPM.
 
 ### Home Brew
 

--- a/npm/post-install.js
+++ b/npm/post-install.js
@@ -27,7 +27,7 @@ async function checkMSVC() {
       return false
     }
   }
-  return true  // Not Windows, no need for MSVC
+  return true // Not Windows, no need for MSVC
 }
 
 async function install() {
@@ -35,8 +35,12 @@ async function install() {
   if (platform === "win32") {
     const hasMSVC = await checkMSVC()
     if (!hasMSVC) {
-      console.error("\x1b[31mError: Microsoft Visual C++ Build Tools (MSVC) is required for Tailcall on Windows.\x1b[0m")
-      console.error("Please install the Visual C++ Build Tools from: https://visualstudio.microsoft.com/visual-cpp-build-tools/")
+      console.error(
+        "\x1b[31mError: Microsoft Visual C++ Build Tools (MSVC) is required for Tailcall on Windows.\x1b[0m",
+      )
+      console.error(
+        "Please install the Visual C++ Build Tools from: https://visualstudio.microsoft.com/visual-cpp-build-tools/",
+      )
       process.exit(1)
     }
   }
@@ -47,17 +51,17 @@ async function install() {
     stderr ? console.log(stderr) : console.log(`Successfully installed optional dependency: ${pkg}`, stdout)
   } catch (error) {
     console.error(`\x1b[31mFailed to install optional dependency: ${pkg}\x1b[0m`)
-    console.error(error.stderr || error.message || 'Unknown error')
-    
+    console.error(error.stderr || error.message || "Unknown error")
+
     if (platform === "win32") {
       console.error("\nOn Windows, please ensure you have the following requirements:")
       console.error("1. Microsoft Visual C++ Build Tools installed")
       console.error("2. Node.js installed with the same architecture (x86 or x64) as your Windows")
     }
-    
+
     // Kill the process with a non-zero exit code
     process.exit(1)
   }
 }
 
-install();
+install()

--- a/npm/post-install.js
+++ b/npm/post-install.js
@@ -17,10 +17,47 @@ if (platform === "win32") {
 
 const pkg = `@tailcallhq/core-${platform}-${arch}${libc}`
 
-try {
-  // @ts-ignore
-  const {stdout, stderr} = await execa(`npm install ${pkg}@${version} --no-save`)
-  stderr ? console.log(stderr) : console.log(`Successfully installed optional dependency: ${pkg}`, stdout)
-} catch (error) {
-  console.error(`Failed to install optional dependency: ${pkg}`, error.stderr)
+// For Windows, check if MSVC is installed
+async function checkMSVC() {
+  if (platform === "win32") {
+    try {
+      await execa("where cl.exe")
+      return true
+    } catch (error) {
+      return false
+    }
+  }
+  return true  // Not Windows, no need for MSVC
 }
+
+async function install() {
+  // Check for MSVC on Windows
+  if (platform === "win32") {
+    const hasMSVC = await checkMSVC()
+    if (!hasMSVC) {
+      console.error("\x1b[31mError: Microsoft Visual C++ Build Tools (MSVC) is required for Tailcall on Windows.\x1b[0m")
+      console.error("Please install the Visual C++ Build Tools from: https://visualstudio.microsoft.com/visual-cpp-build-tools/")
+      process.exit(1)
+    }
+  }
+
+  try {
+    // @ts-ignore
+    const {stdout, stderr} = await execa(`npm install ${pkg}@${version} --no-save`)
+    stderr ? console.log(stderr) : console.log(`Successfully installed optional dependency: ${pkg}`, stdout)
+  } catch (error) {
+    console.error(`\x1b[31mFailed to install optional dependency: ${pkg}\x1b[0m`)
+    console.error(error.stderr || error.message || 'Unknown error')
+    
+    if (platform === "win32") {
+      console.error("\nOn Windows, please ensure you have the following requirements:")
+      console.error("1. Microsoft Visual C++ Build Tools installed")
+      console.error("2. Node.js installed with the same architecture (x86 or x64) as your Windows")
+    }
+    
+    // Kill the process with a non-zero exit code
+    process.exit(1)
+  }
+}
+
+install();

--- a/npm/post-install.js
+++ b/npm/post-install.js
@@ -2,6 +2,8 @@
 import {familySync, GLIBC, MUSL} from "detect-libc"
 import {exec} from "child_process"
 import util from "util"
+import fs from "fs"
+import path from "path"
 
 const execa = util.promisify(exec)
 const platform = process.platform
@@ -49,6 +51,26 @@ async function install() {
     // @ts-ignore
     const {stdout, stderr} = await execa(`npm install ${pkg}@${version} --no-save`)
     stderr ? console.log(stderr) : console.log(`Successfully installed optional dependency: ${pkg}`, stdout)
+
+    // Verify the binary exists after installation - specifically for Windows
+    if (platform === "win32") {
+      try {
+        // Get npm's global bin directory
+        const {stdout: npmBin} = await execa("npm bin -g")
+        const binaryPath = path.join(npmBin.trim(), "tailcall.exe")
+
+        if (!fs.existsSync(binaryPath)) {
+          console.warn(`\x1b[33mWarning: Could not find tailcall.exe in ${binaryPath}\x1b[0m`)
+          console.warn("The binary may not have been installed correctly.")
+          console.warn("Please ensure you have the following requirements:")
+          console.warn("1. Microsoft Visual C++ Build Tools installed")
+          console.warn("2. Node.js installed with the same architecture (x86 or x64) as your Windows")
+          console.warn("3. Run the installation command with administrator privileges")
+        }
+      } catch (error) {
+        console.warn(`\x1b[33mWarning: Could not verify binary installation: ${error.message}\x1b[0m`)
+      }
+    }
   } catch (error) {
     console.error(`\x1b[31mFailed to install optional dependency: ${pkg}\x1b[0m`)
     console.error(error.stderr || error.message || "Unknown error")


### PR DESCRIPTION
### Fixes issue #3384 where Tailcall CLI isn't recognized on Windows after installation.

- Adds MSVC detection for Windows installations
- Improves error handling with descriptive messages
- Adds `process.exit(1)` on installation failure
- Updates README with Windows requirements

/claim #3384

---

### Build & Testing:

- [x] I ran `cargo test` successfully.
- [x] I have run `./lint.sh --mode=fix` to fix all linting issues raised by `./lint.sh --mode=check`.

### Checklist:

- [ ] I have added relevant unit & integration tests.
- [x] I have updated the documentation accordingly.
- [x] I have performed a self-review of my code.
- [x] PR follows the naming convention of `<type>(<optional scope>): <title>`
