### PR TITLE
ci: faster WASM tooling install + drop deprecated toolchain action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,15 @@ jobs:
         with:
           node-version: "20.20.0"
 
-      - name: Install Wasm Pack
-        run: cargo install wasm-bindgen-cli --vers "0.2.106"
+      # Install prebuilt binaries instead of compiling from source (saves
+      # several minutes of CI per run).
+      - name: Install WASM tooling
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.106,wasm-pack
 
       - name: Test WASM
-        run: |
-          cargo install wasm-pack
-          wasm-pack test --node
+        run: wasm-pack test --node
 
   test_cf:
     name: Run Tests (Cloudflare)
@@ -220,15 +222,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Build Project
         run: cargo build


### PR DESCRIPTION
Follow-up to #3553 (CI Actions billing reductions). Two more minute-saving cleanups for GitHub-billed jobs.

## Changes
- **`test_wasm`**: install `wasm-bindgen-cli@0.2.106` and `wasm-pack` as **prebuilt binaries** via `taiki-e/install-action` instead of `cargo install` (which compiles them from source on every run, costing several minutes).
- **`check-examples`**: remove the archived/unmaintained `actions-rs/toolchain@v1`, which was redundantly setting up the toolchain a second time alongside `actions-rust-lang/setup-rust-toolchain@v1`.

## Notes
- Considered adding `paths-ignore` to skip CI on docs-only PRs, but **deliberately skipped** it: `Run Tests on linux-x64-gnu`, `Run Tests (WASM)`, and `Check Examples` are required status checks (strict mode), so a skipped workflow would block merges.
- Benchmark workflows run on self-hosted runners (`group: benchmarking-runner`) and don't consume GitHub-billed minutes, so they were left untouched.

## Validation
- `ci.yml` parses as valid YAML.